### PR TITLE
Return nil when attributes are nil

### DIFF
--- a/aws-v1/client/client_test.go
+++ b/aws-v1/client/client_test.go
@@ -1133,6 +1133,14 @@ func TestQueryWithContext(t *testing.T) {
 	c.Len(out.Items, 1)
 	c.Empty(out.LastEvaluatedKey)
 
+	var pokemonQueried = pokemon{}
+
+	err = dynamodbattribute.UnmarshalMap(out.Items[0], &pokemonQueried)
+	c.NoError(err)
+	c.Equal(pokemonQueried.ID, "004")
+	c.Equal(pokemonQueried.Type, "fire")
+	c.Equal(pokemonQueried.Name, "Charmander")
+
 	input.FilterExpression = aws.String("#type = :type")
 
 	input.ExpressionAttributeNames["#type"] = aws.String("type")

--- a/aws-v1/client/mapper.go
+++ b/aws-v1/client/mapper.go
@@ -274,7 +274,7 @@ func mapUpdateItemInputToTypes(input *dynamodb.UpdateItemInput) *types.UpdateIte
 }
 
 func mapAttributeValueToTypes(attrs map[string]*dynamodb.AttributeValue) map[string]*types.Item {
-	if len(attrs) == 0 {
+	if attrs == nil {
 		return nil
 	}
 
@@ -332,6 +332,10 @@ func mapAttributeValueListToTypes(attrs []*dynamodb.AttributeValue) []*types.Ite
 }
 
 func mapAttributeValueToDynamodb(attrs map[string]*types.Item) map[string]*dynamodb.AttributeValue {
+	if len(attrs) == 0 {
+		return nil
+	}
+
 	mapItems := make(map[string]*dynamodb.AttributeValue, len(attrs))
 
 	for key, attr := range attrs {
@@ -363,6 +367,10 @@ func mapItemSliceToDynamodb(items []map[string]*types.Item) []map[string]*dynamo
 }
 
 func mapAttributeValueListToDynamodb(attrs []*types.Item) []*dynamodb.AttributeValue {
+	if attrs == nil {
+		return nil
+	}
+
 	mapItems := make([]*dynamodb.AttributeValue, len(attrs))
 
 	for i, attr := range attrs {

--- a/aws-v1/client/minidyn.go
+++ b/aws-v1/client/minidyn.go
@@ -106,7 +106,7 @@ func AddIndex(client dynamodbiface.DynamoDBAPI, tableName, indexName, partitionK
 		AttributeDefinitions: attributes,
 		TableName:            aws.String(tableName),
 		GlobalSecondaryIndexUpdates: []*dynamodb.GlobalSecondaryIndexUpdate{
-			&dynamodb.GlobalSecondaryIndexUpdate{
+			{
 				Create: &dynamodb.CreateGlobalSecondaryIndexAction{
 					IndexName: aws.String(indexName),
 					KeySchema: keySchema,


### PR DESCRIPTION
What: Return nil if attrs came nil or empty
Why: Do not create an empty map that has not
values