### PR TITLE
Add syntax validation on ExpressionAttributeNames and ExpressionAttributeValues

### DIFF
--- a/client.go
+++ b/client.go
@@ -678,6 +678,7 @@ func validateSyntaxExpression(regex *regexp.Regexp, expressions []string, errorM
 			return awserr.New("ValidationException", fmt.Sprintf("%s: Syntax error; key: %s", errorMsg, exprName), nil)
 		}
 	}
+
 	return nil
 }
 

--- a/client.go
+++ b/client.go
@@ -20,7 +20,8 @@ const (
 	batchRequestsLimit                 = 25
 	unusedExpressionAttributeNamesMsg  = "Value provided in ExpressionAttributeNames unused in expressions"
 	unusedExpressionAttributeValuesMsg = "Value provided in ExpressionAttributeValues unused in expressions"
-	invalidExpressionAttributeName     = "Invalid syntax in ExpressionAttributeName"
+	invalidExpressionAttributeName     = "ExpressionAttributeNames contains invalid key"
+	invalidExpressionAttributeValue    = "ExpressionAttributeValues contains invalid key"
 )
 
 var (
@@ -31,8 +32,9 @@ var (
 	// ErrResourceNotFoundException when the requested resource is not found
 	ErrResourceNotFoundException = errors.New("requested resource not found")
 	// ErrConditionalRequestFailed when the conditional write is not meet
-	ErrConditionalRequestFailed   = errors.New("the conditional request failed")
-	expressionAttributeNamesRegex = regexp.MustCompile("^#[A-Za-z0-9]+$")
+	ErrConditionalRequestFailed    = errors.New("the conditional request failed")
+	expressionAttributeNamesRegex  = regexp.MustCompile("^#[A-Za-z0-9_]+$")
+	expressionAttributeValuesRegex = regexp.MustCompile("^:[A-Za-z0-9_]+$")
 )
 
 // Client define a mock struct to be used
@@ -668,7 +670,7 @@ func validateSyntaxExpression(regex *regexp.Regexp, expressions []string, errorM
 	for _, exprName := range expressions {
 		ok := regex.MatchString(exprName)
 		if !ok {
-			return awserr.New("ValidationException", fmt.Sprintf("%s: expression: {%s}", errorMsg, exprName), nil)
+			return awserr.New("ValidationException", fmt.Sprintf("%s: Syntax error; key: %s", errorMsg, exprName), nil)
 		}
 	}
 	return nil

--- a/client.go
+++ b/client.go
@@ -663,6 +663,11 @@ func validateExpressionAttributes(exprNames map[string]*string, exprValues map[s
 		return awserr.New("ValidationException", fmt.Sprintf("%s: keys: {%s}", unusedExpressionAttributeValuesMsg, strings.Join(missingValues, ", ")), nil)
 	}
 
+	err = validateSyntaxExpression(expressionAttributeValuesRegex, flattenValues, invalidExpressionAttributeValue)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/client_test.go
+++ b/client_test.go
@@ -655,6 +655,20 @@ func TestPutItemWithConditions(t *testing.T) {
 	_, err = client.PutItemWithContext(context.Background(), input)
 	c.NotNil(err)
 	c.Contains(err.Error(), invalidExpressionAttributeName)
+
+	input.ConditionExpression = aws.String("#valid_name = :invalid-value")
+
+	input.ExpressionAttributeNames = map[string]*string{
+		"#valid_name": aws.String("hello"),
+	}
+
+	input.ExpressionAttributeValues = map[string]*dynamodb.AttributeValue{
+		":invalid-value": {NULL: aws.Bool(true)},
+	}
+
+	_, err = client.PutItemWithContext(context.Background(), input)
+	c.NotNil(err)
+	c.Contains(err.Error(), invalidExpressionAttributeValue)
 }
 
 func TestUpdateItemWithContext(t *testing.T) {
@@ -756,12 +770,26 @@ func TestUpdateItemWithConditionalExpression(t *testing.T) {
 	input.ConditionExpression = aws.String("attribute_exists(#invalid-name)")
 
 	input.ExpressionAttributeNames = map[string]*string{
-		"#invalid-name": aws.String("hello"),
+		"#invalid-name": aws.String("type"),
 	}
 
 	_, err = client.UpdateItemWithContext(context.Background(), input)
 	c.NotNil(err)
 	c.Contains(err.Error(), invalidExpressionAttributeName)
+
+	input.ConditionExpression = aws.String("#t = :invalid-value")
+
+	input.ExpressionAttributeNames = map[string]*string{
+		"#t": aws.String("type"),
+	}
+
+	input.ExpressionAttributeValues = map[string]*dynamodb.AttributeValue{
+		":invalid-value": {NULL: aws.Bool(true)},
+	}
+
+	_, err = client.UpdateItemWithContext(context.Background(), input)
+	c.NotNil(err)
+	c.Contains(err.Error(), invalidExpressionAttributeValue)
 
 	input = &dynamodb.UpdateItemInput{
 		TableName: aws.String(tableName),
@@ -954,6 +982,20 @@ func TestQueryWithContext(t *testing.T) {
 	_, err = client.QueryWithContext(context.Background(), input)
 	c.NotNil(err)
 	c.Contains(err.Error(), invalidExpressionAttributeName)
+
+	input.KeyConditionExpression = aws.String("#t = :invalid-value")
+
+	input.ExpressionAttributeNames = map[string]*string{
+		"#t": aws.String("type"),
+	}
+
+	input.ExpressionAttributeValues = map[string]*dynamodb.AttributeValue{
+		":invalid-value": {NULL: aws.Bool(true)},
+	}
+
+	_, err = client.QueryWithContext(context.Background(), input)
+	c.NotNil(err)
+	c.Contains(err.Error(), invalidExpressionAttributeValue)
 }
 
 func TestQueryWithContextPagination(t *testing.T) {
@@ -1139,12 +1181,26 @@ func TestScanWithContext(t *testing.T) {
 
 	input.FilterExpression = aws.String("#invalid-name = Raichu")
 	input.ExpressionAttributeNames = map[string]*string{
-		"#invalid-name": aws.String("name"),
+		"#invalid-name": aws.String("Name"),
 	}
 
 	_, err = client.ScanWithContext(context.Background(), input)
 	c.NotNil(err)
 	c.Contains(err.Error(), invalidExpressionAttributeName)
+
+	input.FilterExpression = aws.String("#t = :invalid-value")
+
+	input.ExpressionAttributeNames = map[string]*string{
+		"#t": aws.String("type"),
+	}
+
+	input.ExpressionAttributeValues = map[string]*dynamodb.AttributeValue{
+		":invalid-value": {NULL: aws.Bool(true)},
+	}
+
+	_, err = client.ScanWithContext(context.Background(), input)
+	c.NotNil(err)
+	c.Contains(err.Error(), invalidExpressionAttributeValue)
 
 	input.Limit = nil
 	input.FilterExpression = aws.String("#name = :name")
@@ -1293,7 +1349,7 @@ func TestDeleteItemWithConditions(t *testing.T) {
 	c.NotNil(err)
 	c.Contains(err.Error(), unusedExpressionAttributeNamesMsg)
 
-	input.ConditionExpression = aws.String("#invalid-name > 3")
+	input.ConditionExpression = aws.String("#invalid-name = Squirtle")
 
 	input.ExpressionAttributeNames = map[string]*string{
 		"#invalid-name": aws.String("hello"),
@@ -1302,6 +1358,20 @@ func TestDeleteItemWithConditions(t *testing.T) {
 	_, err = client.DeleteItemWithContext(context.Background(), input)
 	c.NotNil(err)
 	c.Contains(err.Error(), invalidExpressionAttributeName)
+
+	input.ConditionExpression = aws.String("#t = :invalid-value")
+
+	input.ExpressionAttributeNames = map[string]*string{
+		"#t": aws.String("type"),
+	}
+
+	input.ExpressionAttributeValues = map[string]*dynamodb.AttributeValue{
+		":invalid-value": {NULL: aws.Bool(true)},
+	}
+
+	_, err = client.DeleteItemWithContext(context.Background(), input)
+	c.NotNil(err)
+	c.Contains(err.Error(), invalidExpressionAttributeValue)
 
 }
 

--- a/client_test.go
+++ b/client_test.go
@@ -1372,7 +1372,6 @@ func TestDeleteItemWithConditions(t *testing.T) {
 	_, err = client.DeleteItemWithContext(context.Background(), input)
 	c.NotNil(err)
 	c.Contains(err.Error(), invalidExpressionAttributeValue)
-
 }
 
 func TestDeleteItemWithContextWithReturnValues(t *testing.T) {

--- a/client_test.go
+++ b/client_test.go
@@ -583,6 +583,32 @@ func TestGetItemWithUnusedAttributes(t *testing.T) {
 	c.Contains(err.Error(), unusedExpressionAttributeNamesMsg)
 }
 
+func TestGetItemWithInvalidExpressionAttributeNames(t *testing.T) {
+	c := require.New(t)
+
+	client := setupClient(tableName)
+
+	err := ensurePokemonTable(client)
+	c.NoError(err)
+
+	input := &dynamodb.GetItemInput{
+		TableName: aws.String(tableName),
+		Key: map[string]*dynamodb.AttributeValue{
+			"id": {
+				S: aws.String("001"),
+			},
+		},
+		ProjectionExpression: aws.String("#name_1"),
+		ExpressionAttributeNames: map[string]*string{
+			"#name_1": aws.String("name"),
+		},
+	}
+
+	_, err = client.GetItemWithContext(context.Background(), input)
+	c.NotNil(err)
+	c.Contains(err.Error(), invalidExpressionAttributeName)
+}
+
 func TestPutItemWithConditions(t *testing.T) {
 	c := require.New(t)
 
@@ -619,6 +645,16 @@ func TestPutItemWithConditions(t *testing.T) {
 	_, err = client.PutItemWithContext(context.Background(), input)
 	c.NotNil(err)
 	c.Contains(err.Error(), unusedExpressionAttributeValuesMsg)
+
+	input.ConditionExpression = aws.String("attribute_not_exists(#invalid-name)")
+
+	input.ExpressionAttributeNames = map[string]*string{
+		"#invalid-name": aws.String("hello"),
+	}
+
+	_, err = client.PutItemWithContext(context.Background(), input)
+	c.NotNil(err)
+	c.Contains(err.Error(), invalidExpressionAttributeName)
 }
 
 func TestUpdateItemWithContext(t *testing.T) {
@@ -716,6 +752,16 @@ func TestUpdateItemWithConditionalExpression(t *testing.T) {
 
 	_, err = client.UpdateItemWithContext(context.Background(), input)
 	c.Contains(err.Error(), unusedExpressionAttributeNamesMsg)
+
+	input.ConditionExpression = aws.String("attribute_exists(#invalid-name)")
+
+	input.ExpressionAttributeNames = map[string]*string{
+		"#invalid-name": aws.String("hello"),
+	}
+
+	_, err = client.UpdateItemWithContext(context.Background(), input)
+	c.NotNil(err)
+	c.Contains(err.Error(), invalidExpressionAttributeName)
 
 	input = &dynamodb.UpdateItemInput{
 		TableName: aws.String(tableName),
@@ -899,6 +945,15 @@ func TestQueryWithContext(t *testing.T) {
 	_, err = client.QueryWithContext(context.Background(), input)
 	c.NotNil(err)
 	c.Contains(err.Error(), unusedExpressionAttributeNamesMsg)
+
+	input.KeyConditionExpression = aws.String("#invalid-name = :id")
+	input.ExpressionAttributeNames = map[string]*string{
+		"#invalid-name": aws.String("id"),
+	}
+
+	_, err = client.QueryWithContext(context.Background(), input)
+	c.NotNil(err)
+	c.Contains(err.Error(), invalidExpressionAttributeName)
 }
 
 func TestQueryWithContextPagination(t *testing.T) {
@@ -1082,6 +1137,15 @@ func TestScanWithContext(t *testing.T) {
 	c.Len(out.Items, 1)
 	c.NotEmpty(out.LastEvaluatedKey)
 
+	input.FilterExpression = aws.String("#invalid-name = Raichu")
+	input.ExpressionAttributeNames = map[string]*string{
+		"#invalid-name": aws.String("name"),
+	}
+
+	_, err = client.ScanWithContext(context.Background(), input)
+	c.NotNil(err)
+	c.Contains(err.Error(), invalidExpressionAttributeName)
+
 	input.Limit = nil
 	input.FilterExpression = aws.String("#name = :name")
 	input.ExpressionAttributeValues = map[string]*dynamodb.AttributeValue{
@@ -1228,6 +1292,17 @@ func TestDeleteItemWithConditions(t *testing.T) {
 	_, err = client.DeleteItemWithContext(context.Background(), input)
 	c.NotNil(err)
 	c.Contains(err.Error(), unusedExpressionAttributeNamesMsg)
+
+	input.ConditionExpression = aws.String("#invalid-name > 3")
+
+	input.ExpressionAttributeNames = map[string]*string{
+		"#invalid-name": aws.String("hello"),
+	}
+
+	_, err = client.DeleteItemWithContext(context.Background(), input)
+	c.NotNil(err)
+	c.Contains(err.Error(), invalidExpressionAttributeName)
+
 }
 
 func TestDeleteItemWithContextWithReturnValues(t *testing.T) {

--- a/client_test.go
+++ b/client_test.go
@@ -598,9 +598,9 @@ func TestGetItemWithInvalidExpressionAttributeNames(t *testing.T) {
 				S: aws.String("001"),
 			},
 		},
-		ProjectionExpression: aws.String("#name_1"),
+		ProjectionExpression: aws.String("#name-1"),
 		ExpressionAttributeNames: map[string]*string{
-			"#name_1": aws.String("name"),
+			"#name-1": aws.String("name"),
 		},
 	}
 


### PR DESCRIPTION
What:
- Adds validateSyntaxExpression function
- Uses regex to validate syntax
- Adds tests in client_test

Why:
- To ensure ExpressionAttributeNames are valid.

Issue: #2