### PR TITLE
Improve tests for update expression

### DIFF
--- a/interpreter/language/object.go
+++ b/interpreter/language/object.go
@@ -376,7 +376,7 @@ func (l *List) Remove(pos int64) Object {
 		return NULL
 	}
 
-	// TODO: review how dynamodb behaves in this cases
+	// dynamodb does nothing when the index greater than the list size
 
 	return NULL
 }


### PR DESCRIPTION
Why:
It will help to test possible errors in the update expression
interpreter implementation.

What:
- It adds basic tests for the update operations ADD, REMOVE,
  and DELETE.

Issue: #3