### PR TITLE
Implement DELETE action for update expression

### DIFF
--- a/interpreter/language/evaluator.go
+++ b/interpreter/language/evaluator.go
@@ -742,6 +742,28 @@ func evalAction(node *ActionExpression, env *Environment) Object {
 		}
 
 		return NULL
+	case DELETE:
+		val := EvalUpdate(node.Right, env)
+		if isError(val) {
+			return val
+		}
+
+		id, ok := node.Left.(*Identifier)
+		if ok {
+			obj := env.Get(id.Value)
+
+			if obj == NULL {
+				env.Set(id.Value, val)
+				return obj
+			}
+
+			addObj, ok := obj.(DetachableObject)
+			if !ok {
+				return newError("an operand in the update expression has an incorrect data type")
+			}
+
+			return addObj.Delete(val)
+		}
 	}
 
 	return newError("unknown update action type: %s", node.Token.Literal)

--- a/interpreter/language/object_test.go
+++ b/interpreter/language/object_test.go
@@ -224,6 +224,28 @@ func TestStringSetAdd(t *testing.T) {
 	}
 }
 
+func TestStringSetDelete(t *testing.T) {
+	ss := StringSet{Value: map[string]bool{"Cookies": true, "Orange": true, "Milk": true}}
+
+	obj := ss.Delete(&String{Value: "Orange"})
+	if obj != NULL {
+		t.Fatalf("return object should be NULL, got=%q", obj.Inspect())
+	}
+
+	if len(ss.Value) != 2 {
+		t.Fatalf("result object should have 2 elements, got=%q", ss.Inspect())
+	}
+
+	obj = ss.Delete(&StringSet{Value: map[string]bool{"Milk": true, "Cookies": true}})
+	if obj != NULL {
+		t.Fatalf("return object should be NULL, got=%q", obj.Inspect())
+	}
+
+	if len(ss.Value) != 0 {
+		t.Fatalf("result object should be empty SS, got=%q", ss.Inspect())
+	}
+}
+
 func TestBinarySetInspect(t *testing.T) {
 	strSet := BinarySet{
 		Value: [][]byte{
@@ -264,6 +286,74 @@ func TestBinarySetContains(t *testing.T) {
 
 	if strSet.Contains(&Number{Value: 10}) {
 		t.Fatalf("should be false")
+	}
+}
+
+func TestBinaryAdd(t *testing.T) {
+	bs := BinarySet{
+		Value: [][]byte{
+			[]byte("Cookies"),
+		},
+	}
+
+	obj := bs.Add(&Binary{Value: []byte("Coffee")})
+	if obj != NULL {
+		t.Fatalf("return object should be NULL, got=%q", obj.Inspect())
+	}
+
+	if len(bs.Value) != 2 {
+		t.Fatalf("result object should have 2 elements, got=%q", bs.Inspect())
+	}
+
+	more := &BinarySet{
+		Value: [][]byte{
+			[]byte("Cookies"),
+			[]byte("Milk"),
+		},
+	}
+
+	obj = bs.Add(more)
+	if obj != NULL {
+		t.Fatalf("return object should be NULL, got=%q", obj.Inspect())
+	}
+
+	if len(bs.Value) != 3 {
+		t.Fatalf("result object should have 3 elements, got=%q", bs.Inspect())
+	}
+}
+
+func TestBinarySetRemove(t *testing.T) {
+	bs := BinarySet{
+		Value: [][]byte{
+			[]byte("Cookies"),
+			[]byte("Coffee"),
+			[]byte("Milk"),
+		},
+	}
+
+	obj := bs.Delete(&Binary{Value: []byte("Coffee")})
+	if obj != NULL {
+		t.Fatalf("return object should be NULL, got=%q", obj.Inspect())
+	}
+
+	if len(bs.Value) != 2 {
+		t.Fatalf("result object should have 2 elements, got=%q", bs.Inspect())
+	}
+
+	rest := &BinarySet{
+		Value: [][]byte{
+			[]byte("Cookies"),
+			[]byte("Milk"),
+		},
+	}
+
+	obj = bs.Delete(rest)
+	if obj != NULL {
+		t.Fatalf("return object should be NULL, got=%q", obj.Inspect())
+	}
+
+	if len(bs.Value) != 0 {
+		t.Fatalf("result object should be empty elements, got=%q", bs.Inspect())
 	}
 }
 
@@ -329,6 +419,28 @@ func TestNumberSetAdd(t *testing.T) {
 
 	if len(ns.Value) != 3 {
 		t.Fatalf("result object should be 3 elements, got=%q", ns.Inspect())
+	}
+}
+
+func TestNumberSetDelete(t *testing.T) {
+	ns := NumberSet{Value: map[float64]bool{1: true, 2: true, 3: true}}
+
+	obj := ns.Delete(&Number{Value: 2})
+	if obj != NULL {
+		t.Fatalf("return object should be NULL, got=%q", obj.Inspect())
+	}
+
+	if len(ns.Value) != 2 {
+		t.Fatalf("result object should have 2 elements, got=%q", ns.Inspect())
+	}
+
+	obj = ns.Delete(&NumberSet{Value: map[float64]bool{1: true, 3: true}})
+	if obj != NULL {
+		t.Fatalf("return object should be NULL, got=%q", obj.Inspect())
+	}
+
+	if len(ns.Value) != 0 {
+		t.Fatalf("result object should be empty, got=%q", ns.Inspect())
 	}
 }
 

--- a/interpreter/language/parser.go
+++ b/interpreter/language/parser.go
@@ -100,7 +100,7 @@ func NewUpdateParser(l *Lexer) *Parser {
 	p.registerPrefix(SET, p.parseUpdateActionExpression)
 	p.registerPrefix(ADD, p.parseUpdateActionExpression)
 	p.registerPrefix(REMOVE, p.parseUnsupportedExpression)
-	p.registerPrefix(DELETE, p.parseUnsupportedExpression)
+	p.registerPrefix(DELETE, p.parseUpdateActionExpression)
 
 	p.infixParseFns = make(map[TokenType]infixParseFn)
 	p.registerInfix(LBRACKET, p.parseIndexExpression)

--- a/interpreter/language/parser_test.go
+++ b/interpreter/language/parser_test.go
@@ -440,7 +440,6 @@ func TestParsingUnsupportedExpressions(t *testing.T) {
 		msg   string
 	}{
 		{"REMOVE ProductTotal[:c]", "the REMOVE expression is not supported yet"},
-		{"DELETE ProductTotal :c", "the DELETE expression is not supported yet"},
 	}
 
 	for _, tt := range setTests {


### PR DESCRIPTION
Why:
It will help to complete the interpretation of
update expressions.

What:
- It defines the detachable object interface
- It implements the detachable interface for
  StringSet NumberSet and BinarySet.
- It uses the new interface to implement the
  evaluation of the DELETE action expression.

Issue: #3