### PR TITLE
Add the force failure support

### DIFF
--- a/aws-v2/client/client.go
+++ b/aws-v2/client/client.go
@@ -476,6 +476,10 @@ func (fd *Client) BatchWriteItem(ctx context.Context, input *dynamodb.BatchWrite
 
 // BatchGetItem mock response for dynamodb
 func (fd *Client) BatchGetItem(ctx context.Context, input *dynamodb.BatchGetItemInput, opts ...func(*dynamodb.Options)) (*dynamodb.BatchGetItemOutput, error) {
+	if fd.forceFailureErr != nil {
+		return nil, fd.forceFailureErr
+	}
+
 	responses := make(map[string][]map[string]types.AttributeValue, len(input.RequestItems))
 	unprocessed := make(map[string]types.KeysAndAttributes, len(input.RequestItems))
 

--- a/aws-v2/client/client_test.go
+++ b/aws-v2/client/client_test.go
@@ -655,7 +655,15 @@ func TestPutAndGetBatchItem(t *testing.T) {
 		},
 	}
 
+	ActiveForceFailure(client)
+
 	out, err := client.BatchGetItem(context.Background(), getInput)
+	c.Nil(out)
+	c.EqualError(err, ErrForcedFailure.Error())
+
+	DeactiveForceFailure(client)
+
+	out, err = client.BatchGetItem(context.Background(), getInput)
 	c.NoError(err)
 	c.Len(out.Responses[tableName], 2)
 	c.Equal("001", out.Responses[tableName][0]["id"].(*dynamodbtypes.AttributeValueMemberS).Value)


### PR DESCRIPTION
What: Include forced failure in batch get item
Why: It is necessary to test the failure case

CAN-3647