### PR TITLE
Reject duplicate update clause keywords in the expression parser

### DIFF
--- a/aws-v2/client/client_test.go
+++ b/aws-v2/client/client_test.go
@@ -1990,6 +1990,66 @@ func TestBatchWriteItemWithFailingDatabase(t *testing.T) {
 	c.Nil(output)
 }
 
+func TestHandleBatchWriteRequestError(t *testing.T) {
+	t.Run("nil error", func(t *testing.T) {
+		unprocessed := map[string][]dynamodbtypes.WriteRequest{}
+		req := dynamodbtypes.WriteRequest{PutRequest: &dynamodbtypes.PutRequest{}}
+		err := handleBatchWriteRequestError("t", req, unprocessed, nil)
+		require.NoError(t, err)
+		require.Empty(t, unprocessed)
+	})
+
+	t.Run("non smithy API error", func(t *testing.T) {
+		unprocessed := map[string][]dynamodbtypes.WriteRequest{}
+		req := dynamodbtypes.WriteRequest{}
+		in := errors.New("plain failure")
+		err := handleBatchWriteRequestError("t", req, unprocessed, in)
+		require.ErrorIs(t, err, in)
+		require.Empty(t, unprocessed)
+	})
+
+	t.Run("smithy API error not retriable", func(t *testing.T) {
+		unprocessed := map[string][]dynamodbtypes.WriteRequest{}
+		req := dynamodbtypes.WriteRequest{}
+		in := &smithy.GenericAPIError{Code: "ValidationException", Message: "invalid"}
+		err := handleBatchWriteRequestError("t", req, unprocessed, in)
+		require.ErrorIs(t, err, in)
+		require.Empty(t, unprocessed)
+	})
+
+	t.Run("internal server error adds to unprocessed", func(t *testing.T) {
+		unprocessed := map[string][]dynamodbtypes.WriteRequest{}
+		req := dynamodbtypes.WriteRequest{PutRequest: &dynamodbtypes.PutRequest{}}
+		in := &dynamodbtypes.InternalServerError{Message: aws.String("emulated")}
+		err := handleBatchWriteRequestError("mytable", req, unprocessed, in)
+		require.NoError(t, err)
+		require.Len(t, unprocessed["mytable"], 1)
+		require.Equal(t, req, unprocessed["mytable"][0])
+	})
+
+	t.Run("internal server error appends when table key already exists", func(t *testing.T) {
+		first := dynamodbtypes.WriteRequest{DeleteRequest: &dynamodbtypes.DeleteRequest{}}
+		second := dynamodbtypes.WriteRequest{PutRequest: &dynamodbtypes.PutRequest{}}
+		unprocessed := map[string][]dynamodbtypes.WriteRequest{"tbl": {first}}
+		in := &dynamodbtypes.InternalServerError{Message: aws.String("retry")}
+		err := handleBatchWriteRequestError("tbl", second, unprocessed, in)
+		require.NoError(t, err)
+		require.Len(t, unprocessed["tbl"], 2)
+		require.Equal(t, first, unprocessed["tbl"][0])
+		require.Equal(t, second, unprocessed["tbl"][1])
+	})
+
+	t.Run("provisioned throughput exceeded adds to unprocessed", func(t *testing.T) {
+		unprocessed := map[string][]dynamodbtypes.WriteRequest{}
+		req := dynamodbtypes.WriteRequest{PutRequest: &dynamodbtypes.PutRequest{}}
+		in := &dynamodbtypes.ProvisionedThroughputExceededException{Message: aws.String("throttled")}
+		err := handleBatchWriteRequestError("tbl", req, unprocessed, in)
+		require.NoError(t, err)
+		require.Len(t, unprocessed["tbl"], 1)
+		require.Equal(t, req, unprocessed["tbl"][0])
+	})
+}
+
 func TestTransactWriteItems(t *testing.T) {
 	c := require.New(t)
 	client := NewClient()

--- a/core/table_test.go
+++ b/core/table_test.go
@@ -787,6 +787,86 @@ func TestUpdate(t *testing.T) {
 	newTable.Clear()
 }
 
+func TestUpdateMultiClauseExpression(t *testing.T) {
+	c := require.New(t)
+
+	newTable, err := createPokemonTable()
+	c.NoError(err)
+
+	item := createPokemon(pokemon{
+		ID:   "001",
+		Type: "grass",
+		Name: "Bulbasaur",
+	})
+	item["lvl"] = &types.Item{N: new("1")}
+
+	input := &types.PutItemInput{
+		Item:      item,
+		TableName: &newTable.Name,
+	}
+
+	_, err = newTable.Put(input)
+	c.NoError(err)
+
+	updateInput := &types.UpdateItemInput{
+		Key: item,
+		ExpressionAttributeNames: map[string]string{
+			"#n": "name",
+		},
+		ExpressionAttributeValues: map[string]*types.Item{
+			":new": {S: new("Ivysaur")},
+			":one": {N: new("1")},
+		},
+		UpdateExpression: "SET #n = :new ADD lvl :one",
+	}
+
+	result, err := newTable.Update(updateInput)
+	c.NoError(err)
+	c.Equal("Ivysaur", types.StringValue(result["name"].S))
+	c.Equal("2", types.StringValue(result["lvl"].N))
+
+	newTable.Clear()
+}
+
+func TestUpdateDuplicateClauseKeywordError(t *testing.T) {
+	c := require.New(t)
+
+	newTable, err := createPokemonTable()
+	c.NoError(err)
+
+	item := createPokemon(pokemon{
+		ID:   "001",
+		Type: "grass",
+		Name: "Bulbasaur",
+	})
+
+	input := &types.PutItemInput{
+		Item:      item,
+		TableName: &newTable.Name,
+	}
+
+	_, err = newTable.Put(input)
+	c.NoError(err)
+
+	updateInput := &types.UpdateItemInput{
+		Key: item,
+		ExpressionAttributeNames: map[string]string{
+			"#n": "name",
+		},
+		ExpressionAttributeValues: map[string]*types.Item{
+			":a": {S: new("x")},
+			":b": {S: new("y")},
+		},
+		UpdateExpression: "SET #n = :a SET name = :b",
+	}
+
+	_, err = newTable.Update(updateInput)
+	c.Error(err)
+	c.ErrorContains(err, "duplicate update clause keyword")
+
+	newTable.Clear()
+}
+
 func TestPutItem(t *testing.T) {
 	c := require.New(t)
 

--- a/interpreter/language/evaluator_test.go
+++ b/interpreter/language/evaluator_test.go
@@ -1011,6 +1011,44 @@ func TestUpdateEvalSyntaxError(t *testing.T) {
 	}
 }
 
+func testEvalBooleanInfixUndefinedOrNil(t *testing.T, name string, left, right Object) {
+	t.Helper()
+	t.Run(name, func(t *testing.T) {
+		got := evalBooleanInfixExpression("AND", left, right)
+		if got != FALSE {
+			t.Fatalf("AND: got %s, want FALSE", got.Inspect())
+		}
+		got = evalBooleanInfixExpression("OR", left, right)
+		if got != FALSE {
+			t.Fatalf("OR: got %s, want FALSE", got.Inspect())
+		}
+	})
+}
+
+func TestEvalBooleanInfixExpressionUndefinedOrNil(t *testing.T) {
+	testEvalBooleanInfixUndefinedOrNil(t, "undefined_left", UNDEFINED, TRUE)
+	testEvalBooleanInfixUndefinedOrNil(t, "undefined_right", TRUE, UNDEFINED)
+	testEvalBooleanInfixUndefinedOrNil(t, "both_undefined", UNDEFINED, UNDEFINED)
+	testEvalBooleanInfixUndefinedOrNil(t, "nil_left", nil, TRUE)
+	testEvalBooleanInfixUndefinedOrNil(t, "nil_right", TRUE, nil)
+}
+
+func TestEvalBooleanInfixExpressionLeftNotBoolean(t *testing.T) {
+	got := evalBooleanInfixExpression("AND", &Number{Value: 1}, TRUE)
+	want := newError("left operand is not boolean: N")
+	if !isError(got) || got.Inspect() != want.Inspect() {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
+func TestEvalBooleanInfixExpressionRightNotBoolean(t *testing.T) {
+	got := evalBooleanInfixExpression("OR", TRUE, &String{Value: "x"})
+	want := newError("right operand is not boolean: S")
+	if !isError(got) || got.Inspect() != want.Inspect() {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
 func BenchmarkEval(b *testing.B) {
 	input := ":a OR :b"
 

--- a/interpreter/language/parser.go
+++ b/interpreter/language/parser.go
@@ -14,6 +14,10 @@ type Parser struct {
 
 	unsupported bool
 
+	// updateClauseHeaders tracks SET/ADD/REMOVE/DELETE clause headers for the
+	// current ParseUpdateExpression (each keyword at most once, per DynamoDB).
+	updateClauseHeaders map[TokenType]bool
+
 	prefixParseFns map[TokenType]prefixParseFn
 	infixParseFns  map[TokenType]infixParseFn
 }
@@ -313,12 +317,19 @@ func (p *Parser) parseCallArguments() []Expression {
 
 // ParseUpdateExpression it tokenizes the update expression and returns an UpdateStatement
 func (p *Parser) ParseUpdateExpression() *UpdateStatement {
+	p.updateClauseHeaders = make(map[TokenType]bool)
+
 	stmt := &UpdateStatement{Token: p.curToken}
 
-	for p.curToken.Type != EOF {
-		stmt.Expression = p.parseExpression(precedenceValueLowset)
+	if p.curToken.Type == EOF {
+		return stmt
+	}
 
-		p.nextToken()
+	stmt.Expression = p.parseExpression(precedenceValueLowset)
+
+	if !p.peekTokenIs(EOF) {
+		msg := fmt.Sprintf("unexpected token after update expression: %s", p.peekToken.Type)
+		p.errors = append(p.errors, msg)
 	}
 
 	return stmt
@@ -363,6 +374,19 @@ func (p *Parser) parseAction(token Token) *ActionExpression {
 
 func (p *Parser) parseActions(token Token) []Expression {
 	actions := []Expression{}
+
+	if p.updateClauseHeaders == nil {
+		p.updateClauseHeaders = make(map[TokenType]bool)
+	}
+
+	if p.updateClauseHeaders[token.Type] {
+		msg := fmt.Sprintf("duplicate update clause keyword: %s", token.Literal)
+		p.errors = append(p.errors, msg)
+
+		return nil
+	}
+
+	p.updateClauseHeaders[token.Type] = true
 
 	if p.peekTokenIs(EOF) {
 		return actions

--- a/interpreter/language/parser_test.go
+++ b/interpreter/language/parser_test.go
@@ -468,6 +468,50 @@ func TestParsingRemoveExpression(t *testing.T) {
 	}
 }
 
+func TestParsingDuplicateUpdateClauseHeaders(t *testing.T) {
+	t.Parallel()
+
+	duplicateCases := []string{
+		"SET a = :x SET b = :y",
+		"ADD n :one ADD m :two",
+		"REMOVE a REMOVE b",
+		"DELETE s :x DELETE s :y",
+		"SET a = :x REMOVE b SET c = :z",
+	}
+
+	for _, input := range duplicateCases {
+		t.Run(input, func(t *testing.T) {
+			t.Parallel()
+
+			l := NewLexer(input)
+			p := NewUpdateParser(l)
+			p.ParseUpdateExpression()
+
+			if len(p.Errors()) == 0 {
+				t.Fatalf("expected parse errors for duplicate clause headers, got none (input=%q)", input)
+			}
+		})
+	}
+}
+
+func TestParsingCommaSeparatedSameClauseStillValid(t *testing.T) {
+	t.Parallel()
+
+	l := NewLexer("SET a = :x, b = :y")
+	p := NewUpdateParser(l)
+	update := p.ParseUpdateExpression()
+	checkParserErrors(t, p)
+
+	opExp, ok := update.Expression.(*UpdateExpression)
+	if !ok {
+		t.Fatalf("exp is not UpdateExpression. got=%T(%s)", update.Expression, update.Expression)
+	}
+
+	if len(opExp.Expressions) != 2 {
+		t.Fatalf("unexpected actions size. got=%d want=2", len(opExp.Expressions))
+	}
+}
+
 func TestParsingTwoUpdateActions(t *testing.T) {
 	setTests := []struct {
 		input       string

--- a/scripts/check_coverage.sh
+++ b/scripts/check_coverage.sh
@@ -2,7 +2,7 @@
 
 # We are evaluating all files for now (later we could change it so it only uses changed files)
 # pkgs_to_test=`git diff --name-status $diff |  grep -E '^(A|M|R)'  | awk '{ print $NF }' | grep '\.go$' | xargs -n1 dirname | sort -u`
-pkgs_to_test=`find . -type f | grep -E ".go$" | xargs -n1 dirname | sort -u`
+pkgs_to_test=`find . -type f -name '*.go' | grep -v '^\./tools/' | xargs -n1 dirname | sort -u`
 
 
 function parse_test {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1285,6 +1285,174 @@ func TestServerScanFiltersAndErrors(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestClientGetItemMissingTableEmulatedErrorAndInvalidKeyMap(t *testing.T) {
+	ctx := context.Background()
+	s := NewServer()
+	cli := s.client
+
+	_, err := cli.CreateTable(ctx, &CreateTableInput{
+		TableName: aws.String("items"),
+		KeySchema: []ddbtypes.KeySchemaElement{
+			{AttributeName: aws.String("id"), KeyType: ddbtypes.KeyTypeHash},
+		},
+		AttributeDefinitions: []ddbtypes.AttributeDefinition{
+			{AttributeName: aws.String("id"), AttributeType: ddbtypes.ScalarAttributeTypeS},
+		},
+		BillingMode: ddbtypes.BillingModePayPerRequest,
+	})
+	require.NoError(t, err)
+
+	_, err = cli.GetItem(ctx, &GetItemInput{
+		TableName: aws.String("no-such-table"),
+		Key:       map[string]*AttributeValue{"id": {S: aws.String("1")}},
+	})
+	var notFound *ddbtypes.ResourceNotFoundException
+	require.ErrorAs(t, err, &notFound)
+
+	s.EmulateFailure(FailureConditionInternalServerError)
+	_, err = cli.GetItem(ctx, &GetItemInput{
+		TableName: aws.String("items"),
+		Key:       map[string]*AttributeValue{"id": {S: aws.String("1")}},
+	})
+	var internal *ddbtypes.InternalServerError
+	require.ErrorAs(t, err, &internal)
+	s.EmulateFailure(FailureConditionNone)
+
+	dupA, dupB := "x", "x"
+	_, err = cli.GetItem(ctx, &GetItemInput{
+		TableName: aws.String("items"),
+		Key: map[string]*AttributeValue{
+			"id": {SS: []*string{&dupA, &dupB}},
+		},
+	})
+	var apiErr smithy.APIError
+	require.ErrorAs(t, err, &apiErr)
+	require.Equal(t, "ValidationException", apiErr.ErrorCode())
+	require.Contains(t, apiErr.ErrorMessage(), "duplicates")
+}
+
+func TestClientQueryScanMissingTableEmulatedErrorAndInvalidExprValues(t *testing.T) {
+	ctx := context.Background()
+	s := NewServer()
+	cli := s.client
+
+	_, err := cli.CreateTable(ctx, &CreateTableInput{
+		TableName: aws.String("items"),
+		KeySchema: []ddbtypes.KeySchemaElement{
+			{AttributeName: aws.String("id"), KeyType: ddbtypes.KeyTypeHash},
+		},
+		AttributeDefinitions: []ddbtypes.AttributeDefinition{
+			{AttributeName: aws.String("id"), AttributeType: ddbtypes.ScalarAttributeTypeS},
+		},
+		BillingMode: ddbtypes.BillingModePayPerRequest,
+	})
+	require.NoError(t, err)
+
+	_, err = cli.Query(ctx, &QueryInput{
+		TableName: aws.String("missing"),
+	})
+	var notFoundQ *ddbtypes.ResourceNotFoundException
+	require.ErrorAs(t, err, &notFoundQ)
+
+	_, err = cli.Scan(ctx, &ScanInput{
+		TableName: aws.String("missing"),
+	})
+	var notFoundS *ddbtypes.ResourceNotFoundException
+	require.ErrorAs(t, err, &notFoundS)
+
+	s.EmulateFailure(FailureConditionInternalServerError)
+	_, err = cli.Query(ctx, &QueryInput{TableName: aws.String("items")})
+	var internalQ *ddbtypes.InternalServerError
+	require.ErrorAs(t, err, &internalQ)
+
+	_, err = cli.Scan(ctx, &ScanInput{TableName: aws.String("items")})
+	var internalS *ddbtypes.InternalServerError
+	require.ErrorAs(t, err, &internalS)
+	s.EmulateFailure(FailureConditionNone)
+
+	dupA, dupB := "p", "p"
+	_, err = cli.Query(ctx, &QueryInput{
+		TableName: aws.String("items"),
+		ExpressionAttributeValues: map[string]*AttributeValue{
+			":v": {SS: []*string{&dupA, &dupB}},
+		},
+	})
+	var valErrQ smithy.APIError
+	require.ErrorAs(t, err, &valErrQ)
+	require.Equal(t, "ValidationException", valErrQ.ErrorCode())
+
+	_, err = cli.Scan(ctx, &ScanInput{
+		TableName: aws.String("items"),
+		ExpressionAttributeValues: map[string]*AttributeValue{
+			":v": {SS: []*string{&dupA, &dupB}},
+		},
+	})
+	var valErrS smithy.APIError
+	require.ErrorAs(t, err, &valErrS)
+	require.Equal(t, "ValidationException", valErrS.ErrorCode())
+}
+
+func TestClientQueryScanIndexForwardFalseAndScanWithLimitAndStartKey(t *testing.T) {
+	ctx := context.Background()
+	cli := NewClient()
+
+	_, err := cli.CreateTable(ctx, &CreateTableInput{
+		TableName: aws.String("pk"),
+		KeySchema: []ddbtypes.KeySchemaElement{
+			{AttributeName: aws.String("h"), KeyType: ddbtypes.KeyTypeHash},
+			{AttributeName: aws.String("r"), KeyType: ddbtypes.KeyTypeRange},
+		},
+		AttributeDefinitions: []ddbtypes.AttributeDefinition{
+			{AttributeName: aws.String("h"), AttributeType: ddbtypes.ScalarAttributeTypeS},
+			{AttributeName: aws.String("r"), AttributeType: ddbtypes.ScalarAttributeTypeS},
+		},
+		BillingMode: ddbtypes.BillingModePayPerRequest,
+	})
+	require.NoError(t, err)
+
+	for _, r := range []string{"a", "b", "c"} {
+		_, putErr := cli.PutItem(ctx, &PutItemInput{
+			TableName: aws.String("pk"),
+			Item: map[string]*AttributeValue{
+				"h": {S: aws.String("1")},
+				"r": {S: aws.String(r)},
+			},
+		})
+		require.NoError(t, putErr)
+	}
+
+	qOut, err := cli.Query(ctx, &QueryInput{
+		TableName:              aws.String("pk"),
+		KeyConditionExpression: aws.String("h = :h"),
+		ExpressionAttributeValues: map[string]*AttributeValue{
+			":h": {S: aws.String("1")},
+		},
+		ScanIndexForward: aws.Bool(false),
+		Limit:            aws.Int32(1),
+	})
+	require.NoError(t, err)
+	require.Len(t, qOut.Items, 1)
+	require.Equal(t, "c", aws.ToString(qOut.Items[0]["r"].S))
+	require.NotEmpty(t, qOut.LastEvaluatedKey)
+
+	scanOut, err := cli.Scan(ctx, &ScanInput{
+		TableName: aws.String("pk"),
+		Limit:     aws.Int32(2),
+	})
+	require.NoError(t, err)
+	require.Len(t, scanOut.Items, 2)
+	require.Equal(t, int32(2), scanOut.Count)
+	require.NotEmpty(t, scanOut.LastEvaluatedKey)
+
+	scan2, err := cli.Scan(ctx, &ScanInput{
+		TableName:         aws.String("pk"),
+		Limit:             aws.Int32(10),
+		ExclusiveStartKey: scanOut.LastEvaluatedKey,
+	})
+	require.NoError(t, err)
+	require.Len(t, scan2.Items, 1)
+}
+
 // helpers
 
 func makeBasicTable(t *testing.T, cli *dynamodb.Client, table, hashKey string) {

--- a/types/types.go
+++ b/types/types.go
@@ -309,13 +309,6 @@ type TableDescription struct {
 	TableStatus            string                            `type:"string" enum:"TableStatus"`
 }
 
-// ToString returns the pointer of a string
-//
-//go:fix inline
-func ToString(str string) *string {
-	return new(str)
-}
-
 // StringValue returns the string value of a string pointer
 func StringValue(str *string) string {
 	if str == nil {

--- a/types/types_test.go
+++ b/types/types_test.go
@@ -3,7 +3,6 @@ package types
 import (
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/private/protocol"
 	"github.com/stretchr/testify/require"
 )
@@ -18,7 +17,7 @@ func TestConditionalCheckFailedExceptionMethods(t *testing.T) {
 			RequestID:  "req-abc",
 		},
 		Item: map[string]*Item{
-			"id": {S: aws.String("1")},
+			"id": {S: new("1")},
 		},
 	}
 
@@ -40,7 +39,7 @@ func TestConditionalCheckFailedExceptionMethods(t *testing.T) {
 func TestToStringAndStringValue(t *testing.T) {
 	t.Parallel()
 
-	p := ToString("x")
+	p := new("x")
 	require.NotNil(t, p)
 	require.Equal(t, "x", *p)
 	require.Equal(t, "x", StringValue(p))


### PR DESCRIPTION
Why:
DynamoDB allows each clause keyword at most once per update expression. Minidyn previously accepted duplicate headers, which diverged from DynamoDB validation.

What:
- Track seen SET/ADD/REMOVE/DELETE headers in parseActions and error on duplicates.
- Parse update expressions once and reject trailing tokens after a full parse.
- Add parser tests for duplicate headers and comma-separated same-clause forms.
- Add core table tests for multi-clause updates and duplicate-clause errors.

Issue: #56