### PR TITLE
Apply ProjectionExpression in core search and DynamoDB clients

### DIFF
--- a/aws-v1/client/client.go
+++ b/aws-v1/client/client.go
@@ -405,10 +405,15 @@ func (fd *Client) GetItem(input *dynamodb.GetItemInput) (*dynamodb.GetItemOutput
 		return nil, awserr.New("ValidationException", err.Error(), nil)
 	}
 
-	item := copyItem(mapAttributeValueToDynamodb(table.Data[key]))
+	stored := table.Data[key]
+
+	item, err := getItemAttributesForOutputV1(table, stored, aws.StringValue(input.ProjectionExpression), aws.StringValueMap(input.ExpressionAttributeNames))
+	if err != nil {
+		return nil, awserr.New("ValidationException", err.Error(), nil)
+	}
 
 	output := &dynamodb.GetItemOutput{
-		Item: item,
+		Item: copyItem(item),
 	}
 
 	return output, nil
@@ -452,6 +457,7 @@ func (fd *Client) Query(input *dynamodb.QueryInput) (*dynamodb.QueryOutput, erro
 		ExclusiveStartKey:         mapAttributeValueToTypes(input.ExclusiveStartKey),
 		KeyConditionExpression:    *input.KeyConditionExpression,
 		FilterExpression:          aws.StringValue(input.FilterExpression),
+		ProjectionExpression:      aws.StringValue(input.ProjectionExpression),
 		ScanIndexForward:          aws.BoolValue(input.ScanIndexForward),
 	})
 	if err != nil {
@@ -502,6 +508,7 @@ func (fd *Client) Scan(input *dynamodb.ScanInput) (*dynamodb.ScanOutput, error) 
 		Limit:                     aws.Int64Value(input.Limit),
 		ExclusiveStartKey:         mapAttributeValueToTypes(input.ExclusiveStartKey),
 		FilterExpression:          aws.StringValue(input.FilterExpression),
+		ProjectionExpression:      aws.StringValue(input.ProjectionExpression),
 		Scan:                      true,
 		ScanIndexForward:          true,
 	})
@@ -667,6 +674,23 @@ func (fd *Client) TransactWriteItems(input *dynamodb.TransactWriteItemsInput) (*
 // TransactWriteItemsWithContext mock response for dynamodb
 func (fd *Client) TransactWriteItemsWithContext(ctx aws.Context, input *dynamodb.TransactWriteItemsInput, opts ...request.Option) (*dynamodb.TransactWriteItemsOutput, error) {
 	return fd.TransactWriteItems(input)
+}
+
+func getItemAttributesForOutputV1(table *core.Table, stored map[string]*types.Item, projectionExpr string, aliases map[string]string) (map[string]*dynamodb.AttributeValue, error) {
+	if projectionExpr == "" {
+		return mapAttributeValueToDynamodb(stored), nil
+	}
+
+	projected, err := table.LangInterpreter.Project(interpreter.ProjectInput{
+		Expression: projectionExpr,
+		Item:       stored,
+		Aliases:    aliases,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return mapAttributeValueToDynamodb(projected), nil
 }
 
 func (fd *Client) getTable(tableName string) (*core.Table, error) {

--- a/aws-v1/client/client_test.go
+++ b/aws-v1/client/client_test.go
@@ -670,6 +670,55 @@ func TestGetItemWithInvalidExpressionAttributeNames(t *testing.T) {
 	c.Contains(err.Error(), invalidExpressionAttributeName)
 }
 
+func TestGetItemWithProjectionExpression(t *testing.T) {
+	c := require.New(t)
+
+	client := setupClient(tableName)
+
+	err := ensurePokemonTable(client)
+	c.NoError(err)
+
+	err = createPokemon(client, pokemon{ID: "001", Type: "grass", Name: "Bulbasaur"})
+	c.NoError(err)
+
+	out, err := client.GetItemWithContext(context.Background(), &dynamodb.GetItemInput{
+		TableName: new(tableName),
+		Key: map[string]*dynamodb.AttributeValue{
+			"id": {S: new("001")},
+		},
+		ProjectionExpression: new("#n"),
+		ExpressionAttributeNames: map[string]*string{
+			"#n": new("name"),
+		},
+	})
+	c.NoError(err)
+	c.Len(out.Item, 1)
+
+	c.Equal("Bulbasaur", *out.Item["name"].S)
+}
+
+func TestGetItemWithProjectionInvalidExpression(t *testing.T) {
+	c := require.New(t)
+
+	client := setupClient(tableName)
+
+	err := ensurePokemonTable(client)
+	c.NoError(err)
+
+	err = createPokemon(client, pokemon{ID: "001", Type: "grass", Name: "Bulbasaur"})
+	c.NoError(err)
+
+	_, err = client.GetItemWithContext(context.Background(), &dynamodb.GetItemInput{
+		TableName: new(tableName),
+		Key: map[string]*dynamodb.AttributeValue{
+			"id": {S: new("001")},
+		},
+		ProjectionExpression: new("("),
+	})
+	c.Error(err)
+	c.Contains(err.Error(), "ValidationException")
+}
+
 func TestPutItemWithConditions(t *testing.T) {
 	c := require.New(t)
 

--- a/aws-v2/client/client.go
+++ b/aws-v2/client/client.go
@@ -15,7 +15,7 @@ import (
 	"github.com/aws/smithy-go"
 	"github.com/truora/minidyn/core"
 	"github.com/truora/minidyn/interpreter"
-	mintypes "github.com/truora/minidyn/types"
+	mtypes "github.com/truora/minidyn/types"
 )
 
 const (
@@ -346,8 +346,8 @@ func (fd *Client) GetItem(ctx context.Context, input *dynamodb.GetItemInput, opt
 	}
 
 	keyMap := mapDynamoToTypesMapItem(input.Key)
-	if vErr := mintypes.ValidateItemMap(keyMap); vErr != nil {
-		return nil, mapKnownError(mintypes.NewError("ValidationException", vErr.Error(), nil))
+	if vErr := mtypes.ValidateItemMap(keyMap); vErr != nil {
+		return nil, mapKnownError(mtypes.NewError("ValidationException", vErr.Error(), nil))
 	}
 
 	key, err := table.KeySchema.GetKey(table.AttributesDef, keyMap)
@@ -355,10 +355,15 @@ func (fd *Client) GetItem(ctx context.Context, input *dynamodb.GetItemInput, opt
 		return nil, &smithy.GenericAPIError{Code: "ValidationException", Message: err.Error()}
 	}
 
-	item := copyItem(mapTypesToDynamoMapItem(table.Data[key]))
+	stored := table.Data[key]
+
+	item, err := getItemAttributesForOutput(table, stored, aws.ToString(input.ProjectionExpression), input.ExpressionAttributeNames)
+	if err != nil {
+		return nil, &smithy.GenericAPIError{Code: "ValidationException", Message: err.Error()}
+	}
 
 	output := &dynamodb.GetItemOutput{
-		Item: item,
+		Item: copyItem(item),
 	}
 
 	return output, nil
@@ -436,6 +441,7 @@ func (fd *Client) Scan(ctx context.Context, input *dynamodb.ScanInput, opt ...fu
 		Limit:                     int64(aws.ToInt32(input.Limit)),
 		ExclusiveStartKey:         mapDynamoToTypesMapItem(input.ExclusiveStartKey),
 		FilterExpression:          aws.ToString(input.FilterExpression),
+		ProjectionExpression:      aws.ToString(input.ProjectionExpression),
 		ScanIndexForward:          true,
 		Scan:                      true,
 	})
@@ -662,6 +668,23 @@ func (fd *Client) getTable(tableName string) (*core.Table, error) {
 	}
 
 	return table, nil
+}
+
+func getItemAttributesForOutput(table *core.Table, stored map[string]*mtypes.Item, projectionExpr string, aliases map[string]string) (map[string]types.AttributeValue, error) {
+	if projectionExpr == "" {
+		return mapTypesToDynamoMapItem(stored), nil
+	}
+
+	projected, err := table.LangInterpreter.Project(interpreter.ProjectInput{
+		Expression: projectionExpr,
+		Item:       stored,
+		Aliases:    aliases,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return mapTypesToDynamoMapItem(projected), nil
 }
 
 func validateExpressionAttributes(exprNames map[string]string, exprValues map[string]types.AttributeValue, genericExpressions ...string) error {

--- a/aws-v2/client/client_test.go
+++ b/aws-v2/client/client_test.go
@@ -770,6 +770,65 @@ func TestGetItemWithInvalidExpressionAttributeNames(t *testing.T) {
 	c.Contains(err.Error(), invalidExpressionAttributeName)
 }
 
+func TestGetItemWithProjectionExpression(t *testing.T) {
+	c := require.New(t)
+
+	client := setupClient(tableName)
+
+	err := ensurePokemonTable(client)
+	c.NoError(err)
+
+	err = createPokemon(client, pokemon{
+		ID:   "001",
+		Type: "grass",
+		Name: "Bulbasaur",
+	})
+	c.NoError(err)
+
+	out, err := client.GetItem(context.Background(), &dynamodb.GetItemInput{
+		TableName: aws.String(tableName),
+		Key: map[string]dynamodbtypes.AttributeValue{
+			"id": &dynamodbtypes.AttributeValueMemberS{Value: "001"},
+		},
+		ProjectionExpression: aws.String("#n"),
+		ExpressionAttributeNames: map[string]string{
+			"#n": "name",
+		},
+	})
+	c.NoError(err)
+	c.Len(out.Item, 1)
+
+	name, ok := out.Item["name"].(*dynamodbtypes.AttributeValueMemberS)
+	c.True(ok)
+	c.Equal("Bulbasaur", name.Value)
+}
+
+func TestGetItemWithProjectionInvalidExpression(t *testing.T) {
+	c := require.New(t)
+
+	client := setupClient(tableName)
+
+	err := ensurePokemonTable(client)
+	c.NoError(err)
+
+	err = createPokemon(client, pokemon{
+		ID:   "001",
+		Type: "grass",
+		Name: "Bulbasaur",
+	})
+	c.NoError(err)
+
+	_, err = client.GetItem(context.Background(), &dynamodb.GetItemInput{
+		TableName: aws.String(tableName),
+		Key: map[string]dynamodbtypes.AttributeValue{
+			"id": &dynamodbtypes.AttributeValueMemberS{Value: "001"},
+		},
+		ProjectionExpression: aws.String("("),
+	})
+	c.Error(err)
+	c.Contains(err.Error(), "ValidationException")
+}
+
 func TestPutItemWithConditions(t *testing.T) {
 	c := require.New(t)
 

--- a/aws-v2/client/mapper.go
+++ b/aws-v2/client/mapper.go
@@ -398,6 +398,10 @@ func mapDynamoToTypesQueryInput(input *dynamodb.QueryInput, indexName string) co
 		output.ScanIndexForward = aws.ToBool(input.ScanIndexForward)
 	}
 
+	if input.ProjectionExpression != nil {
+		output.ProjectionExpression = aws.ToString(input.ProjectionExpression)
+	}
+
 	return output
 }
 

--- a/core/table.go
+++ b/core/table.go
@@ -18,6 +18,7 @@ type QueryInput struct {
 	KeyConditionExpression    string
 	ConditionExpression       *string
 	FilterExpression          string
+	ProjectionExpression      string
 	Aliases                   map[string]string
 	ScanIndexForward          bool
 	Scan                      bool
@@ -333,17 +334,31 @@ func prepareSearch(input *QueryInput, index *index, k, startKey string) (string,
 	return "", false
 }
 
-func (t *Table) getMatchedItemAndCount(input *QueryInput, pk, startKey string) (map[string]*types.Item, interpreter.ExpressionType, bool) {
+func (t *Table) getMatchedItemAndCount(input *QueryInput, pk, startKey string) (map[string]*types.Item, map[string]*types.Item, interpreter.ExpressionType, bool) {
 	storedItem, ok := t.Data[pk]
 
 	lastMatchExpressionType, matched := t.matchKey(*input, storedItem)
 
+	fullCopy := copyItem(storedItem)
+
 	if !ok || !input.started || !matched {
-		return copyItem(storedItem), lastMatchExpressionType, false
+		return fullCopy, fullCopy, lastMatchExpressionType, false
 	}
 
-	// TODO: use project info to create the copy
-	return copyItem(storedItem), lastMatchExpressionType, true
+	if input.ProjectionExpression != "" {
+		projected, err := t.LangInterpreter.Project(interpreter.ProjectInput{
+			Expression: input.ProjectionExpression,
+			Item:       storedItem,
+			Aliases:    input.Aliases,
+		})
+		if err != nil {
+			panic(err)
+		}
+
+		return projected, fullCopy, lastMatchExpressionType, true
+	}
+
+	return fullCopy, fullCopy, lastMatchExpressionType, true
 }
 
 func shouldReturnNextKey(item map[string]*types.Item, count, scanned, limit, keysSize int64) bool {
@@ -403,7 +418,7 @@ func (t *Table) SearchData(input QueryInput) ([]map[string]*types.Item, map[stri
 			continue
 		}
 
-		item, expressionType, matched := t.getMatchedItemAndCount(&input, pk, startKey)
+		item, keyItem, expressionType, matched := t.getMatchedItemAndCount(&input, pk, startKey)
 
 		if matched {
 			items = append(items, item)
@@ -415,7 +430,7 @@ func (t *Table) SearchData(input QueryInput) ([]map[string]*types.Item, map[stri
 			count++
 		}
 
-		last = item
+		last = keyItem
 
 		if shouldBreakPage(count, limit) {
 			break

--- a/core/table_test.go
+++ b/core/table_test.go
@@ -1104,3 +1104,34 @@ func TestFetchQueryData(t *testing.T) {
 	c.NotEmpty(sortedKeys)
 	c.Equal(index.sortedRefs[0][0], "006.Bellsprout")
 }
+
+func TestSearchDataWithProjectionExpression(t *testing.T) {
+	c := require.New(t)
+
+	table := NewTable("proj")
+	table.AttributesDef = map[string]string{"id": "S", "foo": "S"}
+	table.KeySchema = keySchema{"id", "", false}
+	table.LangInterpreter = interpreter.Language{}
+
+	_, err := table.Put(&types.PutItemInput{
+		TableName: aws.String("proj"),
+		Item: map[string]*types.Item{
+			"id":  {S: aws.String("1")},
+			"foo": {S: aws.String("bar")},
+		},
+	})
+	c.NoError(err)
+
+	items, lastKey, err := table.SearchData(QueryInput{
+		Scan:                 true,
+		ProjectionExpression: "#f",
+		Aliases:              map[string]string{"#f": "foo"},
+		Limit:                1,
+	})
+
+	c.NoError(err)
+	c.Len(items, 1)
+	c.Len(items[0], 1)
+	c.Equal("bar", *items[0]["foo"].S)
+	c.Contains(lastKey, "id")
+}

--- a/interpreter/language.go
+++ b/interpreter/language.go
@@ -9,6 +9,13 @@ import (
 	"github.com/truora/minidyn/types"
 )
 
+// ProjectInput parameters for Project.
+type ProjectInput struct {
+	Expression string
+	Item       map[string]*types.Item
+	Aliases    map[string]string
+}
+
 // Language interpreter
 type Language struct {
 	Debug bool
@@ -56,6 +63,53 @@ func (li *Language) Match(input MatchInput) (bool, error) {
 	}
 
 	return result == language.TRUE, nil
+}
+
+// Project evaluates a projection expression and returns a new attribute map containing only the requested paths.
+func (li *Language) Project(input ProjectInput) (map[string]*types.Item, error) {
+	l := language.NewLexer(input.Expression)
+	p := language.NewParser(l)
+	exprs := p.ParseProjectionExpression()
+
+	if len(p.Errors()) != 0 {
+		return nil, fmt.Errorf("%w: %s", ErrSyntaxError, strings.Join(p.Errors(), "\n"))
+	}
+
+	env := language.NewEnvironment()
+	aliases := map[string]string{}
+	maps.Copy(aliases, input.Aliases)
+	env.Aliases = aliases
+
+	item := map[string]*types.Item{}
+	maps.Copy(item, input.Item)
+
+	err := env.AddAttributes(item)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %s", ErrUnsupportedFeature, err.Error())
+	}
+
+	out := map[string]*types.Item{}
+
+	for _, expr := range exprs {
+		result := language.Eval(expr, env)
+		if language.IsUndefinedObject(result) {
+			continue
+		}
+
+		if result.Type() == language.ObjectTypeError {
+			return nil, fmt.Errorf("%w: %s", ErrSyntaxError, result.Inspect())
+		}
+
+		path, err := language.ExtractPath(expr, env)
+		if err != nil {
+			return nil, fmt.Errorf("%w: %s", ErrSyntaxError, err.Error())
+		}
+
+		val := result.ToDynamoDB()
+		language.SetProjectedPath(out, path, val)
+	}
+
+	return out, nil
 }
 
 func buildAliases(input UpdateInput) map[string]string {

--- a/interpreter/language/evaluator.go
+++ b/interpreter/language/evaluator.go
@@ -98,6 +98,11 @@ func isUndefined(obj Object) bool {
 	return nullObj.IsUndefined
 }
 
+// IsUndefinedObject reports whether obj is the undefined projection / null sentinel.
+func IsUndefinedObject(obj Object) bool {
+	return isUndefined(obj)
+}
+
 func isComparable(obj Object) bool {
 	return comparableTypes[obj.Type()] || isUndefined(obj)
 }

--- a/interpreter/language/parser.go
+++ b/interpreter/language/parser.go
@@ -144,6 +144,30 @@ func (p *Parser) nextToken() {
 	p.peekToken = p.l.NextToken()
 }
 
+// ParseProjectionExpression parses a comma-separated list of path expressions (ProjectionExpression).
+// Whitespace may appear between paths. An empty input yields an empty slice and no errors.
+func (p *Parser) ParseProjectionExpression() []Expression {
+	var expressions []Expression
+
+	if p.curToken.Type == EOF {
+		return expressions
+	}
+
+	expressions = append(expressions, p.parseExpression(precedenceValueLowset))
+
+	for p.peekTokenIs(COMMA) {
+		p.nextToken()
+		p.nextToken()
+		expressions = append(expressions, p.parseExpression(precedenceValueLowset))
+	}
+
+	if !p.peekTokenIs(EOF) {
+		p.peekError(EOF)
+	}
+
+	return expressions
+}
+
 // ParseConditionalExpression tokenizes a ConditionalExpression
 func (p *Parser) ParseConditionalExpression() *ConditionalExpression {
 	stmt := &ConditionalExpression{Token: p.curToken}

--- a/interpreter/language/project.go
+++ b/interpreter/language/project.go
@@ -1,0 +1,210 @@
+package language
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/truora/minidyn/types"
+)
+
+// PathKind discriminates segments in a DynamoDB document path.
+type PathKind int
+
+const (
+	// PathKindMapKey is a map attribute name (top-level or nested).
+	PathKindMapKey PathKind = iota
+	// PathKindListIndex is a list index (0-based).
+	PathKindListIndex
+)
+
+// PathElement is one step in a projection path (map key or list index).
+type PathElement struct {
+	Kind  PathKind
+	Key   string
+	Index int64
+}
+
+func resolvePathName(name string, env *Environment) string {
+	if env == nil {
+		return name
+	}
+
+	if alias, ok := env.Aliases[name]; ok {
+		return alias
+	}
+
+	return name
+}
+
+// ExtractPath walks a path expression AST and returns document path segments (root-first),
+// resolving expression attribute name placeholders using env.Aliases.
+func ExtractPath(n Expression, env *Environment) ([]PathElement, error) {
+	switch node := n.(type) {
+	case *Identifier:
+		key := resolvePathName(node.Value, env)
+
+		return []PathElement{{Kind: PathKindMapKey, Key: key}}, nil
+	case *IndexExpression:
+		return extractPathFromIndex(node, env)
+	default:
+		return nil, fmt.Errorf("projection path: unsupported expression %T", n)
+	}
+}
+
+func extractPathFromIndex(node *IndexExpression, env *Environment) ([]PathElement, error) {
+	prefix, err := ExtractPath(node.Left, env)
+	if err != nil {
+		return nil, err
+	}
+
+	switch node.Type {
+	case ObjectTypeMap:
+		return appendMapKeySegment(prefix, node.Index, env)
+	case ObjectTypeList:
+		return appendListIndexSegment(prefix, node.Index, env)
+	default:
+		return nil, fmt.Errorf("projection path: unsupported index type")
+	}
+}
+
+func appendMapKeySegment(prefix []PathElement, indexExpr Expression, env *Environment) ([]PathElement, error) {
+	keyIdent, ok := indexExpr.(*Identifier)
+	if !ok {
+		return nil, fmt.Errorf("projection path: map segment must be an identifier")
+	}
+
+	key := resolvePathName(keyIdent.Value, env)
+
+	return append(prefix, PathElement{Kind: PathKindMapKey, Key: key}), nil
+}
+
+func appendListIndexSegment(prefix []PathElement, indexExpr Expression, env *Environment) ([]PathElement, error) {
+	idx, err := extractPathListIndex(indexExpr, env)
+	if err != nil {
+		return nil, err
+	}
+
+	return append(prefix, PathElement{Kind: PathKindListIndex, Index: idx}), nil
+}
+
+func extractPathListIndex(idxExpr Expression, env *Environment) (int64, error) {
+	ident, ok := idxExpr.(*Identifier)
+	if !ok {
+		return 0, fmt.Errorf("projection path: list index must be an identifier")
+	}
+
+	if n, err := strconv.Atoi(ident.Token.Literal); err == nil {
+		return int64(n), nil
+	}
+
+	obj := Eval(ident, env)
+	if isError(obj) {
+		errObj, _ := obj.(*Error)
+
+		return 0, fmt.Errorf("%s", errObj.Message)
+	}
+
+	number, ok := obj.(*Number)
+	if !ok {
+		return 0, fmt.Errorf("projection path: list index must be a number")
+	}
+
+	return int64(number.Value), nil
+}
+
+// SetProjectedPath writes val into target following path, creating nested M and L containers as needed.
+// The first segment must be a map key (DynamoDB top-level attributes are maps).
+func SetProjectedPath(target map[string]*types.Item, path []PathElement, val types.Item) {
+	if len(path) == 0 {
+		return
+	}
+
+	if path[0].Kind != PathKindMapKey {
+		return
+	}
+
+	if len(path) == 1 {
+		copyVal := val
+		target[path[0].Key] = &copyVal
+
+		return
+	}
+
+	key := path[0].Key
+
+	node := target[key]
+	if node == nil {
+		node = &types.Item{}
+		target[key] = node
+	}
+
+	setProjectedPathNested(node, path[1:], val)
+}
+
+func setProjectedPathNested(cur *types.Item, path []PathElement, val types.Item) {
+	if len(path) == 0 {
+		return
+	}
+
+	switch path[0].Kind {
+	case PathKindMapKey:
+		setNestedMapSegment(cur, path, val)
+	case PathKindListIndex:
+		setNestedListSegment(cur, path, val)
+	}
+}
+
+func setNestedMapSegment(cur *types.Item, path []PathElement, val types.Item) {
+	if len(path) == 1 {
+		ensureItemMap(cur)
+		copyVal := val
+		cur.M[path[0].Key] = &copyVal
+
+		return
+	}
+
+	ensureItemMap(cur)
+
+	child := cur.M[path[0].Key]
+	if child == nil {
+		child = &types.Item{}
+		cur.M[path[0].Key] = child
+	}
+
+	setProjectedPathNested(child, path[1:], val)
+}
+
+func setNestedListSegment(cur *types.Item, path []PathElement, val types.Item) {
+	ensureItemList(cur)
+
+	idx := int(path[0].Index)
+
+	for len(cur.L) <= idx {
+		cur.L = append(cur.L, nil)
+	}
+
+	if cur.L[idx] == nil {
+		cur.L[idx] = &types.Item{}
+	}
+
+	if len(path) == 1 {
+		copyVal := val
+		cur.L[idx] = &copyVal
+
+		return
+	}
+
+	setProjectedPathNested(cur.L[idx], path[1:], val)
+}
+
+func ensureItemMap(cur *types.Item) {
+	if cur.M == nil {
+		cur.M = map[string]*types.Item{}
+	}
+}
+
+func ensureItemList(cur *types.Item) {
+	if cur.L == nil {
+		cur.L = []*types.Item{}
+	}
+}

--- a/interpreter/language/project_test.go
+++ b/interpreter/language/project_test.go
@@ -1,0 +1,96 @@
+package language
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/truora/minidyn/types"
+)
+
+func TestExtractPath_identifierAndAlias(t *testing.T) {
+	t.Parallel()
+
+	env := NewEnvironment()
+	env.Aliases = map[string]string{"#n": "real"}
+
+	l := NewLexer("#n")
+	p := NewParser(l)
+	exprs := p.ParseProjectionExpression()
+	checkParserErrors(t, p)
+
+	path, err := ExtractPath(exprs[0], env)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []PathElement{{Kind: PathKindMapKey, Key: "real"}}
+	if diff := cmp.Diff(want, path); diff != "" {
+		t.Fatal(diff)
+	}
+}
+
+func TestExtractPath_nested(t *testing.T) {
+	t.Parallel()
+
+	env := NewEnvironment()
+
+	l := NewLexer("A.B[1]")
+	p := NewParser(l)
+	exprs := p.ParseProjectionExpression()
+	checkParserErrors(t, p)
+
+	path, err := ExtractPath(exprs[0], env)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []PathElement{
+		{Kind: PathKindMapKey, Key: "A"},
+		{Kind: PathKindMapKey, Key: "B"},
+		{Kind: PathKindListIndex, Index: 1},
+	}
+	if diff := cmp.Diff(want, path); diff != "" {
+		t.Fatal(diff)
+	}
+}
+
+func TestSetProjectedPath_topLevelAndNested(t *testing.T) {
+	t.Parallel()
+
+	target := map[string]*types.Item{}
+
+	s := "hello"
+	SetProjectedPath(target, []PathElement{{Kind: PathKindMapKey, Key: "x"}}, types.Item{S: &s})
+
+	inner := "inner"
+	SetProjectedPath(target, []PathElement{
+		{Kind: PathKindMapKey, Key: "m"},
+		{Kind: PathKindMapKey, Key: "k"},
+	}, types.Item{S: &inner})
+
+	want := map[string]*types.Item{
+		"x": {S: &s},
+		"m": {M: map[string]*types.Item{"k": {S: &inner}}},
+	}
+	if diff := cmp.Diff(want, target); diff != "" {
+		t.Fatal(diff)
+	}
+}
+
+func TestSetProjectedPath_listIndex(t *testing.T) {
+	t.Parallel()
+
+	target := map[string]*types.Item{}
+	elt := "e"
+	SetProjectedPath(target, []PathElement{
+		{Kind: PathKindMapKey, Key: "L"},
+		{Kind: PathKindListIndex, Index: 2},
+	}, types.Item{S: &elt})
+
+	want := map[string]*types.Item{
+		"L": {L: []*types.Item{nil, nil, {S: &elt}}},
+	}
+	if diff := cmp.Diff(want, target); diff != "" {
+		t.Fatal(diff)
+	}
+}

--- a/interpreter/language/projection_test.go
+++ b/interpreter/language/projection_test.go
@@ -1,0 +1,58 @@
+package language
+
+import (
+	"testing"
+)
+
+func TestParseProjectionExpression(t *testing.T) {
+	t.Parallel()
+
+	l := NewLexer("A.B[0], C, #name")
+	p := NewParser(l)
+	exprs := p.ParseProjectionExpression()
+	checkParserErrors(t, p)
+
+	if len(exprs) != 3 {
+		t.Fatalf("expected 3 paths, got %d", len(exprs))
+	}
+
+	if exprs[0].String() != "((A[B])[0])" {
+		t.Errorf("first path: got %q", exprs[0].String())
+	}
+
+	ident1, ok := exprs[1].(*Identifier)
+	if !ok || ident1.Value != "C" {
+		t.Errorf("second path: got %#v", exprs[1])
+	}
+
+	ident2, ok := exprs[2].(*Identifier)
+	if !ok || ident2.Value != "#name" {
+		t.Errorf("third path: got %#v", exprs[2])
+	}
+}
+
+func TestParseProjectionExpression_empty(t *testing.T) {
+	t.Parallel()
+
+	l := NewLexer("")
+	p := NewParser(l)
+	exprs := p.ParseProjectionExpression()
+	checkParserErrors(t, p)
+
+	if len(exprs) != 0 {
+		t.Fatalf("expected 0 paths, got %d", len(exprs))
+	}
+}
+
+func TestParseProjectionExpression_singlePath(t *testing.T) {
+	t.Parallel()
+
+	l := NewLexer("foo.bar")
+	p := NewParser(l)
+	exprs := p.ParseProjectionExpression()
+	checkParserErrors(t, p)
+
+	if len(exprs) != 1 {
+		t.Fatalf("expected 1 path, got %d", len(exprs))
+	}
+}

--- a/interpreter/language_test.go
+++ b/interpreter/language_test.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/truora/minidyn/types"
 )
 
@@ -192,5 +193,88 @@ func TestLanguageUpdate(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			updateTestCaseVerify(tc, t)
 		})
+	}
+}
+
+func TestLanguageProject(t *testing.T) {
+	t.Parallel()
+
+	inner := "v"
+	item := map[string]*types.Item{
+		"top": {S: new("x")},
+		"nested": {
+			M: map[string]*types.Item{
+				"k": {S: &inner},
+			},
+		},
+	}
+
+	interp := Language{}
+	out, err := interp.Project(ProjectInput{
+		Expression: "top, nested.k",
+		Item:       item,
+		Aliases:    nil,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	topWant := "x"
+	want := map[string]*types.Item{
+		"top": {S: &topWant},
+		"nested": {
+			M: map[string]*types.Item{
+				"k": {S: &inner},
+			},
+		},
+	}
+	if diff := cmp.Diff(want, out); diff != "" {
+		t.Fatal(diff)
+	}
+}
+
+func TestLanguageProject_skipsMissingPath(t *testing.T) {
+	t.Parallel()
+
+	item := map[string]*types.Item{
+		"present": {S: new("a")},
+	}
+
+	interp := Language{}
+	out, err := interp.Project(ProjectInput{
+		Expression: "present, notThere",
+		Item:       item,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	val := "a"
+	want := map[string]*types.Item{
+		"present": {S: &val},
+	}
+	if diff := cmp.Diff(want, out); diff != "" {
+		t.Fatal(diff)
+	}
+}
+
+func TestLanguageProject_rejectsUpdateExpressionSyntax(t *testing.T) {
+	t.Parallel()
+
+	// ProjectionExpression only accepts path expressions (comma-separated),
+	// not UpdateExpression clauses like SET … = …
+	interp := Language{}
+	_, err := interp.Project(ProjectInput{
+		Expression: "SET #n = :x",
+		Item: map[string]*types.Item{
+			"n": {S: new("v")},
+		},
+		Aliases: map[string]string{"#n": "n"},
+	})
+	if err == nil {
+		t.Fatal("expected error when projection string uses SET clause")
+	}
+	if !errors.Is(err, ErrSyntaxError) {
+		t.Fatalf("expected ErrSyntaxError, got %v", err)
 	}
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -655,9 +655,9 @@ func TestServerGetItemAttributeNameValidation(t *testing.T) {
 			"id": &ddbtypes.AttributeValueMemberS{Value: "1"},
 		},
 		ExpressionAttributeNames: map[string]string{
-			"#name-1": "name",
+			"#n": "name",
 		},
-		ProjectionExpression: aws.String("#name-1"),
+		ProjectionExpression: aws.String("#n"),
 	})
 	require.NoError(t, err)
 	require.Equal(t, "pikachu", out.Item["name"].(*ddbtypes.AttributeValueMemberS).Value)


### PR DESCRIPTION
Why:
Callers using ProjectionExpression on GetItem, Query, and Scan expect only the requested attributes in returned items. Previously expressions were validated but items were not projected, and pagination keys must stay complete when results are filtered.

What:
- Add ProjectionExpression to core QueryInput; project matches in getMatchedItemAndCount while keeping full items for LastEvaluatedKey.
- Wire projection through aws-v1, aws-v2, and server GetItem, Query, and Scan; map v2 Query via mapper.
- Add tests for projection and invalid expressions; adjust server GetItem test alias so the projection parses.

Issue: #60