### PR TITLE
Reject duplicate SS/NS/BS sets with ValidationException in core and c…

### DIFF
--- a/aws-v1/client/client.go
+++ b/aws-v1/client/client.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbiface"
 	"github.com/truora/minidyn/core"
 	"github.com/truora/minidyn/interpreter"
+	"github.com/truora/minidyn/types"
 )
 
 const (
@@ -265,7 +266,7 @@ func (fd *Client) PutItemWithContext(ctx aws.Context, input *dynamodb.PutItemInp
 }
 
 // DeleteItem mock response for dynamodb
-func (fd *Client) DeleteItem(input *dynamodb.DeleteItemInput) (*dynamodb.DeleteItemOutput, error) {
+func (fd *Client) DeleteItem(input *dynamodb.DeleteItemInput) (*dynamodb.DeleteItemOutput, error) { //nolint:gocognit,gocyclo // validate, conditional SearchData, delete, return shapes
 	err := input.Validate()
 	if err != nil {
 		return nil, err
@@ -290,13 +291,17 @@ func (fd *Client) DeleteItem(input *dynamodb.DeleteItemInput) (*dynamodb.DeleteI
 
 	// support conditional writes
 	if input.ConditionExpression != nil {
-		items, _ := table.SearchData(core.QueryInput{
+		items, _, serr := table.SearchData(core.QueryInput{
 			Index:                     core.PrimaryIndexName,
 			ExpressionAttributeValues: mapAttributeValueToTypes(input.ExpressionAttributeValues),
 			Aliases:                   aws.StringValueMap(input.ExpressionAttributeNames),
 			Limit:                     1,
 			ConditionExpression:       input.ConditionExpression,
 		})
+		if serr != nil {
+			return nil, serr
+		}
+
 		if len(items) == 0 {
 			return &dynamodb.DeleteItemOutput{}, awserr.New(dynamodb.ErrCodeConditionalCheckFailedException, core.ErrConditionalRequestFailed.Error(), nil)
 		}
@@ -390,7 +395,12 @@ func (fd *Client) GetItem(input *dynamodb.GetItemInput) (*dynamodb.GetItemOutput
 		return nil, err
 	}
 
-	key, err := table.KeySchema.GetKey(table.AttributesDef, mapAttributeValueToTypes(input.Key))
+	keyMap := mapAttributeValueToTypes(input.Key)
+	if vErr := types.ValidateItemMap(keyMap); vErr != nil {
+		return nil, awserr.New("ValidationException", vErr.Error(), nil)
+	}
+
+	key, err := table.KeySchema.GetKey(table.AttributesDef, keyMap)
 	if err != nil {
 		return nil, awserr.New("ValidationException", err.Error(), nil)
 	}
@@ -434,7 +444,7 @@ func (fd *Client) Query(input *dynamodb.QueryInput) (*dynamodb.QueryOutput, erro
 		input.ScanIndexForward = new(true)
 	}
 
-	items, lastKey := table.SearchData(core.QueryInput{
+	items, lastKey, err := table.SearchData(core.QueryInput{
 		Index:                     indexName,
 		ExpressionAttributeValues: mapAttributeValueToTypes(input.ExpressionAttributeValues),
 		Aliases:                   aws.StringValueMap(input.ExpressionAttributeNames),
@@ -444,6 +454,9 @@ func (fd *Client) Query(input *dynamodb.QueryInput) (*dynamodb.QueryOutput, erro
 		FilterExpression:          aws.StringValue(input.FilterExpression),
 		ScanIndexForward:          aws.BoolValue(input.ScanIndexForward),
 	})
+	if err != nil {
+		return nil, err
+	}
 
 	count := int64(len(items))
 
@@ -482,7 +495,7 @@ func (fd *Client) Scan(input *dynamodb.ScanInput) (*dynamodb.ScanOutput, error) 
 
 	indexName := aws.StringValue(input.IndexName)
 
-	items, lastKey := table.SearchData(core.QueryInput{
+	items, lastKey, err := table.SearchData(core.QueryInput{
 		Index:                     indexName,
 		ExpressionAttributeValues: mapAttributeValueToTypes(input.ExpressionAttributeValues),
 		Aliases:                   aws.StringValueMap(input.ExpressionAttributeNames),
@@ -492,6 +505,9 @@ func (fd *Client) Scan(input *dynamodb.ScanInput) (*dynamodb.ScanOutput, error) 
 		Scan:                      true,
 		ScanIndexForward:          true,
 	})
+	if err != nil {
+		return nil, err
+	}
 
 	count := int64(len(items))
 

--- a/aws-v2/client/client.go
+++ b/aws-v2/client/client.go
@@ -15,6 +15,7 @@ import (
 	"github.com/aws/smithy-go"
 	"github.com/truora/minidyn/core"
 	"github.com/truora/minidyn/interpreter"
+	mintypes "github.com/truora/minidyn/types"
 )
 
 const (
@@ -260,13 +261,17 @@ func (fd *Client) DeleteItem(ctx context.Context, input *dynamodb.DeleteItemInpu
 
 	// support conditional writes
 	if input.ConditionExpression != nil {
-		items, _ := table.SearchData(core.QueryInput{
+		items, _, serr := table.SearchData(core.QueryInput{
 			Index:                     core.PrimaryIndexName,
 			ExpressionAttributeValues: mapDynamoToTypesMapItem(input.ExpressionAttributeValues),
 			Aliases:                   input.ExpressionAttributeNames,
 			Limit:                     aws.ToInt64(aws.Int64(1)),
 			ConditionExpression:       input.ConditionExpression,
 		})
+		if serr != nil {
+			return nil, mapKnownError(serr)
+		}
+
 		if len(items) == 0 {
 			return &dynamodb.DeleteItemOutput{}, &types.ConditionalCheckFailedException{Message: aws.String(core.ErrConditionalRequestFailed.Error())}
 		}
@@ -340,7 +345,12 @@ func (fd *Client) GetItem(ctx context.Context, input *dynamodb.GetItemInput, opt
 		return nil, mapKnownError(err)
 	}
 
-	key, err := table.KeySchema.GetKey(table.AttributesDef, mapDynamoToTypesMapItem(input.Key))
+	keyMap := mapDynamoToTypesMapItem(input.Key)
+	if vErr := mintypes.ValidateItemMap(keyMap); vErr != nil {
+		return nil, mapKnownError(mintypes.NewError("ValidationException", vErr.Error(), nil))
+	}
+
+	key, err := table.KeySchema.GetKey(table.AttributesDef, keyMap)
 	if err != nil {
 		return nil, &smithy.GenericAPIError{Code: "ValidationException", Message: err.Error()}
 	}
@@ -379,7 +389,10 @@ func (fd *Client) Query(ctx context.Context, input *dynamodb.QueryInput, opt ...
 		input.ScanIndexForward = aws.Bool(true)
 	}
 
-	items, lastKey := table.SearchData(mapDynamoToTypesQueryInput(input, indexName))
+	items, lastKey, err := table.SearchData(mapDynamoToTypesQueryInput(input, indexName))
+	if err != nil {
+		return nil, mapKnownError(err)
+	}
 
 	count := len(items)
 	if count > math.MaxInt32 {
@@ -416,7 +429,7 @@ func (fd *Client) Scan(ctx context.Context, input *dynamodb.ScanInput, opt ...fu
 
 	indexName := aws.ToString(input.IndexName)
 
-	items, lastKey := table.SearchData(core.QueryInput{
+	items, lastKey, err := table.SearchData(core.QueryInput{
 		Index:                     indexName,
 		ExpressionAttributeValues: mapDynamoToTypesMapItem(input.ExpressionAttributeValues),
 		Aliases:                   input.ExpressionAttributeNames,
@@ -426,6 +439,9 @@ func (fd *Client) Scan(ctx context.Context, input *dynamodb.ScanInput, opt ...fu
 		ScanIndexForward:          true,
 		Scan:                      true,
 	})
+	if err != nil {
+		return nil, mapKnownError(err)
+	}
 
 	count := len(items)
 	if count > math.MaxInt32 {

--- a/core/table.go
+++ b/core/table.go
@@ -235,6 +235,30 @@ func (t *Table) AddLocalIndexes(input []*types.LocalSecondaryIndex) error {
 	return nil
 }
 
+func validateSearchInputMaps(input QueryInput) error {
+	if err := types.ValidateItemMap(input.ExpressionAttributeValues); err != nil {
+		return types.NewError("ValidationException", err.Error(), nil)
+	}
+
+	if err := types.ValidateItemMap(input.ExclusiveStartKey); err != nil {
+		return types.NewError("ValidationException", err.Error(), nil)
+	}
+
+	return nil
+}
+
+func validateUpdateItemInputKeysAndValues(input *types.UpdateItemInput) error {
+	if err := types.ValidateItemMap(input.Key); err != nil {
+		return types.NewError("ValidationException", err.Error(), nil)
+	}
+
+	if err := types.ValidateItemMap(input.ExpressionAttributeValues); err != nil {
+		return types.NewError("ValidationException", err.Error(), nil)
+	}
+
+	return nil
+}
+
 func (t *Table) parseStartKey(schema keySchema, startkeyAttr map[string]*types.Item) string {
 	startKey := ""
 	if len(startkeyAttr) != 0 {
@@ -320,8 +344,12 @@ func GetKeyAt(sortedKeys []string, size int64, pos int64, forward bool) string {
 	return sortedKeys[pos]
 }
 
-// SearchData quiery the table based on the input
-func (t *Table) SearchData(input QueryInput) ([]map[string]*types.Item, map[string]*types.Item) {
+// SearchData queries the table based on the input.
+func (t *Table) SearchData(input QueryInput) ([]map[string]*types.Item, map[string]*types.Item, error) {
+	if err := validateSearchInputMaps(input); err != nil {
+		return nil, nil, err
+	}
+
 	items := []map[string]*types.Item{}
 	limit := input.Limit
 	exclusiveStartKey := input.ExclusiveStartKey
@@ -367,7 +395,7 @@ func (t *Table) SearchData(input QueryInput) ([]map[string]*types.Item, map[stri
 		}
 	}
 
-	return items, t.getLastKey(last, limit, count, scanned, sortedKeysSize, index)
+	return items, t.getLastKey(last, limit, count, scanned, sortedKeysSize, index), nil
 }
 
 func (t *Table) getLastKey(item map[string]*types.Item, limit, count, scanned, keysSize int64, index *index) map[string]*types.Item {
@@ -471,6 +499,14 @@ func (t *Table) Clear() {
 
 // Put puts items into table
 func (t *Table) Put(input *types.PutItemInput) (map[string]*types.Item, error) {
+	if err := types.ValidateItemMap(input.Item); err != nil {
+		return copyItem(input.Item), types.NewError("ValidationException", err.Error(), nil)
+	}
+
+	if err := types.ValidateItemMap(input.ExpressionAttributeValues); err != nil {
+		return copyItem(input.Item), types.NewError("ValidationException", err.Error(), nil)
+	}
+
 	item := copyItem(input.Item)
 
 	key, err := t.KeySchema.GetKey(t.AttributesDef, input.Item)
@@ -514,7 +550,11 @@ func (t *Table) interpreterUpdate(input interpreter.UpdateInput) error {
 }
 
 // Update updates an item in the table based on the input
-func (t *Table) Update(input *types.UpdateItemInput) (map[string]*types.Item, error) {
+func (t *Table) Update(input *types.UpdateItemInput) (map[string]*types.Item, error) { //nolint:gocognit,gocyclo // conditional writes, interpreter update, GSI updates
+	if err := validateUpdateItemInputKeysAndValues(input); err != nil {
+		return nil, err
+	}
+
 	// update primary index
 	key, err := t.KeySchema.GetKey(t.AttributesDef, input.Key)
 	if err != nil {
@@ -582,6 +622,14 @@ func (t *Table) Update(input *types.UpdateItemInput) (map[string]*types.Item, er
 
 // Delete deletes an item in the table based on the input
 func (t *Table) Delete(input *types.DeleteItemInput) (map[string]*types.Item, error) {
+	if err := types.ValidateItemMap(input.Key); err != nil {
+		return nil, types.NewError("ValidationException", err.Error(), nil)
+	}
+
+	if err := types.ValidateItemMap(input.ExpressionAttributeValues); err != nil {
+		return nil, types.NewError("ValidationException", err.Error(), nil)
+	}
+
 	key, err := t.KeySchema.GetKey(t.AttributesDef, input.Key)
 	if err != nil {
 		return nil, types.NewError("ValidationException", err.Error(), nil)

--- a/core/table_test.go
+++ b/core/table_test.go
@@ -471,7 +471,8 @@ func TestSearchData(t *testing.T) {
 
 	queryInput := QueryInput{}
 
-	result, lastItem := newTable.SearchData(queryInput)
+	result, lastItem, err := newTable.SearchData(queryInput)
+	c.NoError(err)
 	c.Equal([]map[string]*types.Item{}, result)
 	c.Equal(map[string]*types.Item{}, lastItem)
 
@@ -495,7 +496,8 @@ func TestSearchData(t *testing.T) {
 		},
 	}
 
-	result, lastItem = newTable.SearchData(queryInput)
+	result, lastItem, err = newTable.SearchData(queryInput)
+	c.NoError(err)
 	c.Equal([]map[string]*types.Item{}, result)
 	c.Equal(map[string]*types.Item{}, lastItem)
 
@@ -518,16 +520,91 @@ func TestSearchData(t *testing.T) {
 	queryInput.Index = "indice"
 	queryInput.started = true
 
-	result, lastItem = newTable.SearchData(queryInput)
+	result, lastItem, err = newTable.SearchData(queryInput)
+	c.NoError(err)
 	c.Equal([]map[string]*types.Item{}, result)
 	c.Equal(map[string]*types.Item{}, lastItem)
 
 	queryInput.ExclusiveStartKey = item
-	result, lastItem = newTable.SearchData(queryInput)
+	result, lastItem, err = newTable.SearchData(queryInput)
+	c.NoError(err)
 	c.Equal([]map[string]*types.Item{}, result)
 	c.Equal(map[string]*types.Item{}, lastItem)
 
 	newIndex.Clear()
+}
+
+func TestPut_duplicateSetValidationException(t *testing.T) {
+	c := require.New(t)
+
+	newTable := NewTable(tableName)
+	newTable.AttributesDef = map[string]string{"id": "S", "name": "S"}
+	newTable.KeySchema = keySchema{"id", "name", false}
+
+	a, b := "x", "x"
+	item := map[string]*types.Item{
+		"id":   {S: new("001")},
+		"name": {S: new("n")},
+		"tags": {SS: []*string{&a, &b}},
+	}
+
+	_, err := newTable.Put(&types.PutItemInput{Item: item, TableName: &newTable.Name})
+	c.Error(err)
+
+	var apiErr types.Error
+	c.True(errors.As(err, &apiErr))
+	c.Equal("ValidationException", apiErr.Code())
+	c.Contains(apiErr.Message(), "contains duplicates")
+}
+
+func TestSearchData_duplicateExpressionAttributeValues(t *testing.T) {
+	c := require.New(t)
+
+	newTable, err := createPokemonTable()
+	c.NoError(err)
+
+	a, b := "d", "d"
+	_, _, err = newTable.SearchData(QueryInput{
+		ExpressionAttributeValues: map[string]*types.Item{
+			":v": {SS: []*string{&a, &b}},
+		},
+	})
+	c.Error(err)
+
+	var apiErr types.Error
+	c.True(errors.As(err, &apiErr))
+	c.Equal("ValidationException", apiErr.Code())
+	c.Contains(apiErr.Message(), "contains duplicates")
+}
+
+func TestUpdate_duplicateExpressionAttributeValues(t *testing.T) {
+	c := require.New(t)
+
+	newTable, err := createPokemonTable()
+	c.NoError(err)
+
+	item := createPokemon(pokemon{
+		ID:   "001",
+		Type: "grass",
+		Name: "Bulbasaur",
+	})
+
+	_, err = newTable.Put(&types.PutItemInput{Item: item, TableName: &newTable.Name})
+	c.NoError(err)
+
+	a, b := "p", "p"
+	_, err = newTable.Update(&types.UpdateItemInput{
+		Key: item,
+		ExpressionAttributeValues: map[string]*types.Item{
+			":s": {SS: []*string{&a, &b}},
+		},
+	})
+	c.Error(err)
+
+	var apiErr types.Error
+	c.True(errors.As(err, &apiErr))
+	c.Equal("ValidationException", apiErr.Code())
+	c.Contains(apiErr.Message(), "contains duplicates")
 }
 
 func TestUpdate(t *testing.T) {

--- a/server/client.go
+++ b/server/client.go
@@ -283,7 +283,12 @@ func (c *Client) GetItem(ctx context.Context, input *GetItemInput) (*GetItemOutp
 		return nil, err
 	}
 
-	key, err := table.KeySchema.GetKey(table.AttributesDef, mapAttributeValueMapToTypes(input.Key))
+	keyMap := mapAttributeValueMapToTypes(input.Key)
+	if vErr := types.ValidateItemMap(keyMap); vErr != nil {
+		return nil, mapKnownError(types.NewError("ValidationException", vErr.Error(), nil))
+	}
+
+	key, err := table.KeySchema.GetKey(table.AttributesDef, keyMap)
 	if err != nil {
 		return nil, &smithy.GenericAPIError{Code: "ValidationException", Message: err.Error()}
 	}
@@ -309,7 +314,7 @@ func (c *Client) Query(ctx context.Context, input *QueryInput) (*QueryOutput, er
 		input.ScanIndexForward = aws.Bool(true)
 	}
 
-	items, last := table.SearchData(core.QueryInput{
+	items, last, err := table.SearchData(core.QueryInput{
 		Index:                     aws.ToString(input.IndexName),
 		ExpressionAttributeValues: mapAttributeValueMapToTypes(input.ExpressionAttributeValues),
 		Aliases:                   input.ExpressionAttributeNames,
@@ -319,6 +324,9 @@ func (c *Client) Query(ctx context.Context, input *QueryInput) (*QueryOutput, er
 		Limit:                     int64(aws.ToInt32(input.Limit)),
 		ScanIndexForward:          aws.ToBool(input.ScanIndexForward),
 	})
+	if err != nil {
+		return nil, mapKnownError(err)
+	}
 
 	count := int32(len(items))
 
@@ -343,7 +351,7 @@ func (c *Client) Scan(ctx context.Context, input *ScanInput) (*ScanOutput, error
 		return nil, err
 	}
 
-	items, last := table.SearchData(core.QueryInput{
+	items, last, err := table.SearchData(core.QueryInput{
 		Index:                     aws.ToString(input.IndexName),
 		ExpressionAttributeValues: mapAttributeValueMapToTypes(input.ExpressionAttributeValues),
 		Aliases:                   input.ExpressionAttributeNames,
@@ -353,6 +361,9 @@ func (c *Client) Scan(ctx context.Context, input *ScanInput) (*ScanOutput, error
 		Scan:                      true,
 		ScanIndexForward:          true,
 	})
+	if err != nil {
+		return nil, mapKnownError(err)
+	}
 
 	count := int32(len(items))
 

--- a/types/validate_item.go
+++ b/types/validate_item.go
@@ -1,0 +1,146 @@
+package types
+
+import (
+	"bytes"
+	"encoding/base64"
+	"fmt"
+	"strings"
+)
+
+// ValidateItemAttributeValue walks an attribute value, including nested List (L) and Map (M)
+// entries, and returns an error when any String Set (SS), Number Set (NS), or Binary Set (BS)
+// contains duplicate members. The error message matches the DynamoDB ValidationException body:
+// Callers typically wrap the result with NewError("ValidationException", msg, nil).
+//
+// Nil av is valid. NS duplicates are detected by exact wire string equality of each element
+// (e.g. "1" and "1.0" are not duplicates). SS uses the same string comparison as StringValue.
+// BS duplicates use bytes.Equal (nil and empty slices compare equal).
+func ValidateItemAttributeValue(av *Item) error {
+	if av == nil {
+		return nil
+	}
+
+	if err := validateItemScalarSets(av); err != nil {
+		return err
+	}
+
+	return validateItemNested(av)
+}
+
+func validateItemScalarSets(av *Item) error {
+	if err := validateStringSet(av.SS); err != nil {
+		return err
+	}
+
+	if err := validateNumberSet(av.NS); err != nil {
+		return err
+	}
+
+	return validateBinarySet(av.BS)
+}
+
+func validateItemNested(av *Item) error {
+	for _, elem := range av.L {
+		if err := ValidateItemAttributeValue(elem); err != nil {
+			return err
+		}
+	}
+
+	for _, v := range av.M {
+		if err := ValidateItemAttributeValue(v); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// ValidateItemMap runs ValidateItemAttributeValue on every value in m.
+// Nil or empty maps are valid.
+func ValidateItemMap(m map[string]*Item) error {
+	if m == nil {
+		return nil
+	}
+
+	for _, v := range m {
+		if err := ValidateItemAttributeValue(v); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func duplicateCollectionError(displayParts []string) error {
+	inner := strings.Join(displayParts, ", ")
+
+	// Wording matches DynamoDB ValidationException; linters prefer generic Go error style.
+	//nolint:revive,staticcheck // error-strings / ST1005 — message aligned with AWS.
+	return fmt.Errorf("One or more parameter values were invalid: Input collection [%s] contains duplicates.", inner)
+}
+
+func validateStringSet(ss []*string) error {
+	if len(ss) < 2 {
+		return nil
+	}
+
+	parts := make([]string, len(ss))
+	for i, p := range ss {
+		parts[i] = StringValue(p)
+	}
+
+	seen := make(map[string]struct{}, len(parts))
+	for _, v := range parts {
+		if _, ok := seen[v]; ok {
+			return duplicateCollectionError(parts)
+		}
+
+		seen[v] = struct{}{}
+	}
+
+	return nil
+}
+
+func validateNumberSet(ns []*string) error {
+	if len(ns) < 2 {
+		return nil
+	}
+
+	// Duplicates follow DynamoDB wire encoding: compared as the exact string sent for each N.
+	parts := make([]string, len(ns))
+	for i, p := range ns {
+		parts[i] = StringValue(p)
+	}
+
+	seen := make(map[string]struct{}, len(parts))
+	for _, v := range parts {
+		if _, ok := seen[v]; ok {
+			return duplicateCollectionError(parts)
+		}
+
+		seen[v] = struct{}{}
+	}
+
+	return nil
+}
+
+func validateBinarySet(bs [][]byte) error {
+	if len(bs) < 2 {
+		return nil
+	}
+
+	parts := make([]string, len(bs))
+	for i, b := range bs {
+		parts[i] = base64.StdEncoding.EncodeToString(b)
+	}
+
+	for i := range bs {
+		for j := i + 1; j < len(bs); j++ {
+			if bytes.Equal(bs[i], bs[j]) {
+				return duplicateCollectionError(parts)
+			}
+		}
+	}
+
+	return nil
+}

--- a/types/validate_item_test.go
+++ b/types/validate_item_test.go
@@ -1,0 +1,178 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateItemAttributeValue_nil(t *testing.T) {
+	t.Parallel()
+
+	require.NoError(t, ValidateItemAttributeValue(nil))
+}
+
+func TestValidateItemAttributeValue_stringSet(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		item    *Item
+		wantErr string
+	}{
+		{
+			name: "unique SS",
+			item: &Item{SS: []*string{aws.String("a"), aws.String("b")}},
+		},
+		{
+			name: "empty SS",
+			item: &Item{SS: []*string{}},
+		},
+		{
+			name: "nil SS slice",
+			item: &Item{SS: nil},
+		},
+		{
+			name:    "duplicate SS top-level",
+			item:    &Item{SS: []*string{aws.String("x"), aws.String("y"), aws.String("x")}},
+			wantErr: "One or more parameter values were invalid: Input collection [x, y, x] contains duplicates.",
+		},
+		{
+			name:    "duplicate SS via nil pointers (empty string)",
+			item:    &Item{SS: []*string{nil, nil}},
+			wantErr: "One or more parameter values were invalid: Input collection [, ] contains duplicates.",
+		},
+		{
+			name: "nested duplicate SS inside M",
+			item: &Item{M: map[string]*Item{
+				"inner": {SS: []*string{aws.String("p"), aws.String("p")}},
+			}},
+			wantErr: "One or more parameter values were invalid: Input collection [p, p] contains duplicates.",
+		},
+		{
+			name: "nested duplicate SS inside L",
+			item: &Item{L: []*Item{
+				{S: aws.String("skip")},
+				{SS: []*string{aws.String("a"), aws.String("b"), aws.String("a")}},
+			}},
+			wantErr: "One or more parameter values were invalid: Input collection [a, b, a] contains duplicates.",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := ValidateItemAttributeValue(tt.item)
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+
+				return
+			}
+
+			require.Error(t, err)
+			require.Equal(t, tt.wantErr, err.Error())
+		})
+	}
+}
+
+func TestValidateItemAttributeValue_numberSet(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		item    *Item
+		wantErr string
+	}{
+		{
+			name: "unique NS wire strings",
+			item: &Item{NS: []*string{aws.String("1"), aws.String("1.0")}},
+		},
+		{
+			name:    "duplicate NS compares wire encoding only",
+			item:    &Item{NS: []*string{aws.String("42"), aws.String("42")}},
+			wantErr: "One or more parameter values were invalid: Input collection [42, 42] contains duplicates.",
+		},
+		{
+			name: "empty NS",
+			item: &Item{NS: nil},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := ValidateItemAttributeValue(tt.item)
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+
+				return
+			}
+
+			require.Error(t, err)
+			require.Equal(t, tt.wantErr, err.Error())
+		})
+	}
+}
+
+func TestValidateItemAttributeValue_binarySet(t *testing.T) {
+	t.Parallel()
+
+	dup := []byte{1, 2, 3}
+
+	tests := []struct {
+		name    string
+		item    *Item
+		wantErr string
+	}{
+		{
+			name: "unique BS",
+			item: &Item{BS: [][]byte{{1}, {2}}},
+		},
+		{
+			name:    "duplicate BS same bytes",
+			item:    &Item{BS: [][]byte{dup, {9}, dup}},
+			wantErr: "One or more parameter values were invalid: Input collection [AQID, CQ==, AQID] contains duplicates.",
+		},
+		{
+			name: "empty BS",
+			item: &Item{BS: [][]byte{}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := ValidateItemAttributeValue(tt.item)
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+
+				return
+			}
+
+			require.Error(t, err)
+			require.Equal(t, tt.wantErr, err.Error())
+		})
+	}
+}
+
+func TestValidateItemMap(t *testing.T) {
+	t.Parallel()
+
+	require.NoError(t, ValidateItemMap(nil))
+	require.NoError(t, ValidateItemMap(map[string]*Item{}))
+	require.NoError(t, ValidateItemMap(map[string]*Item{
+		"k": {SS: []*string{aws.String("only")}},
+	}))
+
+	err := ValidateItemMap(map[string]*Item{
+		"colors": {SS: []*string{aws.String("red"), aws.String("red")}},
+	})
+	require.Error(t, err)
+	require.Equal(t,
+		"One or more parameter values were invalid: Input collection [red, red] contains duplicates.",
+		err.Error())
+}


### PR DESCRIPTION
…lients

Why:
DynamoDB returns ValidationException when SS, NS, or BS contain duplicate members. Minidyn should match that so tests and mocks behave like the real API.

What:
- Walk attribute trees (including nested L/M) and reject duplicate SS/NS/BS via types.ValidateItemMap / ValidateItemAttributeValue.
- Run validation at the start of Table.Put, Update, Delete, and SearchData (expression attribute values and exclusive start key).
- Change SearchData to return an error and handle it in aws-v2, server, and aws-v1 (Query, Scan, conditional DeleteItem).
- Validate GetItem keys before GetKey in aws-v2, server, and aws-v1.
- Add core tests for duplicate sets on Put, SearchData, and Update.

Issue: #50