### PR TITLE
Fix UpdateItem validation for primary key attribute updates

### DIFF
--- a/core/table.go
+++ b/core/table.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 
 	"github.com/truora/minidyn/interpreter"
+	"github.com/truora/minidyn/interpreter/language"
 	"github.com/truora/minidyn/types"
 )
 
@@ -630,6 +631,17 @@ func (t *Table) Update(input *types.UpdateItemInput) (map[string]*types.Item, er
 
 	if err := t.KeySchema.validatePrimaryKeyMap(input.Key); err != nil {
 		return nil, types.NewError("ValidationException", err.Error(), nil)
+	}
+
+	if !t.KeySchema.Secondary {
+		if err := language.ValidateUpdateExpressionDoesNotTargetPrimaryKey(
+			input.UpdateExpression,
+			input.ExpressionAttributeNames,
+			t.KeySchema.HashKey,
+			t.KeySchema.RangeKey,
+		); err != nil {
+			return nil, types.NewError("ValidationException", err.Error(), nil)
+		}
 	}
 
 	// update primary index

--- a/core/table_test.go
+++ b/core/table_test.go
@@ -788,9 +788,14 @@ func TestUpdate(t *testing.T) {
 	updateInput.ConditionExpression = new("attribute_exists(id)")
 	updateInput.UpdateExpression = "SET id = :id"
 
-	result, err := newTable.Update(updateInput)
-	c.NoError(err)
-	c.Equal("002", types.StringValue(result["id"].S))
+	_, err = newTable.Update(updateInput)
+	c.Error(err)
+
+	var keyUpdateErr types.Error
+	c.True(errors.As(err, &keyUpdateErr))
+	c.Equal("ValidationException", keyUpdateErr.Code())
+	c.Contains(keyUpdateErr.Message(), "Cannot update attribute id")
+	c.Contains(keyUpdateErr.Message(), "part of the key")
 
 	newTable.Clear()
 }
@@ -819,18 +824,18 @@ func TestUpdateMultiClauseExpression(t *testing.T) {
 	updateInput := &types.UpdateItemInput{
 		Key: primaryKeyFromPokemonItem(item),
 		ExpressionAttributeNames: map[string]string{
-			"#n": "name",
+			"#t": "type",
 		},
 		ExpressionAttributeValues: map[string]*types.Item{
-			":new": {S: new("Ivysaur")},
+			":new": {S: new("poison")},
 			":one": {N: new("1")},
 		},
-		UpdateExpression: "SET #n = :new ADD lvl :one",
+		UpdateExpression: "SET #t = :new ADD lvl :one",
 	}
 
 	result, err := newTable.Update(updateInput)
 	c.NoError(err)
-	c.Equal("Ivysaur", types.StringValue(result["name"].S))
+	c.Equal("poison", types.StringValue(result["type"].S))
 	c.Equal("2", types.StringValue(result["lvl"].N))
 
 	newTable.Clear()
@@ -859,13 +864,13 @@ func TestUpdateDuplicateClauseKeywordError(t *testing.T) {
 	updateInput := &types.UpdateItemInput{
 		Key: primaryKeyFromPokemonItem(item),
 		ExpressionAttributeNames: map[string]string{
-			"#n": "name",
+			"#t": "type",
 		},
 		ExpressionAttributeValues: map[string]*types.Item{
 			":a": {S: new("x")},
 			":b": {S: new("y")},
 		},
-		UpdateExpression: "SET #n = :a SET name = :b",
+		UpdateExpression: "SET #t = :a SET type = :b",
 	}
 
 	_, err = newTable.Update(updateInput)

--- a/e2e/parity_item_test.go
+++ b/e2e/parity_item_test.go
@@ -596,6 +596,57 @@ func TestE2E_Item(t *testing.T) {
 			},
 		},
 		{
+			name: "UpdateItemCannotSetPartitionKey",
+			fn: func(t *testing.T, client *dynamodb.Client) any {
+				t.Helper()
+				ctx := context.Background()
+
+				parityCreatePokemonTable(ctx, t, client)
+				parityCreatePokemon(ctx, t, client, parityPokemon{ID: "001", Type: "grass", Name: "Bulbasaur"})
+
+				_, err := client.UpdateItem(ctx, &dynamodb.UpdateItemInput{
+					TableName: aws.String(parityPokemonTable),
+					Key: map[string]dynamodbtypes.AttributeValue{
+						"id": &dynamodbtypes.AttributeValueMemberS{Value: "001"},
+					},
+					UpdateExpression: aws.String("SET id = :new"),
+					ExpressionAttributeValues: map[string]dynamodbtypes.AttributeValue{
+						":new": &dynamodbtypes.AttributeValueMemberS{Value: "002"},
+					},
+				})
+				require.Error(t, err)
+
+				return normalizeSDKErrorString(err.Error())
+			},
+		},
+		{
+			name: "UpdateItemCannotSetPartitionKeyWithNameAlias",
+			fn: func(t *testing.T, client *dynamodb.Client) any {
+				t.Helper()
+				ctx := context.Background()
+
+				parityCreatePokemonTable(ctx, t, client)
+				parityCreatePokemon(ctx, t, client, parityPokemon{ID: "001", Type: "grass", Name: "Bulbasaur"})
+
+				_, err := client.UpdateItem(ctx, &dynamodb.UpdateItemInput{
+					TableName: aws.String(parityPokemonTable),
+					Key: map[string]dynamodbtypes.AttributeValue{
+						"id": &dynamodbtypes.AttributeValueMemberS{Value: "001"},
+					},
+					UpdateExpression: aws.String("SET #pk = :new"),
+					ExpressionAttributeNames: map[string]string{
+						"#pk": "id",
+					},
+					ExpressionAttributeValues: map[string]dynamodbtypes.AttributeValue{
+						":new": &dynamodbtypes.AttributeValueMemberS{Value: "002"},
+					},
+				})
+				require.Error(t, err)
+
+				return normalizeSDKErrorString(err.Error())
+			},
+		},
+		{
 			name: "UpdateExpressions_add",
 			fn: func(t *testing.T, client *dynamodb.Client) any {
 				t.Helper()

--- a/interpreter/language/update_key_validation.go
+++ b/interpreter/language/update_key_validation.go
@@ -1,0 +1,83 @@
+package language
+
+import (
+	"fmt"
+	"strings"
+)
+
+func resolveExpressionAttributeName(name string, aliases map[string]string) string {
+	if aliases == nil {
+		return name
+	}
+
+	if resolved, ok := aliases[name]; ok {
+		return resolved
+	}
+
+	return name
+}
+
+// updateActionRootAttributeName returns the top-level DynamoDB attribute name for the LHS of
+// SET, ADD, REMOVE, or DELETE (Identifier or IndexExpression chain).
+func updateActionRootAttributeName(expr Expression, aliases map[string]string) (string, bool) {
+	switch n := expr.(type) {
+	case *Identifier:
+		return resolveExpressionAttributeName(n.Value, aliases), true
+	case *IndexExpression:
+		return updateActionRootAttributeName(n.Left, aliases)
+	default:
+		return "", false
+	}
+}
+
+func walkUpdateTargets(expr Expression, aliases map[string]string, visit func(root string)) {
+	switch n := expr.(type) {
+	case *UpdateExpression:
+		for _, sub := range n.Expressions {
+			walkUpdateTargets(sub, aliases, visit)
+		}
+	case *ActionExpression:
+		if root, ok := updateActionRootAttributeName(n.Left, aliases); ok {
+			visit(root)
+		}
+	}
+}
+
+// ValidateUpdateExpressionDoesNotTargetPrimaryKey parses the update expression and returns an
+// error when any action targets the given hash or range key attribute name (after resolving
+// ExpressionAttributeNames). If parsing fails, it returns nil so the interpreter can report syntax errors.
+func ValidateUpdateExpressionDoesNotTargetPrimaryKey(expression string, aliases map[string]string, hashKey, rangeKey string) error {
+	if strings.TrimSpace(expression) == "" {
+		return nil
+	}
+
+	l := NewLexer(expression)
+	p := NewUpdateParser(l)
+	stmt := p.ParseUpdateExpression()
+
+	if len(p.Errors()) != 0 || stmt.Expression == nil {
+		return nil
+	}
+
+	var hit string
+
+	walkUpdateTargets(stmt.Expression, aliases, func(root string) {
+		if hit != "" {
+			return
+		}
+
+		if root == hashKey || (rangeKey != "" && root == rangeKey) {
+			hit = root
+		}
+	})
+
+	if hit == "" {
+		return nil
+	}
+
+	//nolint:staticcheck,ST1005 // DynamoDB ValidationException message parity
+	return fmt.Errorf(
+		"One or more parameter values were invalid: Cannot update attribute %s. This attribute is part of the key",
+		hit,
+	)
+}

--- a/interpreter/language/update_key_validation_test.go
+++ b/interpreter/language/update_key_validation_test.go
@@ -1,0 +1,116 @@
+package language
+
+import (
+	"strings"
+	"testing"
+)
+
+func assertPrimaryKeyUpdateError(t *testing.T, err error, wantSubstr string) {
+	t.Helper()
+
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	if wantSubstr != "" && !strings.Contains(err.Error(), wantSubstr) {
+		t.Fatalf("error %q does not contain %q", err.Error(), wantSubstr)
+	}
+
+	if !strings.Contains(err.Error(), "part of the key") {
+		t.Fatalf("error %q missing key suffix", err.Error())
+	}
+}
+
+func TestValidateUpdateExpressionDoesNotTargetPrimaryKey(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		expr       string
+		aliases    map[string]string
+		hashKey    string
+		rangeKey   string
+		wantErr    bool
+		wantSubstr string
+	}{
+		{
+			name:    "empty expression",
+			expr:    "   ",
+			hashKey: "id",
+			wantErr: false,
+		},
+		{
+			name:       "SET partition key literal",
+			expr:       "SET id = :new",
+			hashKey:    "id",
+			wantErr:    true,
+			wantSubstr: "Cannot update attribute id",
+		},
+		{
+			name:       "SET partition key via name alias",
+			expr:       "SET #pk = :new",
+			aliases:    map[string]string{"#pk": "id"},
+			hashKey:    "id",
+			wantErr:    true,
+			wantSubstr: "Cannot update attribute id",
+		},
+		{
+			name:    "SET non-key attribute",
+			expr:    "SET type = :t",
+			hashKey: "id",
+			wantErr: false,
+		},
+		{
+			name:       "REMOVE partition key",
+			expr:       "REMOVE id",
+			hashKey:    "id",
+			wantErr:    true,
+			wantSubstr: "Cannot update attribute id",
+		},
+		{
+			name:       "SET sort key when table has range",
+			expr:       "SET sk = :s",
+			hashKey:    "pk",
+			rangeKey:   "sk",
+			wantErr:    true,
+			wantSubstr: "Cannot update attribute sk",
+		},
+		{
+			name:     "SET attribute same name as range but no range on table",
+			expr:     "SET sk = :s",
+			hashKey:  "pk",
+			rangeKey: "",
+			wantErr:  false,
+		},
+		{
+			name:       "nested path root is key",
+			expr:       "SET id[0] = :x",
+			hashKey:    "id",
+			wantErr:    true,
+			wantSubstr: "Cannot update attribute id",
+		},
+		{
+			name:    "parse error defers to interpreter",
+			expr:    "SET",
+			hashKey: "id",
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := ValidateUpdateExpressionDoesNotTargetPrimaryKey(tt.expr, tt.aliases, tt.hashKey, tt.rangeKey)
+			if tt.wantErr {
+				assertPrimaryKeyUpdateError(t, err, tt.wantSubstr)
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Why:
DynamoDB returns ValidationException when an update expression targets partition or sort key attributes. Minidyn previously applied those updates, which also risked desyncing the in-memory key from item attributes.

What:
- Add ValidateUpdateExpressionDoesNotTargetPrimaryKey in interpreter/language.
- Invoke it from core.Table.Update; wrap failures as ValidationException.
- Fix core table tests that SET key attributes; expect error on SET id.
- Add E2E parity cases for SET on partition key (literal and #pk alias).

Issue: #76