### PR TITLE
Add support for using filters in minidyn queries and paginate

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -893,7 +893,8 @@ func TestQueryWithContextPagination(t *testing.T) {
 	input.ExclusiveStartKey = out.LastEvaluatedKey
 	out, err = client.QueryWithContext(context.Background(), input)
 	c.NoError(err)
-	c.Empty(out.Items)
+	c.Len(out.Items, 1)
+	c.Equal("001", aws.StringValue(out.Items[0]["id"].S))
 }
 
 func TestQuerySyntaxError(t *testing.T) {


### PR DESCRIPTION
This pull request ensures that during a query in DynamoDB we add all items that have a match to the query and return a key for pagination only when we are not in the last page. Tests are adjusted to reflect this

Fix #4 