### PR TITLE
Fix ExpressionAttributeNames with nested notation

### DIFF
--- a/interpreter/language/environment.go
+++ b/interpreter/language/environment.go
@@ -33,13 +33,74 @@ func (e *Environment) AddAttributes(attributes map[string]*dynamodb.AttributeVal
 }
 
 // Get gets the value of the variable in the environment
-func (e *Environment) Get(name string) (Object, bool) {
+func (e *Environment) Get(name string) Object {
 	if alias, ok := e.Aliases[name]; ok {
 		name = alias
 	}
 
 	obj, ok := e.store[name]
-	return obj, ok
+	if ok {
+		return obj
+	}
+
+	// support index notation
+	names := e.evalNameWithIndex(name)
+
+	size := len(names)
+	if size == 0 {
+		return NULL
+	}
+
+	return e.getFromIndexes(names, size)
+}
+
+func (e *Environment) evalNameWithIndex(name string) []string {
+	names := strings.Split(name, ".")
+	for _, n := range names {
+		if alias, ok := e.Aliases[n]; ok {
+			names = append(names, e.evalNameWithIndex(alias)...)
+		}
+	}
+
+	return names
+}
+
+func (e *Environment) getFromIndexes(names []string, size int) Object {
+	var obj Object
+
+	ok := false
+
+	obj, ok = e.store[names[0]]
+	if !ok {
+		return NULL
+	}
+
+	for i, n := range names[1:] {
+		if alias, ok := e.Aliases[n]; ok {
+			n = alias
+		}
+
+		obj = getFromMap(obj, n)
+
+		if i+2 == size {
+			break
+		}
+
+		if isError(obj) {
+			return obj
+		}
+	}
+
+	return obj
+}
+
+func getFromMap(obj Object, key string) Object {
+	m, ok := obj.(*Map)
+	if !ok {
+		return newError("index operator not supported for %q", obj.Type())
+	}
+
+	return m.Get(key)
 }
 
 // Set assigns the value of the variable in the environment

--- a/interpreter/language/object.go
+++ b/interpreter/language/object.go
@@ -289,6 +289,16 @@ func (m *Map) ToDynamoDB() *dynamodb.AttributeValue {
 	return attr
 }
 
+// Get returns the contained object in the field
+func (m *Map) Get(field string) Object {
+	obj, ok := m.Value[field]
+	if !ok {
+		return NULL
+	}
+
+	return obj
+}
+
 // List is the representation of list
 type List struct {
 	Value []Object
@@ -326,6 +336,16 @@ func (l *List) ToDynamoDB() *dynamodb.AttributeValue {
 	}
 
 	return attr
+}
+
+// Get returns the contained object in the position
+func (l *List) Get(position int64) Object {
+	obj := l.Value[position]
+	if obj == nil {
+		return NULL
+	}
+
+	return obj
 }
 
 // Contains whether or not the obj is contained in the list


### PR DESCRIPTION
Why:
It was not working propertly with the
ExpressionAttributeNames had nested
field access.

What:
- It modifies the environment.Get method
  support this notation.

Issue: #9