### PR TITLE
Fix aws-v2 object mapper

### DIFF
--- a/aws-v2/client/client_test.go
+++ b/aws-v2/client/client_test.go
@@ -618,10 +618,12 @@ func TestPutWithGSI(t *testing.T) {
 
 	_ = AddIndex(context.Background(), client, tableName, "sort-by-second-type", "id", "second_type")
 
-	item, err = attributevalue.MarshalMap(pokemon{
+	item, err = attributevalue.MarshalMapWithOptions(pokemon{
 		ID:   "002",
 		Name: "Ivysaur",
 		Type: "grass",
+	}, func(eo *attributevalue.EncoderOptions) {
+		eo.TagKey = "json"
 	})
 	c.NoError(err)
 

--- a/aws-v2/client/mapper.go
+++ b/aws-v2/client/mapper.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"errors"
-	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
@@ -229,7 +228,7 @@ func mapDynamoToTypesMapItem(input map[string]dynamodbtypes.AttributeValue) map[
 	output := map[string]*types.Item{}
 
 	for key, item := range input {
-		output[strings.ToLower(key)] = mapDynamoToTypesItem(item)
+		output[key] = mapDynamoToTypesItem(item)
 	}
 
 	return output


### PR DESCRIPTION
Why:
It was incorretly lowering the keys names
breaking the conditional expression feature.

What:
- It removes the usage of strings.ToLower

Issue: #86