### PR TITLE
Fix UpdateItem ReturnValues for DynamoDB parity

### DIFF
--- a/aws-v1/client/client.go
+++ b/aws-v1/client/client.go
@@ -359,8 +359,10 @@ func (fd *Client) UpdateItem(input *dynamodb.UpdateItemInput) (*dynamodb.UpdateI
 		return nil, err
 	}
 
-	output := &dynamodb.UpdateItemOutput{
-		Attributes: mapAttributeValueToDynamodb(item),
+	output := &dynamodb.UpdateItemOutput{}
+
+	if item != nil {
+		output.Attributes = mapAttributeValueToDynamodb(item)
 	}
 
 	return output, nil

--- a/aws-v1/client/client_test.go
+++ b/aws-v1/client/client_test.go
@@ -853,6 +853,60 @@ func TestUpdateItemWithContext(t *testing.T) {
 	c.Equal("water", aws.StringValue(item["second_type"].S))
 }
 
+func TestUpdateItemReturnValuesMatrix(t *testing.T) {
+	c := require.New(t)
+	client := setupClient(tableName)
+
+	c.NoError(ensurePokemonTable(client))
+
+	putAndUpdate := func(pk string, rv *string) map[string]*dynamodb.AttributeValue {
+		t.Helper()
+
+		_, err := client.PutItemWithContext(context.Background(), &dynamodb.PutItemInput{
+			TableName: aws.String(tableName),
+			Item: map[string]*dynamodb.AttributeValue{
+				"id":   {S: aws.String(pk)},
+				"type": {S: aws.String("grass")},
+				"name": {S: aws.String("Bulbasaur")},
+			},
+		})
+		c.NoError(err)
+
+		out, err := client.UpdateItemWithContext(context.Background(), &dynamodb.UpdateItemInput{
+			TableName: aws.String(tableName),
+			Key: map[string]*dynamodb.AttributeValue{
+				"id": {S: aws.String(pk)},
+			},
+			UpdateExpression: aws.String("SET second_type = :st"),
+			ExpressionAttributeValues: map[string]*dynamodb.AttributeValue{
+				":st": {S: aws.String("poison")},
+			},
+			ReturnValues: rv,
+		})
+		c.NoError(err)
+
+		return out.Attributes
+	}
+
+	c.Nil(putAndUpdate("v1-urv-none", aws.String("NONE")))
+
+	allOld := putAndUpdate("v1-urv-all-old", aws.String("ALL_OLD"))
+	c.Len(allOld, 3)
+	c.Equal("Bulbasaur", aws.StringValue(allOld["name"].S))
+	c.Equal("grass", aws.StringValue(allOld["type"].S))
+
+	updatedOld := putAndUpdate("v1-urv-upd-old", aws.String("UPDATED_OLD"))
+	c.Empty(updatedOld)
+
+	updatedNew := putAndUpdate("v1-urv-upd-new", aws.String("UPDATED_NEW"))
+	c.Len(updatedNew, 1)
+	c.Equal("poison", aws.StringValue(updatedNew["second_type"].S))
+
+	allNew := putAndUpdate("v1-urv-all-new", aws.String("ALL_NEW"))
+	c.Len(allNew, 4)
+	c.Equal("poison", aws.StringValue(allNew["second_type"].S))
+}
+
 func TestUpdateItemWithConditionalExpression(t *testing.T) {
 	c := require.New(t)
 	client := setupClient(tableName)

--- a/aws-v2/client/client.go
+++ b/aws-v2/client/client.go
@@ -319,8 +319,10 @@ func (fd *Client) UpdateItem(ctx context.Context, input *dynamodb.UpdateItemInpu
 		return nil, mapKnownError(err)
 	}
 
-	output := &dynamodb.UpdateItemOutput{
-		Attributes: mapTypesToDynamoMapItem(item),
+	output := &dynamodb.UpdateItemOutput{}
+
+	if item != nil {
+		output.Attributes = mapTypesToDynamoMapItem(item)
 	}
 
 	return output, nil

--- a/aws-v2/client/client_test.go
+++ b/aws-v2/client/client_test.go
@@ -966,6 +966,60 @@ func TestUpdateItem(t *testing.T) {
 	c.Equal(&dynamodbtypes.AttributeValueMemberS{Value: "water"}, item["second_type"])
 }
 
+func TestUpdateItemReturnValuesMatrix(t *testing.T) {
+	c := require.New(t)
+	client := setupClient(tableName)
+
+	c.NoError(ensurePokemonTable(client))
+
+	putAndUpdate := func(pk string, rv dynamodbtypes.ReturnValue) map[string]dynamodbtypes.AttributeValue {
+		t.Helper()
+
+		_, err := client.PutItem(context.Background(), &dynamodb.PutItemInput{
+			TableName: aws.String(tableName),
+			Item: map[string]dynamodbtypes.AttributeValue{
+				"id":   &dynamodbtypes.AttributeValueMemberS{Value: pk},
+				"type": &dynamodbtypes.AttributeValueMemberS{Value: "grass"},
+				"name": &dynamodbtypes.AttributeValueMemberS{Value: "Bulbasaur"},
+			},
+		})
+		c.NoError(err)
+
+		out, err := client.UpdateItem(context.Background(), &dynamodb.UpdateItemInput{
+			TableName: aws.String(tableName),
+			Key: map[string]dynamodbtypes.AttributeValue{
+				"id": &dynamodbtypes.AttributeValueMemberS{Value: pk},
+			},
+			UpdateExpression: aws.String("SET second_type = :st"),
+			ExpressionAttributeValues: map[string]dynamodbtypes.AttributeValue{
+				":st": &dynamodbtypes.AttributeValueMemberS{Value: "poison"},
+			},
+			ReturnValues: rv,
+		})
+		c.NoError(err)
+
+		return out.Attributes
+	}
+
+	c.Nil(putAndUpdate("urv-none", dynamodbtypes.ReturnValueNone))
+
+	allOld := putAndUpdate("urv-all-old", dynamodbtypes.ReturnValueAllOld)
+	c.Len(allOld, 3)
+	c.Equal(&dynamodbtypes.AttributeValueMemberS{Value: "Bulbasaur"}, allOld["name"])
+	c.Equal(&dynamodbtypes.AttributeValueMemberS{Value: "grass"}, allOld["type"])
+
+	updatedOld := putAndUpdate("urv-upd-old", dynamodbtypes.ReturnValueUpdatedOld)
+	c.Empty(updatedOld)
+
+	updatedNew := putAndUpdate("urv-upd-new", dynamodbtypes.ReturnValueUpdatedNew)
+	c.Len(updatedNew, 1)
+	c.Equal(&dynamodbtypes.AttributeValueMemberS{Value: "poison"}, updatedNew["second_type"])
+
+	allNew := putAndUpdate("urv-all-new", dynamodbtypes.ReturnValueAllNew)
+	c.Len(allNew, 4)
+	c.Equal(&dynamodbtypes.AttributeValueMemberS{Value: "poison"}, allNew["second_type"])
+}
+
 func TestUpdateItemWithConditionalExpression(t *testing.T) {
 	c := require.New(t)
 	client := setupClient(tableName)

--- a/aws-v2/client/mapper.go
+++ b/aws-v2/client/mapper.go
@@ -612,6 +612,10 @@ func mapTypesToDynamoAttributeDefinitionMapOrList(item *types.Item) dynamodbtype
 }
 
 func mapTypesToDynamoMapItem(input map[string]*types.Item) map[string]dynamodbtypes.AttributeValue {
+	if input == nil {
+		return nil
+	}
+
 	output := map[string]dynamodbtypes.AttributeValue{}
 
 	for key, item := range input {

--- a/core/table.go
+++ b/core/table.go
@@ -3,6 +3,7 @@ package core
 import (
 	"fmt"
 	"maps"
+	"reflect"
 	"sort"
 
 	"github.com/truora/minidyn/interpreter"
@@ -623,9 +624,116 @@ func (t *Table) interpreterUpdate(input interpreter.UpdateInput) error {
 	return t.LangInterpreter.Update(input)
 }
 
+func validateUpdateItemReturnValues(rv *string) error {
+	if rv == nil || *rv == "" {
+		return nil
+	}
+
+	switch *rv {
+	case "NONE", "ALL_OLD", "UPDATED_OLD", "UPDATED_NEW", "ALL_NEW":
+		return nil
+	default:
+		return types.NewError("ValidationException",
+			fmt.Sprintf("1 validation error detected: Value '%s' at 'returnValues' failed to satisfy constraint: Member must satisfy enum value set: [NONE, ALL_OLD, UPDATED_OLD, UPDATED_NEW, ALL_NEW]", *rv),
+			nil)
+	}
+}
+
+func dynamoItemEqual(a, b *types.Item) bool {
+	return reflect.DeepEqual(a, b)
+}
+
+func changedUpdateAttributeKeys(oldItem, newItem map[string]*types.Item) []string {
+	keys := make(map[string]struct{})
+
+	for k := range oldItem {
+		keys[k] = struct{}{}
+	}
+
+	for k := range newItem {
+		keys[k] = struct{}{}
+	}
+
+	changed := make([]string, 0, len(keys))
+
+	for k := range keys {
+		ov, okO := oldItem[k]
+		nv, okN := newItem[k]
+
+		if !okO {
+			ov = nil
+		}
+
+		if !okN {
+			nv = nil
+		}
+
+		if !dynamoItemEqual(ov, nv) {
+			changed = append(changed, k)
+		}
+	}
+
+	sort.Strings(changed)
+
+	return changed
+}
+
+func buildUpdateItemReturnAttributes(rv *string, oldItem, newItem map[string]*types.Item) map[string]*types.Item {
+	mode := ""
+
+	if rv != nil {
+		mode = *rv
+	}
+
+	switch mode {
+	case "", "NONE":
+		return nil
+	case "ALL_NEW":
+		return copyItem(newItem)
+	case "ALL_OLD":
+		return copyItem(oldItem)
+	case "UPDATED_OLD":
+		ck := changedUpdateAttributeKeys(oldItem, newItem)
+		if len(ck) == 0 {
+			return map[string]*types.Item{}
+		}
+
+		out := make(map[string]*types.Item, len(ck))
+
+		for _, k := range ck {
+			if v, ok := oldItem[k]; ok {
+				out[k] = deepCopyTypesItem(v)
+			}
+		}
+
+		return out
+	case "UPDATED_NEW":
+		ck := changedUpdateAttributeKeys(oldItem, newItem)
+		if len(ck) == 0 {
+			return map[string]*types.Item{}
+		}
+
+		out := make(map[string]*types.Item, len(ck))
+
+		for _, k := range ck {
+			if v, ok := newItem[k]; ok {
+				out[k] = deepCopyTypesItem(v)
+			}
+		}
+
+		return out
+	default:
+		return nil
+	}
+}
+
 // Update updates an item in the table based on the input
 func (t *Table) Update(input *types.UpdateItemInput) (map[string]*types.Item, error) { //nolint:gocognit,gocyclo // conditional writes, interpreter update, GSI updates
 	if err := validateUpdateItemInputKeysAndValues(input); err != nil {
+		return nil, err
+	}
+
+	if err := validateUpdateItemReturnValues(input.ReturnValues); err != nil {
 		return nil, err
 	}
 
@@ -687,7 +795,7 @@ func (t *Table) Update(input *types.UpdateItemInput) (map[string]*types.Item, er
 		item = copyItem(input.Key)
 	}
 
-	oldItem := copyItem(item)
+	oldItem := deepCopyItemMap(item)
 
 	err = t.interpreterUpdate(interpreter.UpdateInput{
 		TableName:  t.Name,
@@ -710,7 +818,9 @@ func (t *Table) Update(input *types.UpdateItemInput) (map[string]*types.Item, er
 		}
 	}
 
-	return copyItem(item), nil
+	newItem := copyItem(item)
+
+	return buildUpdateItemReturnAttributes(input.ReturnValues, oldItem, newItem), nil
 }
 
 // Delete deletes an item in the table based on the input

--- a/core/table_test.go
+++ b/core/table_test.go
@@ -787,6 +787,7 @@ func TestUpdate(t *testing.T) {
 
 	updateInput.ConditionExpression = new("attribute_exists(id)")
 	updateInput.UpdateExpression = "SET id = :id"
+	updateInput.ReturnValues = aws.String("ALL_NEW")
 
 	_, err = newTable.Update(updateInput)
 	c.Error(err)
@@ -831,12 +832,106 @@ func TestUpdateMultiClauseExpression(t *testing.T) {
 			":one": {N: new("1")},
 		},
 		UpdateExpression: "SET #t = :new ADD lvl :one",
+		ReturnValues:     aws.String("ALL_NEW"),
 	}
 
 	result, err := newTable.Update(updateInput)
 	c.NoError(err)
 	c.Equal("poison", types.StringValue(result["type"].S))
 	c.Equal("2", types.StringValue(result["lvl"].N))
+
+	newTable.Clear()
+}
+
+func TestUpdateReturnValuesSemantics(t *testing.T) {
+	c := require.New(t)
+
+	newTable, err := createPokemonTable()
+	c.NoError(err)
+
+	exprVals := map[string]*types.Item{":st": {S: new("poison")}}
+	uexpr := "SET second_type = :st"
+
+	run := func(id string, rv *string) map[string]*types.Item {
+		t.Helper()
+
+		item := createPokemon(pokemon{
+			ID:   id,
+			Type: "grass",
+			Name: "Bulbasaur",
+		})
+
+		_, perr := newTable.Put(&types.PutItemInput{
+			Item:      item,
+			TableName: &newTable.Name,
+		})
+		c.NoError(perr)
+
+		out, uerr := newTable.Update(&types.UpdateItemInput{
+			TableName:                 &newTable.Name,
+			Key:                       primaryKeyFromPokemonItem(item),
+			ReturnValues:              rv,
+			UpdateExpression:          uexpr,
+			ExpressionAttributeValues: exprVals,
+		})
+		c.NoError(uerr)
+
+		return out
+	}
+
+	c.Nil(run("rv-none", nil))
+	c.Nil(run("rv-none-explicit", aws.String("NONE")))
+
+	allOld := run("rv-all-old", aws.String("ALL_OLD"))
+	c.Len(allOld, 3)
+	c.Equal("Bulbasaur", types.StringValue(allOld["name"].S))
+	c.Equal("grass", types.StringValue(allOld["type"].S))
+	c.Equal("rv-all-old", types.StringValue(allOld["id"].S))
+
+	updatedOld := run("rv-upd-old", aws.String("UPDATED_OLD"))
+	c.Empty(updatedOld)
+
+	updatedNew := run("rv-upd-new", aws.String("UPDATED_NEW"))
+	c.Len(updatedNew, 1)
+	c.Equal("poison", types.StringValue(updatedNew["second_type"].S))
+
+	allNew := run("rv-all-new", aws.String("ALL_NEW"))
+	c.Len(allNew, 4)
+	c.Equal("poison", types.StringValue(allNew["second_type"].S))
+	c.Equal("Bulbasaur", types.StringValue(allNew["name"].S))
+	c.Equal("rv-all-new", types.StringValue(allNew["id"].S))
+
+	newTable.Clear()
+}
+
+func TestUpdateInvalidReturnValues(t *testing.T) {
+	c := require.New(t)
+
+	newTable, err := createPokemonTable()
+	c.NoError(err)
+
+	item := createPokemon(pokemon{
+		ID:   "bad-rv",
+		Type: "grass",
+		Name: "Bulbasaur",
+	})
+
+	_, err = newTable.Put(&types.PutItemInput{
+		Item:      item,
+		TableName: &newTable.Name,
+	})
+	c.NoError(err)
+
+	_, err = newTable.Update(&types.UpdateItemInput{
+		TableName:                 &newTable.Name,
+		Key:                       primaryKeyFromPokemonItem(item),
+		ReturnValues:              aws.String("NOT_A_REAL_MODE"),
+		UpdateExpression:          "SET #n = :new",
+		ExpressionAttributeNames:  map[string]string{"#n": "name"},
+		ExpressionAttributeValues: map[string]*types.Item{":new": {S: new("X")}},
+	})
+	c.Error(err)
+	c.Contains(err.Error(), "returnValues")
 
 	newTable.Clear()
 }

--- a/core/types.go
+++ b/core/types.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"maps"
@@ -30,6 +31,105 @@ func copyItem(item map[string]*types.Item) map[string]*types.Item {
 	maps.Copy(copy, item)
 
 	return copy
+}
+
+func cloneBoolPtr(b *bool) *bool {
+	if b == nil {
+		return nil
+	}
+
+	v := *b
+
+	return &v
+}
+
+func cloneStringPtr(s *string) *string {
+	if s == nil {
+		return nil
+	}
+
+	v := *s
+
+	return &v
+}
+
+func deepCopyStringPtrSlice(src []*string) []*string {
+	if len(src) == 0 {
+		return nil
+	}
+
+	out := make([]*string, len(src))
+
+	for i, s := range src {
+		out[i] = cloneStringPtr(s)
+	}
+
+	return out
+}
+
+func deepCopyByteSliceSlice(src [][]byte) [][]byte {
+	if len(src) == 0 {
+		return nil
+	}
+
+	out := make([][]byte, len(src))
+
+	for i, b := range src {
+		out[i] = bytes.Clone(b)
+	}
+
+	return out
+}
+
+// deepCopyTypesItem returns a deep copy of a DynamoDB attribute value tree.
+func deepCopyTypesItem(it *types.Item) *types.Item {
+	if it == nil {
+		return nil
+	}
+
+	out := &types.Item{
+		BOOL: cloneBoolPtr(it.BOOL),
+		NULL: cloneBoolPtr(it.NULL),
+		S:    cloneStringPtr(it.S),
+		N:    cloneStringPtr(it.N),
+	}
+
+	if it.B != nil {
+		out.B = bytes.Clone(it.B)
+	}
+
+	out.BS = deepCopyByteSliceSlice(it.BS)
+	out.SS = deepCopyStringPtrSlice(it.SS)
+	out.NS = deepCopyStringPtrSlice(it.NS)
+
+	if len(it.L) > 0 {
+		out.L = make([]*types.Item, len(it.L))
+
+		for i, e := range it.L {
+			out.L[i] = deepCopyTypesItem(e)
+		}
+	}
+
+	if len(it.M) > 0 {
+		out.M = deepCopyItemMap(it.M)
+	}
+
+	return out
+}
+
+// deepCopyItemMap returns a deep copy of an item attribute map.
+func deepCopyItemMap(m map[string]*types.Item) map[string]*types.Item {
+	if m == nil {
+		return nil
+	}
+
+	out := make(map[string]*types.Item, len(m))
+
+	for k, v := range m {
+		out[k] = deepCopyTypesItem(v)
+	}
+
+	return out
 }
 
 func mapSliceType(t reflect.Type) string {

--- a/e2e/parity_item_test.go
+++ b/e2e/parity_item_test.go
@@ -427,6 +427,59 @@ func TestE2E_Item(t *testing.T) {
 			},
 		},
 		{
+			name: "UpdateItemReturnValues",
+			fn: func(t *testing.T, client *dynamodb.Client) any {
+				t.Helper()
+				ctx := context.Background()
+
+				parityCreatePokemonTable(ctx, t, client)
+
+				opt := func(o *attributevalue.EncoderOptions) {
+					o.TagKey = "json"
+				}
+
+				putAndUpdate := func(pk string, rv dynamodbtypes.ReturnValue) map[string]dynamodbtypes.AttributeValue {
+					t.Helper()
+
+					item, err := attributevalue.MarshalMapWithOptions(parityPokemon{
+						ID:   pk,
+						Type: "grass",
+						Name: "Bulbasaur",
+					}, opt)
+					require.NoError(t, err)
+
+					_, err = client.PutItem(ctx, &dynamodb.PutItemInput{
+						TableName: aws.String(parityPokemonTable),
+						Item:      item,
+					})
+					require.NoError(t, err)
+
+					out, err := client.UpdateItem(ctx, &dynamodb.UpdateItemInput{
+						TableName: aws.String(parityPokemonTable),
+						Key: map[string]dynamodbtypes.AttributeValue{
+							"id": &dynamodbtypes.AttributeValueMemberS{Value: pk},
+						},
+						UpdateExpression: aws.String("SET second_type = :st"),
+						ExpressionAttributeValues: map[string]dynamodbtypes.AttributeValue{
+							":st": &dynamodbtypes.AttributeValueMemberS{Value: "poison"},
+						},
+						ReturnValues: rv,
+					})
+					require.NoError(t, err)
+
+					return out.Attributes
+				}
+
+				none := putAndUpdate("e2e-urv-none", dynamodbtypes.ReturnValueNone)
+				allOld := putAndUpdate("e2e-urv-all-old", dynamodbtypes.ReturnValueAllOld)
+				updatedOld := putAndUpdate("e2e-urv-upd-old", dynamodbtypes.ReturnValueUpdatedOld)
+				updatedNew := putAndUpdate("e2e-urv-upd-new", dynamodbtypes.ReturnValueUpdatedNew)
+				allNew := putAndUpdate("e2e-urv-all-new", dynamodbtypes.ReturnValueAllNew)
+
+				return []any{none, allOld, updatedOld, updatedNew, allNew}
+			},
+		},
+		{
 			name: "UpdateItemWithConditionalExpression",
 			fn: func(t *testing.T, client *dynamodb.Client) any {
 				t.Helper()

--- a/server/client.go
+++ b/server/client.go
@@ -285,6 +285,7 @@ func (c *Client) UpdateItem(ctx context.Context, input *UpdateItemInput) (*Updat
 		ExpressionAttributeValues:           mapAttributeValueMapToTypes(input.ExpressionAttributeValues),
 		Key:                                 mapAttributeValueMapToTypes(input.Key),
 		UpdateExpression:                    aws.ToString(input.UpdateExpression),
+		ReturnValues:                        toStringPtr(string(input.ReturnValues)),
 		ReturnValuesOnConditionCheckFailure: toStringPtr(string(input.ReturnValuesOnConditionCheckFailure)),
 	})
 	if err != nil {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -543,6 +543,61 @@ func TestServerUpdateItemWithSDKv2(t *testing.T) {
 	require.Equal(t, "2", upd.Attributes["lvl"].(*ddbtypes.AttributeValueMemberN).Value)
 }
 
+func TestServerUpdateItemReturnValuesMatrix(t *testing.T) {
+	ts := httptest.NewServer(NewServer())
+	defer ts.Close()
+	cli := newTestDynamoClient(t, ts.URL)
+
+	makeBasicTable(t, cli, "pokemons", "id")
+	ctx := context.Background()
+
+	putAndUpdate := func(pk string, rv ddbtypes.ReturnValue) map[string]ddbtypes.AttributeValue {
+		t.Helper()
+
+		_, err := cli.PutItem(ctx, &dynamodb.PutItemInput{
+			TableName: aws.String("pokemons"),
+			Item: map[string]ddbtypes.AttributeValue{
+				"id":   &ddbtypes.AttributeValueMemberS{Value: pk},
+				"type": &ddbtypes.AttributeValueMemberS{Value: "grass"},
+				"name": &ddbtypes.AttributeValueMemberS{Value: "Bulbasaur"},
+			},
+		})
+		require.NoError(t, err)
+
+		out, err := cli.UpdateItem(ctx, &dynamodb.UpdateItemInput{
+			TableName: aws.String("pokemons"),
+			Key: map[string]ddbtypes.AttributeValue{
+				"id": &ddbtypes.AttributeValueMemberS{Value: pk},
+			},
+			UpdateExpression: aws.String("SET second_type = :st"),
+			ExpressionAttributeValues: map[string]ddbtypes.AttributeValue{
+				":st": &ddbtypes.AttributeValueMemberS{Value: "poison"},
+			},
+			ReturnValues: rv,
+		})
+		require.NoError(t, err)
+
+		return out.Attributes
+	}
+
+	require.Nil(t, putAndUpdate("srv-urv-none", ddbtypes.ReturnValueNone))
+
+	allOld := putAndUpdate("srv-urv-all-old", ddbtypes.ReturnValueAllOld)
+	require.Len(t, allOld, 3)
+	require.Equal(t, "Bulbasaur", allOld["name"].(*ddbtypes.AttributeValueMemberS).Value)
+
+	updatedOld := putAndUpdate("srv-urv-upd-old", ddbtypes.ReturnValueUpdatedOld)
+	require.Empty(t, updatedOld)
+
+	updatedNew := putAndUpdate("srv-urv-upd-new", ddbtypes.ReturnValueUpdatedNew)
+	require.Len(t, updatedNew, 1)
+	require.Equal(t, "poison", updatedNew["second_type"].(*ddbtypes.AttributeValueMemberS).Value)
+
+	allNew := putAndUpdate("srv-urv-all-new", ddbtypes.ReturnValueAllNew)
+	require.Len(t, allNew, 4)
+	require.Equal(t, "poison", allNew["second_type"].(*ddbtypes.AttributeValueMemberS).Value)
+}
+
 func TestServerUpdateItemWithConditionalExpression(t *testing.T) {
 	ts := httptest.NewServer(NewServer())
 	defer ts.Close()


### PR DESCRIPTION
Why:
DynamoDB UpdateItem documents ReturnValues; minidyn always returned the full post-update item (ALL_NEW), breaking callers that rely on NONE or partial returns.

What:
- Deep-snapshot pre-update state; build Attributes from ReturnValues.
- Forward ReturnValues in server Client.UpdateItem.
- Omit Attributes in aws-v1/aws-v2 clients when update returns nil.
- Allow nil input in mapTypesToDynamoMapItem; add tests and e2e parity.

Issue: #109