### PR TITLE
Fix scan operation after ScanIndexForward implementation

### DIFF
--- a/client.go
+++ b/client.go
@@ -492,6 +492,7 @@ func (fd *Client) Scan(input *dynamodb.ScanInput) (*dynamodb.ScanOutput, error) 
 		ExclusiveStartKey:         input.ExclusiveStartKey,
 		FilterExpression:          input.FilterExpression,
 		Scan:                      true,
+		ScanIndexForward:          aws.Bool(true),
 	})
 
 	count := int64(len(items))

--- a/types.go
+++ b/types.go
@@ -2,6 +2,7 @@ package minidyn
 
 import (
 	"errors"
+	"fmt"
 	"reflect"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -48,13 +49,13 @@ func mapToDynamoDBType(v interface{}) string {
 func getItemValue(item map[string]*dynamodb.AttributeValue, field, typ string) (interface{}, error) {
 	val, ok := item[field]
 	if !ok {
-		return nil, errMissingField
+		return nil, fmt.Errorf("%w; field: %q", errMissingField, field)
 	}
 
 	goVal, ok := getGoValue(val, typ)
 	if !ok {
 		// revive:disable-next-line
-		return nil, errors.New("Invalid attribute value type")
+		return nil, fmt.Errorf("Invalid attribute value type; field %q", field)
 	}
 
 	return goVal, nil


### PR DESCRIPTION
Why:
Scan was returning the last element first

What:
- It sets the ScanIndexForward to true in Scan operation.

Issue: #13