### PR TITLE
Add clear-all support with error reuse

### DIFF
--- a/server/client.go
+++ b/server/client.go
@@ -149,6 +149,20 @@ func (c *Client) ClearTable(tableName string) error {
 	return nil
 }
 
+// ClearAllTables removes all data from every table and its indexes.
+func (c *Client) ClearAllTables() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	for _, table := range c.tables {
+		table.Clear()
+
+		for _, index := range table.Indexes {
+			index.Clear()
+		}
+	}
+}
+
 // Reset removes all tables and their indexes from the in-memory client.
 func (c *Client) Reset() {
 	c.mu.Lock()

--- a/server/minidyn.go
+++ b/server/minidyn.go
@@ -24,6 +24,9 @@ var (
 	// ErrForcedFailure when the error is forced (deprecated).
 	ErrForcedFailure = errors.New("forced failure response")
 
+	// ErrServerNotInitialized when the server is not initialized
+	ErrServerNotInitialized = errors.New("server not initialized")
+
 	emulatingErrors = map[FailureCondition]error{
 		FailureConditionNone:                nil,
 		FailureConditionInternalServerError: emulatedInternalServerError,
@@ -43,16 +46,27 @@ func (s *Server) EmulateFailure(condition FailureCondition) {
 // ClearTable removes all data from a table and its indexes using the in-memory client.
 func (s *Server) ClearTable(tableName string) error {
 	if s == nil || s.client == nil {
-		return errors.New("server not initialized")
+		return ErrServerNotInitialized
 	}
 
 	return s.client.ClearTable(tableName)
 }
 
+// ClearAllTables removes all data from every table and its indexes using the in-memory client.
+func (s *Server) ClearAllTables() error {
+	if s == nil || s.client == nil {
+		return ErrServerNotInitialized
+	}
+
+	s.client.ClearAllTables()
+
+	return nil
+}
+
 // Reset removes all tables and indexes from the in-memory client.
 func (s *Server) Reset() error {
 	if s == nil || s.client == nil {
-		return errors.New("server not initialized")
+		return ErrServerNotInitialized
 	}
 
 	s.client.Reset()


### PR DESCRIPTION
Why:
Support clearing data across all tables without dropping schema, to improve test isolation and reduce setup complexity.

What:
Add ErrServerNotInitialized constant and use it in ClearTable, ClearAllTables, Reset. Implement ClearAllTables on client/server to wipe data and indexes for all tables. Add server test covering ClearAllTables flow and verify data cleared while tables remain.

Issue: #80