### PR TITLE
Fix last evalauted key edge case on Query

### DIFF
--- a/aws-v1/client/client_test.go
+++ b/aws-v1/client/client_test.go
@@ -1292,6 +1292,14 @@ func TestQueryWithContextPagination(t *testing.T) {
 	c.Empty(out.Items)
 	c.Empty(out.LastEvaluatedKey)
 
+	input.Limit = nil
+	input.ExclusiveStartKey = nil
+
+	out, err = client.QueryWithContext(context.Background(), input)
+	c.NoError(err)
+	c.Len(out.Items, 3)
+	c.Empty(out.LastEvaluatedKey)
+
 	input.Limit = aws.Int64(4)
 	input.ExclusiveStartKey = nil
 
@@ -1299,6 +1307,23 @@ func TestQueryWithContextPagination(t *testing.T) {
 	c.NoError(err)
 	c.Len(out.Items, 3)
 	c.Empty(out.LastEvaluatedKey)
+
+	input.Limit = aws.Int64(2)
+	input.ExclusiveStartKey = nil
+
+	out, err = client.QueryWithContext(context.Background(), input)
+	c.NoError(err)
+	c.Len(out.Items, 2)
+	c.NotEmpty(out.LastEvaluatedKey)
+	input.ExclusiveStartKey = out.LastEvaluatedKey
+
+	out, err = client.QueryWithContext(context.Background(), input)
+	c.NoError(err)
+	c.Len(out.Items, 1)
+	c.Empty(out.LastEvaluatedKey)
+
+	input.Limit = aws.Int64(4)
+	input.ExclusiveStartKey = nil
 
 	err = createPokemon(client, pokemon{
 		ID:   "004",

--- a/aws-v2/client/client_test.go
+++ b/aws-v2/client/client_test.go
@@ -1293,6 +1293,7 @@ func TestQueryPagination(t *testing.T) {
 	c.NoError(err)
 	c.Len(out.Items, 1)
 	c.Equal("003", out.Items[0]["id"].(*dynamodbtypes.AttributeValueMemberS).Value)
+	c.NotEmpty(out.LastEvaluatedKey)
 
 	input.ExclusiveStartKey = out.LastEvaluatedKey
 	out, err = client.Query(context.Background(), input)
@@ -1307,6 +1308,31 @@ func TestQueryPagination(t *testing.T) {
 	c.NoError(err)
 	c.Len(out.Items, 3)
 	c.Empty(out.LastEvaluatedKey)
+
+	input.Limit = aws.Int32(2)
+	input.ExclusiveStartKey = nil
+
+	out, err = client.Query(context.Background(), input)
+	c.NoError(err)
+	c.Len(out.Items, 2)
+	c.NotEmpty(out.LastEvaluatedKey)
+	input.ExclusiveStartKey = out.LastEvaluatedKey
+
+	out, err = client.Query(context.Background(), input)
+	c.NoError(err)
+	c.Len(out.Items, 1)
+	c.Empty(out.LastEvaluatedKey)
+
+	input.Limit = nil
+	input.ExclusiveStartKey = nil
+
+	out, err = client.Query(context.Background(), input)
+	c.NoError(err)
+	c.Len(out.Items, 3)
+	c.Empty(out.LastEvaluatedKey)
+
+	input.Limit = aws.Int32(4)
+	input.ExclusiveStartKey = nil
 
 	err = createPokemon(client, pokemon{
 		ID:   "004",

--- a/core/table.go
+++ b/core/table.go
@@ -293,16 +293,12 @@ func (t *Table) getMatchedItemAndCount(input *QueryInput, pk, startKey string) (
 	return copyItem(storedItem), lastMatchExpressionType, true
 }
 
-func shouldReturnNextKey(item map[string]*types.Item, scanned, limit, keysSize int64) bool {
+func shouldReturnNextKey(item map[string]*types.Item, count, scanned, limit, keysSize int64) bool {
 	if len(item) == 0 || limit == 0 {
 		return false
 	}
 
-	if limit >= keysSize {
-		return false
-	}
-
-	return scanned <= keysSize
+	return scanned <= keysSize && limit <= count
 }
 
 func shouldCountItem(expressionType interpreter.ExpressionType, matched bool) bool {
@@ -345,7 +341,6 @@ func (t *Table) SearchData(input QueryInput) ([]map[string]*types.Item, map[stri
 		k := GetKeyAt(sortedKeys, sortedKeysSize, int64(pos), forward)
 
 		pk, ok := prepareSearch(&input, index, k, startKey)
-
 		if !ok {
 			scanned++
 			continue
@@ -370,11 +365,11 @@ func (t *Table) SearchData(input QueryInput) ([]map[string]*types.Item, map[stri
 		}
 	}
 
-	return items, t.getLastKey(last, limit, scanned, sortedKeysSize, index)
+	return items, t.getLastKey(last, limit, count, scanned, sortedKeysSize, index)
 }
 
-func (t *Table) getLastKey(item map[string]*types.Item, limit, scanned, keysSize int64, index *index) map[string]*types.Item {
-	if !shouldReturnNextKey(item, scanned, limit, keysSize) {
+func (t *Table) getLastKey(item map[string]*types.Item, limit, count, scanned, keysSize int64, index *index) map[string]*types.Item {
+	if !shouldReturnNextKey(item, count, scanned, limit, keysSize) {
 		return map[string]*types.Item{}
 	}
 

--- a/core/table_test.go
+++ b/core/table_test.go
@@ -652,7 +652,7 @@ func TestGetLastKey(t *testing.T) {
 		Table:      newTable,
 	}
 
-	result := newTable.getLastKey(item, 1, 1, 2, newIndex)
+	result := newTable.getLastKey(item, 1, 1, 1, 2, newIndex)
 	c.Equal(item["id"], result["id"])
 }
 


### PR DESCRIPTION
Why:
It is not working according with the documentation.

What:
- It fixes the conditions to return the last evaluated key when the limit was reached.
- It adds more test for query pagination

Issue: #73