### PR TITLE
Implement update expression add action

### DIFF
--- a/client.go
+++ b/client.go
@@ -309,7 +309,12 @@ func (fd *Client) UpdateItem(input *dynamodb.UpdateItemInput) (*dynamodb.UpdateI
 	}
 
 	item, err := table.update(input)
+
 	if err != nil {
+		if errors.Is(err, interpreter.ErrSyntaxError) {
+			return nil, awserr.New("ValidationException", err.Error(), nil)
+		}
+
 		return nil, err
 	}
 

--- a/interpreter/language.go
+++ b/interpreter/language.go
@@ -75,7 +75,12 @@ func (li *Language) Update(input UpdateInput) error {
 	env.Aliases = aliases
 
 	if len(p.Errors()) != 0 {
-		return fmt.Errorf("%w: %s", ErrSyntaxError, strings.Join(p.Errors(), "\n"))
+		errType := ErrSyntaxError
+		if p.IsUnsupportedExpression() {
+			errType = ErrUnsupportedFeature
+		}
+
+		return fmt.Errorf("%w: %s", errType, strings.Join(p.Errors(), "\n"))
 	}
 
 	item := map[string]*dynamodb.AttributeValue{}

--- a/interpreter/language.go
+++ b/interpreter/language.go
@@ -63,7 +63,7 @@ func (li *Language) Match(input MatchInput) (bool, error) {
 // Update change the item with given expression and attributes
 func (li *Language) Update(input UpdateInput) error {
 	l := language.NewLexer(input.Expression)
-	p := language.NewParser(l)
+	p := language.NewUpdateParser(l)
 	update := p.ParseUpdateExpression()
 
 	aliases := map[string]string{}

--- a/interpreter/language/ast.go
+++ b/interpreter/language/ast.go
@@ -202,13 +202,34 @@ func (ce *BetweenExpression) String() string {
 	return out.String()
 }
 
-// UpdateExpression is the update expression root node
-type UpdateExpression struct {
+// UpdateStatement is the update expression root node
+type UpdateStatement struct {
 	Token      Token // the action token
 	Expression Expression
 }
 
-func (ue *UpdateExpression) statementNode() {
+func (us *UpdateStatement) statementNode() {
+	_ = 1 // HACK for passing coverage
+}
+
+// TokenLiteral returns the literal token of the node
+func (us *UpdateStatement) TokenLiteral() string { return us.Token.Literal }
+
+func (us *UpdateStatement) String() string {
+	if us.Expression != nil {
+		return us.Expression.String()
+	}
+
+	return ""
+}
+
+// UpdateExpression is the update expression
+type UpdateExpression struct {
+	Token       Token // set
+	Expressions []Expression
+}
+
+func (ue *UpdateExpression) expressionNode() {
 	_ = 1 // HACK for passing coverage
 }
 
@@ -216,34 +237,49 @@ func (ue *UpdateExpression) statementNode() {
 func (ue *UpdateExpression) TokenLiteral() string { return ue.Token.Literal }
 
 func (ue *UpdateExpression) String() string {
-	if ue.Expression != nil {
-		return ue.Expression.String()
+	var out bytes.Buffer
+
+	out.WriteString("(")
+	for _, exp := range ue.Expressions {
+		out.WriteString(exp.String())
 	}
+	out.WriteString(")")
 
-	return ""
+	return out.String()
 }
 
-// SetExpression is the set expression
-type SetExpression struct {
-	Token       Token // set
-	Expressions []Expression
+// ActionExpression is the action expression of an update expression
+type ActionExpression struct {
+	Token Token // ADD REMOVE DELETE
+	Left  Expression
+	Right Expression
 }
 
-func (st *SetExpression) expressionNode() {
+func (st *ActionExpression) expressionNode() {
 	_ = 1 // HACK for passing coverage
 }
 
 // TokenLiteral returns the literal token of the node
-func (st *SetExpression) TokenLiteral() string { return st.Token.Literal }
+func (st *ActionExpression) TokenLiteral() string { return st.Token.Literal }
 
-func (st *SetExpression) String() string {
+func (st *ActionExpression) String() string {
 	var out bytes.Buffer
 
-	out.WriteString("SET (")
-	out.WriteString(st.Token.Literal)
-	for _, exp := range st.Expressions {
-		out.WriteString(exp.String())
+	out.WriteString(st.TokenLiteral())
+
+	out.WriteString(" (")
+
+	out.WriteString(st.Left.String())
+
+	sep := ", "
+	if st.Token.Type == SET {
+		sep = " = "
 	}
+
+	out.WriteString(sep)
+
+	out.WriteString(st.Right.String())
+
 	out.WriteString(")")
 
 	return out.String()

--- a/interpreter/language/ast_test.go
+++ b/interpreter/language/ast_test.go
@@ -139,10 +139,8 @@ func TestUpdateExpression(t *testing.T) {
 		t.Fatalf("wrong token literal. expected=%q, got=%q", "a", tl)
 	}
 
-	es.statementNode()
-
-	if es.String() != "" {
-		t.Fatalf("empty expression expected ")
+	if es.String() != "()" {
+		t.Fatalf("unexpected expression representation. expected=%q, got=%q", "SET ()", es.String())
 	}
 }
 

--- a/interpreter/language/mapper.go
+++ b/interpreter/language/mapper.go
@@ -102,7 +102,7 @@ func mapAttributeToStringSet(val *dynamodb.AttributeValue) (Object, error) {
 
 func mapAttributeToBinarySet(val *dynamodb.AttributeValue) (Object, error) {
 	bs := BinarySet{
-		Value: make([][]byte, len(val.BS)),
+		Value: make([][]byte, 0, len(val.BS)),
 	}
 
 	for _, val := range val.BS {

--- a/interpreter/language/parser.go
+++ b/interpreter/language/parser.go
@@ -62,7 +62,6 @@ func NewParser(l *Lexer) *Parser {
 	p.registerPrefix(IDENT, p.parseIdentifier)
 	p.registerPrefix(NOT, p.parsePrefixExpression)
 	p.registerPrefix(LPAREN, p.parseGroupedExpression)
-	p.registerPrefix(SET, p.parseSetExpression)
 
 	p.infixParseFns = make(map[TokenType]infixParseFn)
 	p.registerInfix(EQ, p.parseInfixExpression)
@@ -76,6 +75,32 @@ func NewParser(l *Lexer) *Parser {
 	p.registerInfix(GTE, p.parseInfixExpression)
 	p.registerInfix(AND, p.parseInfixExpression)
 	p.registerInfix(OR, p.parseInfixExpression)
+	p.registerInfix(LPAREN, p.parseCallExpression)
+
+	// Read two tokens, so curToken and peekToken are both set
+	p.nextToken()
+	p.nextToken()
+
+	return p
+}
+
+// NewUpdateParser creates a new parser for update expressions
+func NewUpdateParser(l *Lexer) *Parser {
+	p := &Parser{
+		l:      l,
+		errors: []string{},
+	}
+
+	p.prefixParseFns = map[TokenType]prefixParseFn{}
+	p.registerPrefix(IDENT, p.parseIdentifier)
+
+	p.registerPrefix(LPAREN, p.parseGroupedExpression)
+	p.registerPrefix(SET, p.parseUpdateActionExpression)
+	p.registerPrefix(ADD, p.parseUpdateActionExpression)
+
+	p.infixParseFns = make(map[TokenType]infixParseFn)
+	p.registerInfix(LBRACKET, p.parseIndexExpression)
+	p.registerInfix(DOT, p.parseIndexExpression)
 	p.registerInfix(LPAREN, p.parseCallExpression)
 
 	p.registerInfix(PLUS, p.parseInfixExpression)
@@ -261,8 +286,8 @@ func (p *Parser) parseCallArguments() []Expression {
 	return args
 }
 
-func (p *Parser) ParseUpdateExpression() *UpdateExpression {
-	stmt := &UpdateExpression{Token: p.curToken}
+func (p *Parser) ParseUpdateExpression() *UpdateStatement {
+	stmt := &UpdateStatement{Token: p.curToken}
 
 	for p.curToken.Type != EOF {
 		stmt.Expression = p.parseExpression(precedenceValueLowset)
@@ -273,16 +298,16 @@ func (p *Parser) ParseUpdateExpression() *UpdateExpression {
 	return stmt
 }
 
-func (p *Parser) parseSetExpression() Expression {
-	expression := &SetExpression{
+func (p *Parser) parseUpdateActionExpression() Expression {
+	expression := &UpdateExpression{
 		Token:       p.curToken,
-		Expressions: p.parseActions(),
+		Expressions: p.parseActions(p.curToken),
 	}
 
 	return expression
 }
 
-func (p *Parser) parseActions() []Expression {
+func (p *Parser) parseActions(token Token) []Expression {
 	actions := []Expression{}
 
 	if p.peekTokenIs(EOF) {
@@ -290,12 +315,40 @@ func (p *Parser) parseActions() []Expression {
 	}
 
 	p.nextToken()
-	actions = append(actions, p.parseExpression(precedenceValueLowset))
+
+	action := &ActionExpression{
+		Token: token,
+		Left:  p.parseExpression(precedenceValueLowset),
+	}
+
+	if token.Type == SET && !p.expectPeek(EQ) {
+		return nil
+	}
+
+	p.nextToken()
+
+	action.Right = p.parseExpression(precedenceValueLowset)
+
+	actions = append(actions, action)
 
 	for p.peekTokenIs(COMMA) {
 		p.nextToken()
 		p.nextToken()
-		actions = append(actions, p.parseExpression(precedenceValueLowset))
+
+		action := &ActionExpression{
+			Token: token,
+			Left:  p.parseExpression(precedenceValueLowset),
+		}
+
+		if token.Type == SET && !p.expectPeek(EQ) {
+			return nil
+		}
+
+		p.nextToken()
+
+		action.Right = p.parseExpression(precedenceValueLowset)
+
+		actions = append(actions, action)
 	}
 
 	if !p.expectPeek(EOF) {

--- a/interpreter/language/parser_test.go
+++ b/interpreter/language/parser_test.go
@@ -434,6 +434,36 @@ func TestParsingAddExpression(t *testing.T) {
 	}
 }
 
+func TestParsingUnsupportedExpressions(t *testing.T) {
+	setTests := []struct {
+		input string
+		msg   string
+	}{
+		{"REMOVE ProductTotal[:c]", "the REMOVE expression is not supported yet"},
+		{"DELETE ProductTotal :c", "the DELETE expression is not supported yet"},
+	}
+
+	for _, tt := range setTests {
+		l := NewLexer(tt.input)
+		p := NewUpdateParser(l)
+		p.ParseUpdateExpression()
+
+		errors := p.Errors()
+
+		if len(errors) == 0 {
+			t.Fatalf("the %q expression should fail", tt.input)
+		}
+
+		if errors[0] != tt.msg {
+			t.Fatalf("unexpected message. expect=%s got=%s", tt.input, errors[0])
+		}
+
+		if !p.unsupported {
+			t.Fatalf("the error should be unsupported")
+		}
+	}
+}
+
 func BenchmarkParser(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		l := NewLexer(`attribute_exists(:b) AND begins_with(:b, #s) OR #c`)

--- a/table.go
+++ b/table.go
@@ -480,6 +480,8 @@ func (t *table) interpreterUpdate(input interpreter.UpdateInput) error {
 		if nativeErr != nil {
 			panic(err)
 		}
+
+		return nil
 	}
 
 	return err


### PR DESCRIPTION
    Implement Add action for update expression interpreter
    
    Why:
    It will help to complete the interpreter
    implementation.
    
    What:
    - It changes the parsing of action in the
      upddate expressions to make it easier to extend.
    - It implements the ADD action logic.
    - It changes the client to return the interpreter
      error instead of panicing.