### PR TITLE
Fix nested if_not_exists function

### DIFF
--- a/interpreter/language/evaluator.go
+++ b/interpreter/language/evaluator.go
@@ -725,7 +725,7 @@ func evalUpdateFunctionCall(node *CallExpression, env *Environment) Object {
 		return newError("the function is not allowed in an update expression; function: " + funcObj.Name)
 	}
 
-	args := evalExpressions(node.Arguments, env)
+	args := evalUpdateExpressions(node.Arguments, env)
 	if len(args) == 1 && isError(args[0]) {
 		return args[0]
 	}
@@ -997,6 +997,21 @@ func evalExpressions(exps []Expression, env *Environment) []Object {
 
 	for _, e := range exps {
 		evaluated := Eval(e, env)
+		if isError(evaluated) {
+			return []Object{evaluated}
+		}
+
+		result = append(result, evaluated)
+	}
+
+	return result
+}
+
+func evalUpdateExpressions(exps []Expression, env *Environment) []Object {
+	var result []Object
+
+	for _, e := range exps {
+		evaluated := EvalUpdate(e, env)
 		if isError(evaluated) {
 			return []Object{evaluated}
 		}

--- a/interpreter/language/evaluator_test.go
+++ b/interpreter/language/evaluator_test.go
@@ -403,6 +403,12 @@ func TestEvalSetUpdate(t *testing.T) {
 			false,
 		},
 		{
+			"SET :all = list_append(if_not_exists(:all, :list), :tools)",
+			":all",
+			&List{Value: []Object{&Number{Value: 0}, &String{Value: "Chisel"}, &String{Value: "Hammer"}, &String{Value: "Nails"}, &String{Value: "Screwdriver"}, &String{Value: "Hacksaw"}}},
+			false,
+		},
+		{
 			"SET :nestedMap.lvl1.lvl2 = :nestedMap.lvl1.lvl2 + :one",
 			":nestedMap",
 			&Map{Value: map[string]Object{"lvl1": &Map{Value: map[string]Object{"lvl2": &Number{Value: 1}}}}},


### PR DESCRIPTION
Why:
the update valid expression
`SET pokemons = list_append(if_not_exists(pokemons, :empty_list), :pkmns)`

It was failing because the interpreter
did not recognize the nested expresion as
an update expression.

What:
- It uses the EvalUpdate method to evaluate the nested expression in an update expression.

Issue #53