### PR TITLE
Implement index expressions for maps

### DIFF
--- a/interpreter/language/ast.go
+++ b/interpreter/language/ast.go
@@ -153,6 +153,7 @@ type IndexExpression struct {
 	Token Token // The [ token
 	Left  Expression
 	Index Expression
+	Type  ObjectType
 }
 
 func (ie *IndexExpression) expressionNode() {

--- a/interpreter/language/lexer.go
+++ b/interpreter/language/lexer.go
@@ -104,6 +104,8 @@ func (l *Lexer) NextToken() Token {
 		tok = newToken(LBRACKET, l.ch)
 	case ']':
 		tok = newToken(RBRACKET, l.ch)
+	case '.':
+		tok = newToken(DOT, l.ch)
 	case 0:
 		tok.Literal = ""
 		tok.Type = EOF

--- a/interpreter/language/lexer_test.go
+++ b/interpreter/language/lexer_test.go
@@ -87,6 +87,11 @@ func TestNextToken(t *testing.T) {
 			{IDENT, "1"},
 			{RBRACKET, "]"},
 		},
+		`a.f`: []testCase{
+			{IDENT, "a"},
+			{DOT, "."},
+			{IDENT, "f"},
+		},
 	}
 
 	for input, tests := range table {

--- a/interpreter/language/parser.go
+++ b/interpreter/language/parser.go
@@ -48,6 +48,7 @@ var precedences = map[TokenType]int{
 	MINUS:    precedenceValueOperators,
 	LPAREN:   precedenceValueCall,
 	LBRACKET: precedenceValueINDEX,
+	DOT:      precedenceValueINDEX,
 }
 
 // NewParser creates a new parser
@@ -67,6 +68,7 @@ func NewParser(l *Lexer) *Parser {
 	p.registerInfix(EQ, p.parseInfixExpression)
 	p.registerInfix(NotEQ, p.parseInfixExpression)
 	p.registerInfix(LBRACKET, p.parseIndexExpression)
+	p.registerInfix(DOT, p.parseIndexExpression)
 	p.registerInfix(BETWEEN, p.parseBetweenExpression)
 	p.registerInfix(LT, p.parseInfixExpression)
 	p.registerInfix(GT, p.parseInfixExpression)
@@ -191,10 +193,15 @@ func (p *Parser) parseCallExpression(function Expression) Expression {
 }
 
 func (p *Parser) parseIndexExpression(left Expression) Expression {
-	expression := &IndexExpression{Token: p.curToken, Left: left}
+	expression := &IndexExpression{Token: p.curToken, Left: left, Type: ObjectTypeList}
 	p.nextToken()
 
 	expression.Index = p.parseIdentifier()
+
+	if expression.Token.Type == DOT {
+		expression.Type = ObjectTypeMap
+		return expression
+	}
 
 	if !p.expectPeek(RBRACKET) {
 		return nil

--- a/interpreter/language/parser_test.go
+++ b/interpreter/language/parser_test.go
@@ -95,6 +95,7 @@ func TestParsingIndexExpressions(t *testing.T) {
 		{"a[:i]", "a", ":i"},
 		{"#a[1]", "#a", "1"},
 		{"#a[1][2]", "(#a[1])", "2"},
+		{"a.f", "a", "f"},
 	}
 
 	for _, tt := range indexTests {

--- a/interpreter/language/token.go
+++ b/interpreter/language/token.go
@@ -43,6 +43,8 @@ const (
 	LBRACKET TokenType = "["
 	// RBRACKET right bracket delimiter
 	RBRACKET TokenType = "]"
+	// DOT map index accessor
+	DOT TokenType = "."
 
 	// AND logical evaluation keyword
 	AND = "AND"

--- a/interpreter/language_test.go
+++ b/interpreter/language_test.go
@@ -133,7 +133,7 @@ func TestLanguageUpdate(t *testing.T) {
 			name: "successful",
 			input: UpdateInput{
 				TableName:  "test",
-				Expression: "SET two = :a + :a",
+				Expression: "SET two = :a + :a, a = :a",
 				Item: map[string]*dynamodb.AttributeValue{
 					"a": {
 						S: aws.String("a"),
@@ -147,7 +147,7 @@ func TestLanguageUpdate(t *testing.T) {
 			},
 			output: map[string]*dynamodb.AttributeValue{
 				"a": {
-					S: aws.String("a"),
+					N: aws.String("1"),
 				},
 				"two": {
 					N: aws.String("2"),


### PR DESCRIPTION
Why:
It is an important feature when working with maps

What:
- It adds the token DOT.
- It support parsing index expressions with dot.
- It implements the index expression with dot
  evaluation.

Issue: #9