### PR TITLE
Improve validation for index schema

### DIFF
--- a/client.go
+++ b/client.go
@@ -25,8 +25,6 @@ const (
 )
 
 var (
-	// ErrMissingKeys when missing table keys
-	ErrMissingKeys = awserr.New("ValidationException", "The number of conditions on the keys is invalid", nil)
 	// ErrInvalidTableName when the provided table name is invalid
 	ErrInvalidTableName = errors.New("invalid table name")
 	// ErrResourceNotFoundException when the requested resource is not found
@@ -394,9 +392,9 @@ func (fd *Client) GetItem(input *dynamodb.GetItemInput) (*dynamodb.GetItemOutput
 		return nil, err
 	}
 
-	key, ok := table.keySchema.getKey(table.attributesDef, input.Key)
-	if !ok {
-		return nil, ErrMissingKeys
+	key, err := table.keySchema.getKey(table.attributesDef, input.Key)
+	if err != nil {
+		return nil, awserr.New("ValidationException", err.Error(), nil)
 	}
 
 	item := copyItem(table.data[key])

--- a/index.go
+++ b/index.go
@@ -24,6 +24,8 @@ type index struct {
 }
 
 func newIndex(t *table, typ indexType, ks keySchema) *index {
+	ks.Secondary = true
+
 	return &index{
 		keySchema:  ks,
 		sortedKeys: []string{},
@@ -38,10 +40,10 @@ func (i *index) clear() {
 	i.refs = map[string]string{}
 }
 
-func (i *index) putData(key string, item map[string]*dynamodb.AttributeValue) {
-	indexKey, ok := i.keySchema.getKey(i.table.attributesDef, item)
-	if !ok {
-		return
+func (i *index) putData(key string, item map[string]*dynamodb.AttributeValue) error {
+	indexKey, err := i.keySchema.getKey(i.table.attributesDef, item)
+	if err != nil || indexKey == "" {
+		return err
 	}
 
 	_, exists := i.refs[key]
@@ -52,12 +54,14 @@ func (i *index) putData(key string, item map[string]*dynamodb.AttributeValue) {
 		i.sortedKeys = append(i.sortedKeys, indexKey)
 		sort.Strings(i.sortedKeys)
 	}
+
+	return nil
 }
 
-func (i *index) updateData(key string, item, oldItem map[string]*dynamodb.AttributeValue) {
-	indexKey, ok := i.keySchema.getKey(i.table.attributesDef, item)
-	if !ok {
-		return
+func (i *index) updateData(key string, item, oldItem map[string]*dynamodb.AttributeValue) error {
+	indexKey, err := i.keySchema.getKey(i.table.attributesDef, item)
+	if err != nil || indexKey == "" {
+		return err
 	}
 
 	old, exists := i.refs[key]
@@ -73,24 +77,28 @@ func (i *index) updateData(key string, item, oldItem map[string]*dynamodb.Attrib
 
 		sort.Strings(i.sortedKeys)
 	}
+
+	return nil
 }
 
-func (i *index) delete(key string, item map[string]*dynamodb.AttributeValue) {
+func (i *index) delete(key string, item map[string]*dynamodb.AttributeValue) error {
 	delete(i.refs, key)
 
-	indexKey, ok := i.keySchema.getKey(i.table.attributesDef, item)
-	if !ok {
-		return
+	indexKey, err := i.keySchema.getKey(i.table.attributesDef, item)
+	if err != nil || indexKey == "" {
+		return err
 	}
 
 	pos := sort.SearchStrings(i.sortedKeys, indexKey)
 	if pos == len(i.sortedKeys) {
-		return
+		return err
 	}
 
 	copy(i.sortedKeys[pos:], i.sortedKeys[pos+1:])
 	i.sortedKeys[len(i.sortedKeys)-1] = ""
 	i.sortedKeys = i.sortedKeys[:len(i.sortedKeys)-1]
+
+	return nil
 }
 
 func (i *index) startSearch() {


### PR DESCRIPTION
What:
It validates if the partition key has the type that
was declarated to create the index.

What:
- It improves the function goGetValue to identify if
  the item field do not match the type provided.
- It return an error when getting the item's key
  from the index schema fails

Issue: #41