### PR TITLE
Fix reserved words for map index fields

### DIFF
--- a/interpreter/language/evaluator.go
+++ b/interpreter/language/evaluator.go
@@ -26,7 +26,7 @@ func Eval(n Node, env *Environment) Object {
 	case *CallExpression:
 		return evalFunctionCall(node, env)
 	case *Identifier:
-		return evalIdentifier(node, env)
+		return evalIdentifier(node, env, true)
 	}
 
 	return newError("unsupported expression: %s", n.String())
@@ -46,7 +46,7 @@ func EvalUpdate(n Node, env *Environment) Object {
 	case *CallExpression:
 		return evalUpdateFunctionCall(node, env)
 	case *Identifier:
-		return evalIdentifier(node, env)
+		return evalIdentifier(node, env, true)
 	}
 
 	return newError("unsupported expression: %s", n.String())
@@ -287,10 +287,10 @@ func equalObject(left, right Object) bool {
 	return reflect.DeepEqual(left, right)
 }
 
-func evalIdentifier(node *Identifier, env *Environment) Object {
+func evalIdentifier(node *Identifier, env *Environment, toplevel bool) Object {
 	attributeName := strings.ToUpper(node.Token.Literal)
 
-	if IsReservedWord(attributeName) {
+	if toplevel && IsReservedWord(attributeName) {
 		return newError(fmt.Sprintf("reserved word %s found in expression", attributeName))
 	}
 
@@ -408,7 +408,7 @@ func evalIndexObj(identifierExpression Expression, env *Environment) (Object, Ob
 		return nil, newError("identifier expected: got %q", identifierExpression.String())
 	}
 
-	obj := evalIdentifier(identifier, env)
+	obj := evalIdentifier(identifier, env, true)
 	switch obj.(type) {
 	case *List:
 		return obj, nil
@@ -447,7 +447,7 @@ func evalListIndexValue(node *Identifier, env *Environment) (int64, Object) {
 		return int64(n), nil
 	}
 
-	obj := evalIdentifier(node, env)
+	obj := evalIdentifier(node, env, true)
 	if isError(obj) {
 		return 0, obj
 	}
@@ -461,7 +461,7 @@ func evalListIndexValue(node *Identifier, env *Environment) (int64, Object) {
 }
 
 func evalMapIndexValue(node *Identifier, env *Environment) (string, Object) {
-	obj := evalIdentifier(node, env)
+	obj := evalIdentifier(node, env, false)
 	if isError(obj) {
 		return "", obj
 	}
@@ -536,7 +536,7 @@ func evalBetweenOperand(exp Expression, env *Environment) Object {
 		return newError("identifier expected: got %q", exp.String())
 	}
 
-	val := evalIdentifier(identifier, env)
+	val := evalIdentifier(identifier, env, true)
 	if val.Type() == ObjectTypeError {
 		return val
 	}

--- a/interpreter/language/evaluator_test.go
+++ b/interpreter/language/evaluator_test.go
@@ -438,6 +438,64 @@ func TestErrorHandling(t *testing.T) {
 	}
 }
 
+func TestEvalReservedKeywords(t *testing.T) {
+	tests := []struct {
+		input           string
+		expectedMessage string
+	}{
+		{
+			"size = :x",
+			"reserved word SIZE found in expression",
+		},
+		{
+			"hash = :x",
+			"reserved word HASH found in expression",
+		},
+		{
+			":obj.size = :x",
+			"",
+		},
+	}
+
+	env := NewEnvironment()
+
+	err := env.AddAttributes(map[string]*dynamodb.AttributeValue{
+		":y":   &dynamodb.AttributeValue{N: aws.String("25")},
+		":str": &dynamodb.AttributeValue{S: aws.String("TEXT")},
+		":obj": &dynamodb.AttributeValue{
+			M: map[string]*dynamodb.AttributeValue{
+				"a": &dynamodb.AttributeValue{BOOL: aws.Bool(true)},
+			},
+		},
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	for i, tt := range tests {
+		evaluated := testEval(t, tt.input, env)
+
+		if tt.expectedMessage == "" {
+			errObj, ok := evaluated.(*Error)
+			if ok {
+				t.Errorf("(%d) error not expected for %q. got=%s", i, tt.input, errObj.Message)
+			}
+
+			continue
+		}
+
+		errObj, ok := evaluated.(*Error)
+		if !ok {
+			t.Errorf("(%d) no error object returned for %s. got=%T(%+v)", i, tt.input, evaluated, evaluated)
+			continue
+		}
+
+		if errObj.Message != tt.expectedMessage {
+			t.Errorf("wrong error message for %s. expected=%q, got=%q", tt.input, tt.expectedMessage, errObj.Message)
+		}
+	}
+}
+
 func TestIsError(t *testing.T) {
 	b := isError(nil)
 	if b {


### PR DESCRIPTION
Why:
Reserved words are only for the top level
an not for the index identifiers.

What:
- It adds the boolean parameter toplevel to
  identify when the reserved word should be
  checked or not.

Issue: #11