### PR TITLE
Support multiple causes in Update Expressions

### DIFF
--- a/interpreter/language/ast_test.go
+++ b/interpreter/language/ast_test.go
@@ -200,9 +200,9 @@ func TestUpdateExpression(t *testing.T) {
 
 func TestActionExpression(t *testing.T) {
 	ae := &ActionExpression{
-		Token: Token{Type: DELETE, Literal: "SET"},
+		Token: Token{Type: SET, Literal: "SET"},
 		Left:  &Identifier{Value: ":x", Token: Token{Type: IDENT, Literal: ":x"}},
-		Right: &Identifier{Value: ":x", Token: Token{Type: IDENT, Literal: ":x"}},
+		Right: &Identifier{Value: ":y", Token: Token{Type: IDENT, Literal: ":y"}},
 	}
 
 	tl := ae.TokenLiteral()
@@ -210,8 +210,22 @@ func TestActionExpression(t *testing.T) {
 		t.Fatalf("wrong token literal. expected=%q, got=%q", "SET", tl)
 	}
 
-	if ae.String() != "SET (:x, :x)" {
-		t.Fatalf("wrong string representation. expected=%q, got=%q", "SET (:x, :x)", ae.String())
+	if ae.String() != "SET (:x = :y)" {
+		t.Fatalf("wrong string representation. expected=%q, got=%q", "SET (:x = :y)", ae.String())
+	}
+
+	ae = &ActionExpression{
+		Token: Token{Type: REMOVE, Literal: "REMOVE"},
+		Left:  &Identifier{Value: ":x", Token: Token{Type: IDENT, Literal: ":x"}},
+	}
+
+	tl = ae.TokenLiteral()
+	if tl != "REMOVE" {
+		t.Fatalf("wrong token literal. expected=%q, got=%q", "REMOVE", tl)
+	}
+
+	if ae.String() != "REMOVE (:x)" {
+		t.Fatalf("wrong string representation. expected=%q, got=%q", "SET (:x = :y)", ae.String())
 	}
 
 	ae.expressionNode()

--- a/interpreter/language/evaluator_test.go
+++ b/interpreter/language/evaluator_test.go
@@ -415,6 +415,8 @@ func TestEvalSetUpdate(t *testing.T) {
 			&Map{Value: map[string]Object{"lvl1": &Map{Value: map[string]Object{"lvl2": &Number{Value: 0}}}, "lvl1.lvl2": &Number{Value: 1}}},
 			false,
 		},
+		{"SET :x = :val REMOVE :val", ":x", &String{Value: "text"}, true},
+		{"SET :x = :val REMOVE :val", ":val", NULL, true},
 	}
 
 	env := startEvalUpdateEnv(t)

--- a/interpreter/language/parser_test.go
+++ b/interpreter/language/parser_test.go
@@ -442,6 +442,59 @@ func TestParsingAddExpression(t *testing.T) {
 	}
 }
 
+func TestParsingRemoveExpression(t *testing.T) {
+	setTests := []struct {
+		input       string
+		actionsSize int
+	}{
+		{"REMOVE ProductTotal", 1},
+		{"REMOVE ProductTotal, Price", 2},
+	}
+
+	for _, tt := range setTests {
+		l := NewLexer(tt.input)
+		p := NewUpdateParser(l)
+		update := p.ParseUpdateExpression()
+		checkParserErrors(t, p)
+
+		opExp, ok := update.Expression.(*UpdateExpression)
+		if !ok {
+			t.Fatalf("exp is not UpdateExpression. got=%T(%s)", update.Expression, update.Expression)
+		}
+
+		if len(opExp.Expressions) != tt.actionsSize {
+			t.Fatalf("unexpected actions size. got=%d expected=(%d)", len(opExp.Expressions), tt.actionsSize)
+		}
+	}
+}
+
+func TestParsingTwoUpdateActions(t *testing.T) {
+	setTests := []struct {
+		input       string
+		actionsSize int
+	}{
+		{"SET ProductCategory = :c REMOVE ProductSize", 2},
+		{"SET ProductCategory = :c ADD ProductSize :one", 2},
+		{"SET ProductCategory = :c, ProductDesc = :text ADD ProductSize :one", 3},
+	}
+
+	for _, tt := range setTests {
+		l := NewLexer(tt.input)
+		p := NewUpdateParser(l)
+		update := p.ParseUpdateExpression()
+		checkParserErrors(t, p)
+
+		opExp, ok := update.Expression.(*UpdateExpression)
+		if !ok {
+			t.Fatalf("exp is not UpdateExpression. got=%T(%s)", update.Expression, update.Expression)
+		}
+
+		if len(opExp.Expressions) != tt.actionsSize {
+			t.Fatalf("unexpected actions size. got=%d expected=(%d)", len(opExp.Expressions), tt.actionsSize)
+		}
+	}
+}
+
 func TestParsingUnsupportedExpressions(t *testing.T) {
 	l := NewLexer("f")
 	p := NewUpdateParser(l)


### PR DESCRIPTION
Why:
It is very important to avoid making multiple
request to dynamodb to make diferent updates
actions.

What:
- It supports multiple type of actions in the
  interpreter.

Issue: #56