### PR TITLE
Fix error types for aws-sdk-v2

### DIFF
--- a/aws-v2/client/client_test.go
+++ b/aws-v2/client/client_test.go
@@ -889,7 +889,7 @@ func TestUpdateItemWithConditionalExpression(t *testing.T) {
 		},
 	}
 
-	var errConditionalCheckFailedException *types.ConditionalCheckFailedException
+	var errConditionalCheckFailedException *dynamodbtypes.ConditionalCheckFailedException
 
 	_, err = client.UpdateItem(context.Background(), input)
 	c.True(errors.As(err, &errConditionalCheckFailedException))

--- a/aws-v2/client/mapper.go
+++ b/aws-v2/client/mapper.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"errors"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -652,4 +653,21 @@ func toString(str string) *string {
 	}
 
 	return aws.String(str)
+}
+
+func mapKnownError(err error) error {
+	var intErr types.Error
+
+	if !errors.As(err, &intErr) {
+		return err
+	}
+
+	switch intErr.Code() {
+	case "ConditionalCheckFailedException":
+		return &dynamodbtypes.ConditionalCheckFailedException{Message: aws.String(intErr.Message())}
+	case "ResourceNotFoundException":
+		return &dynamodbtypes.ResourceNotFoundException{Message: aws.String(intErr.Message())}
+	}
+
+	return err
 }


### PR DESCRIPTION
Why:
The right error type is need to check
if an conditional expression failed or
if the resource is not found.

What:
- It maps the internal error to the sdk-v2 errors, for those cases.

Issue: #64