### PR TITLE
Fix update expression tests

### DIFF
--- a/interpreter/language/object.go
+++ b/interpreter/language/object.go
@@ -255,14 +255,31 @@ type Map struct {
 func (m *Map) Inspect() string {
 	var out bytes.Buffer
 
-	out.WriteString("{")
+	out.WriteString("{\n")
 
-	for k, obj := range m.Value {
-		out.WriteString("\n  \"")
+	keys := make([]string, 0, len(m.Value))
+
+	for k := range m.Value {
+		keys = append(keys, k)
+	}
+
+	sort.Strings(keys)
+
+	for _, k := range keys {
+		obj := m.Value[k]
+
+		out.WriteString("\t\"")
 		out.WriteString(k)
 		out.WriteString("\" : ")
 
-		out.WriteString(obj.Inspect())
+		str := obj.Inspect()
+
+		if obj.Type() == ObjectTypeMap {
+			str = strings.ReplaceAll(str, "\n", "\n\t")
+		}
+
+		out.WriteString(str)
+
 		out.WriteString("<")
 		out.WriteString(string(obj.Type()))
 		out.WriteString(">,\n")

--- a/interpreter/language/object_test.go
+++ b/interpreter/language/object_test.go
@@ -72,11 +72,18 @@ func TestStringContains(t *testing.T) {
 func TestMapInspect(t *testing.T) {
 	str := Map{Value: map[string]Object{
 		":a": TRUE,
+		":b": FALSE,
+		":m": &Map{
+			Value: map[string]Object{
+				":x": TRUE,
+				":y": FALSE,
+			},
+		},
 	}}
-	expected := "{\n  \":a\" : true<BOOL>,\n}"
+	expected := "{\n\t\":a\" : true<BOOL>,\n\t\":b\" : false<BOOL>,\n\t\":m\" : {\n\t\t\":x\" : true<BOOL>,\n\t\t\":y\" : false<BOOL>,\n\t}<M>,\n}"
 
 	if str.Inspect() != expected {
-		t.Fatalf("not equal actual=%s expected=%s", str.Inspect(), expected)
+		t.Fatalf("not equal actual=%q expected=%q", str.Inspect(), expected)
 	}
 }
 


### PR DESCRIPTION
Why:
The update texts verification was not working
propertly becuase it was comparing dynamodb
values and they are not comprable values.

What:
- It converts the comparing objects to string
  with the Inspect method to compare the
  expected result with the actual result.
- It sorts the keys in the Map#Inspect result
  to avoid random outputs.

Issue: #3