### PR TITLE
Implement TransactWriteItems

### DIFF
--- a/aws-v2/client/client.go
+++ b/aws-v2/client/client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math"
 	"regexp"
+	"sort"
 	"strings"
 	"sync"
 
@@ -19,11 +20,12 @@ import (
 )
 
 const (
-	batchRequestsLimit                 = 25
-	unusedExpressionAttributeNamesMsg  = "Value provided in ExpressionAttributeNames unused in expressions"
-	unusedExpressionAttributeValuesMsg = "Value provided in ExpressionAttributeValues unused in expressions"
-	invalidExpressionAttributeName     = "ExpressionAttributeNames contains invalid key"
-	invalidExpressionAttributeValue    = "ExpressionAttributeValues contains invalid key"
+	batchRequestsLimit                              = 25
+	unusedExpressionAttributeNamesMsg               = "Value provided in ExpressionAttributeNames unused in expressions"
+	unusedExpressionAttributeValuesMsg              = "Value provided in ExpressionAttributeValues unused in expressions"
+	expressionAttributeValuesOnlyWithExpressionsMsg = "ExpressionAttributeValues can only be specified when using expressions"
+	invalidExpressionAttributeName                  = "ExpressionAttributeNames contains invalid key"
+	invalidExpressionAttributeValue                 = "ExpressionAttributeValues contains invalid key"
 )
 
 var (
@@ -656,8 +658,60 @@ func handleBatchWriteRequestError(table string, req types.WriteRequest, unproces
 	return nil
 }
 
+func (fd *Client) prepareTransact(items []types.TransactWriteItem) (map[string]core.TableSnapshot, error) {
+	snapshots := map[string]core.TableSnapshot{}
+	seenKeys := make(map[string]struct{}, len(items))
+
+	for _, item := range items {
+		var tableName string
+		var rawKeyMap map[string]types.AttributeValue
+
+		switch {
+		case item.Put != nil:
+			tableName, rawKeyMap = aws.ToString(item.Put.TableName), item.Put.Item
+		case item.Update != nil:
+			tableName, rawKeyMap = aws.ToString(item.Update.TableName), item.Update.Key
+		case item.Delete != nil:
+			tableName, rawKeyMap = aws.ToString(item.Delete.TableName), item.Delete.Key
+		case item.ConditionCheck != nil:
+			tableName, rawKeyMap = aws.ToString(item.ConditionCheck.TableName), item.ConditionCheck.Key
+		}
+
+		if tableName == "" {
+			continue
+		}
+
+		if _, alreadySnapped := snapshots[tableName]; !alreadySnapped {
+			table, err := fd.getTable(tableName)
+			if err != nil {
+				return nil, mapKnownError(err)
+			}
+
+			snapshots[tableName] = table.Snapshot()
+		}
+
+		table := fd.tables[tableName]
+		internalKeyMap := mapDynamoToTypesMapItem(rawKeyMap)
+
+		if key, err := table.KeySchema.GetKey(table.AttributesDef, internalKeyMap); err == nil {
+			id := tableName + "|" + key
+
+			if _, exists := seenKeys[id]; exists {
+				return nil, &smithy.GenericAPIError{
+					Code:    "ValidationException",
+					Message: "Transaction request cannot include multiple operations on one item",
+				}
+			}
+
+			seenKeys[id] = struct{}{}
+		}
+	}
+
+	return snapshots, nil
+}
+
 // TransactWriteItems mock response for dynamodb
-func (fd *Client) TransactWriteItems(ctx context.Context, input *dynamodb.TransactWriteItemsInput, opts ...func(*dynamodb.Options)) (_ *dynamodb.TransactWriteItemsOutput, err error) {
+func (fd *Client) TransactWriteItems(ctx context.Context, input *dynamodb.TransactWriteItemsInput, opts ...func(*dynamodb.Options)) (*dynamodb.TransactWriteItemsOutput, error) {
 	fd.mu.Lock()
 	defer fd.mu.Unlock()
 
@@ -665,154 +719,158 @@ func (fd *Client) TransactWriteItems(ctx context.Context, input *dynamodb.Transa
 		return nil, fd.forceFailureErr
 	}
 
-	snapshots := map[string]core.TableSnapshot{}
+	snapshots, err := fd.prepareTransact(input.TransactItems)
+	if err != nil {
+		return nil, err
+	}
+
+	var execErr error
 
 	defer func() {
-		if err != nil {
+		if execErr != nil {
 			for name, snap := range snapshots {
 				fd.tables[name].Restore(snap)
 			}
 		}
 	}()
 
-	for _, item := range input.TransactItems {
-		var tableName string
-
-		switch {
-		case item.Put != nil:
-			tableName = aws.ToString(item.Put.TableName)
-		case item.Update != nil:
-			tableName = aws.ToString(item.Update.TableName)
-		case item.Delete != nil:
-			tableName = aws.ToString(item.Delete.TableName)
-		case item.ConditionCheck != nil:
-			tableName = aws.ToString(item.ConditionCheck.TableName)
-		}
-
-		if _, alreadySnapped := snapshots[tableName]; tableName == "" || alreadySnapped {
-			continue
-		}
-
-		table, tErr := fd.getTable(tableName)
-		if tErr != nil {
-			return nil, mapKnownError(tErr)
-		}
-
-		snapshots[tableName] = table.Snapshot()
-	}
-
 	n := len(input.TransactItems)
 
 	for i, item := range input.TransactItems {
-		switch {
-		case item.Put != nil:
-			if err = validateExpressionAttributes(item.Put.ExpressionAttributeNames, item.Put.ExpressionAttributeValues, aws.ToString(item.Put.ConditionExpression)); err != nil {
-				return nil, err
-			}
-
-			table, tErr := fd.getTable(aws.ToString(item.Put.TableName))
-			if tErr != nil {
-				return nil, mapKnownError(tErr)
-			}
-
-			if _, opErr := table.Put(mapDynamoToTypesTransactPut(item.Put)); opErr != nil {
-				return nil, newTransactionCancelledError(i, n, opErr)
-			}
-
-		case item.Update != nil:
-			if err = validateExpressionAttributes(item.Update.ExpressionAttributeNames, item.Update.ExpressionAttributeValues, aws.ToString(item.Update.UpdateExpression), aws.ToString(item.Update.ConditionExpression)); err != nil {
-				return nil, err
-			}
-
-			table, tErr := fd.getTable(aws.ToString(item.Update.TableName))
-			if tErr != nil {
-				return nil, mapKnownError(tErr)
-			}
-
-			_, opErr := table.Update(mapDynamoToTypesTransactUpdate(item.Update))
-			if opErr != nil {
-				if errors.Is(opErr, interpreter.ErrSyntaxError) {
-					return nil, &smithy.GenericAPIError{Code: "ValidationException", Message: opErr.Error()}
-				}
-
-				return nil, newTransactionCancelledError(i, n, opErr)
-			}
-
-		case item.Delete != nil:
-			if err = validateExpressionAttributes(item.Delete.ExpressionAttributeNames, item.Delete.ExpressionAttributeValues, aws.ToString(item.Delete.ConditionExpression)); err != nil {
-				return nil, err
-			}
-
-			table, tErr := fd.getTable(aws.ToString(item.Delete.TableName))
-			if tErr != nil {
-				return nil, mapKnownError(tErr)
-			}
-
-			if _, opErr := table.Delete(mapDynamoToTypesTransactDelete(item.Delete)); opErr != nil {
-				return nil, newTransactionCancelledError(i, n, opErr)
-			}
-
-		case item.ConditionCheck != nil:
-			if err = validateExpressionAttributes(item.ConditionCheck.ExpressionAttributeNames, item.ConditionCheck.ExpressionAttributeValues, aws.ToString(item.ConditionCheck.ConditionExpression)); err != nil {
-				return nil, err
-			}
-
-			table, tErr := fd.getTable(aws.ToString(item.ConditionCheck.TableName))
-			if tErr != nil {
-				return nil, mapKnownError(tErr)
-			}
-
-			keyMap := mapDynamoToTypesMapItem(item.ConditionCheck.Key)
-			if vErr := mtypes.ValidateItemMap(keyMap); vErr != nil {
-				return nil, mapKnownError(mtypes.NewError("ValidationException", vErr.Error(), nil))
-			}
-
-			if keyErr := table.ValidatePrimaryKeyMap(keyMap); keyErr != nil {
-				return nil, &smithy.GenericAPIError{Code: "ValidationException", Message: keyErr.Error()}
-			}
-
-			key, kErr := table.KeySchema.GetKey(table.AttributesDef, keyMap)
-			if kErr != nil {
-				return nil, &smithy.GenericAPIError{Code: "ValidationException", Message: kErr.Error()}
-			}
-
-			stored := table.Data[key]
-			if stored == nil {
-				stored = map[string]*mtypes.Item{}
-			}
-
-			matchInput := interpreter.MatchInput{
-				TableName:      table.Name,
-				Expression:     aws.ToString(item.ConditionCheck.ConditionExpression),
-				ExpressionType: interpreter.ExpressionTypeConditional,
-				Item:           stored,
-				Aliases:        item.ConditionCheck.ExpressionAttributeNames,
-				Attributes:     mapDynamoToTypesMapItem(item.ConditionCheck.ExpressionAttributeValues),
-			}
-
-			matched, mErr := table.InterpreterMatch(matchInput)
-			if mErr != nil {
-				return nil, &smithy.GenericAPIError{Code: "ValidationException", Message: mErr.Error()}
-			}
-
-			if !matched {
-				checkErr := &mtypes.ConditionalCheckFailedException{
-					MessageText: core.ErrConditionalRequestFailed.Error(),
-				}
-
-				if item.ConditionCheck.ReturnValuesOnConditionCheckFailure == types.ReturnValuesOnConditionCheckFailureAllOld {
-					checkErr.Item = stored
-				}
-
-				return nil, newTransactionCancelledError(i, n, checkErr)
-			}
-
-		default:
-			return nil, &smithy.GenericAPIError{Code: "ValidationException", Message: "transaction item must include one of Put, Update, Delete, or ConditionCheck"}
+		execErr = fd.runTransactItem(i, n, item)
+		if execErr != nil {
+			return nil, execErr
 		}
 	}
 
 	return &dynamodb.TransactWriteItemsOutput{}, nil
+}
+
+func (fd *Client) runTransactItem(i, n int, item types.TransactWriteItem) error {
+	switch {
+	case item.Put != nil:
+		return fd.runTransactPut(i, n, item.Put)
+	case item.Update != nil:
+		return fd.runTransactUpdate(i, n, item.Update)
+	case item.Delete != nil:
+		return fd.runTransactDelete(i, n, item.Delete)
+	case item.ConditionCheck != nil:
+		return fd.runTransactConditionCheck(i, n, item.ConditionCheck)
+	default:
+		return &smithy.GenericAPIError{Code: "ValidationException", Message: "transaction item must include one of Put, Update, Delete, or ConditionCheck"}
+	}
+}
+
+func (fd *Client) runTransactPut(i, n int, put *types.Put) error {
+	if vErr := validateExpressionAttributes(put.ExpressionAttributeNames, put.ExpressionAttributeValues, aws.ToString(put.ConditionExpression)); vErr != nil {
+		return vErr
+	}
+
+	table, tErr := fd.getTable(aws.ToString(put.TableName))
+	if tErr != nil {
+		return mapKnownError(tErr)
+	}
+
+	if _, opErr := table.Put(mapDynamoToTypesTransactPut(put)); opErr != nil {
+		return newTransactionCancelledError(i, n, opErr)
+	}
+
+	return nil
+}
+
+func (fd *Client) runTransactUpdate(i, n int, update *types.Update) error {
+	if vErr := validateExpressionAttributes(update.ExpressionAttributeNames, update.ExpressionAttributeValues, aws.ToString(update.UpdateExpression), aws.ToString(update.ConditionExpression)); vErr != nil {
+		return vErr
+	}
+
+	table, tErr := fd.getTable(aws.ToString(update.TableName))
+	if tErr != nil {
+		return mapKnownError(tErr)
+	}
+
+	_, opErr := table.Update(mapDynamoToTypesTransactUpdate(update))
+	if opErr != nil {
+		if errors.Is(opErr, interpreter.ErrSyntaxError) {
+			return &smithy.GenericAPIError{Code: "ValidationException", Message: opErr.Error()}
+		}
+
+		return newTransactionCancelledError(i, n, opErr)
+	}
+
+	return nil
+}
+
+func (fd *Client) runTransactDelete(i, n int, del *types.Delete) error {
+	if vErr := validateExpressionAttributes(del.ExpressionAttributeNames, del.ExpressionAttributeValues, aws.ToString(del.ConditionExpression)); vErr != nil {
+		return vErr
+	}
+
+	table, tErr := fd.getTable(aws.ToString(del.TableName))
+	if tErr != nil {
+		return mapKnownError(tErr)
+	}
+
+	if _, opErr := table.Delete(mapDynamoToTypesTransactDelete(del)); opErr != nil {
+		return newTransactionCancelledError(i, n, opErr)
+	}
+
+	return nil
+}
+
+func (fd *Client) runTransactConditionCheck(i, n int, check *types.ConditionCheck) error {
+	if vErr := validateExpressionAttributes(check.ExpressionAttributeNames, check.ExpressionAttributeValues, aws.ToString(check.ConditionExpression)); vErr != nil {
+		return vErr
+	}
+
+	table, tErr := fd.getTable(aws.ToString(check.TableName))
+	if tErr != nil {
+		return mapKnownError(tErr)
+	}
+
+	keyMap := mapDynamoToTypesMapItem(check.Key)
+	if vErr := mtypes.ValidateItemMap(keyMap); vErr != nil {
+		return mapKnownError(mtypes.NewError("ValidationException", vErr.Error(), nil))
+	}
+
+	if keyErr := table.ValidatePrimaryKeyMap(keyMap); keyErr != nil {
+		return &smithy.GenericAPIError{Code: "ValidationException", Message: keyErr.Error()}
+	}
+
+	key, kErr := table.KeySchema.GetKey(table.AttributesDef, keyMap)
+	if kErr != nil {
+		return &smithy.GenericAPIError{Code: "ValidationException", Message: kErr.Error()}
+	}
+
+	stored := table.Data[key]
+	if stored == nil {
+		stored = map[string]*mtypes.Item{}
+	}
+
+	matched, mErr := table.InterpreterMatch(interpreter.MatchInput{
+		TableName:      table.Name,
+		Expression:     aws.ToString(check.ConditionExpression),
+		ExpressionType: interpreter.ExpressionTypeConditional,
+		Item:           stored,
+		Aliases:        check.ExpressionAttributeNames,
+		Attributes:     mapDynamoToTypesMapItem(check.ExpressionAttributeValues),
+	})
+	if mErr != nil {
+		return &smithy.GenericAPIError{Code: "ValidationException", Message: mErr.Error()}
+	}
+
+	if !matched {
+		checkErr := &mtypes.ConditionalCheckFailedException{
+			MessageText: core.ErrConditionalRequestFailed.Error(),
+		}
+
+		if check.ReturnValuesOnConditionCheckFailure == types.ReturnValuesOnConditionCheckFailureAllOld {
+			checkErr.Item = stored
+		}
+
+		return newTransactionCancelledError(i, n, checkErr)
+	}
+
+	return nil
 }
 
 func newTransactionCancelledError(i, n int, opErr error) error {
@@ -882,6 +940,8 @@ func validateExpressionAttributes(exprNames map[string]string, exprValues map[st
 	missingValues := getMissingSubstrs(genericExpression, flattenValues)
 
 	if len(missingNames) > 0 {
+		sort.Strings(missingNames)
+
 		return &smithy.GenericAPIError{Code: "ValidationException", Message: fmt.Sprintf("%s: keys: {%s}", unusedExpressionAttributeNamesMsg, strings.Join(missingNames, ", "))}
 	}
 
@@ -891,6 +951,12 @@ func validateExpressionAttributes(exprNames map[string]string, exprValues map[st
 	}
 
 	if len(missingValues) > 0 {
+		if genericExpression == "" {
+			return &smithy.GenericAPIError{Code: "ValidationException", Message: expressionAttributeValuesOnlyWithExpressionsMsg}
+		}
+
+		sort.Strings(missingValues)
+
 		return &smithy.GenericAPIError{Code: "ValidationException", Message: fmt.Sprintf("%s: keys: {%s}", unusedExpressionAttributeValuesMsg, strings.Join(missingValues, ", "))}
 	}
 

--- a/aws-v2/client/client.go
+++ b/aws-v2/client/client.go
@@ -701,7 +701,9 @@ func (fd *Client) TransactWriteItems(ctx context.Context, input *dynamodb.Transa
 		snapshots[tableName] = table.Snapshot()
 	}
 
-	for _, item := range input.TransactItems {
+	n := len(input.TransactItems)
+
+	for i, item := range input.TransactItems {
 		switch {
 		case item.Put != nil:
 			if err = validateExpressionAttributes(item.Put.ExpressionAttributeNames, item.Put.ExpressionAttributeValues, aws.ToString(item.Put.ConditionExpression)); err != nil {
@@ -713,8 +715,8 @@ func (fd *Client) TransactWriteItems(ctx context.Context, input *dynamodb.Transa
 				return nil, mapKnownError(tErr)
 			}
 
-			if _, err = table.Put(mapDynamoToTypesTransactPut(item.Put)); err != nil {
-				return nil, mapKnownError(err)
+			if _, opErr := table.Put(mapDynamoToTypesTransactPut(item.Put)); opErr != nil {
+				return nil, newTransactionCancelledError(i, n, opErr)
 			}
 
 		case item.Update != nil:
@@ -727,13 +729,13 @@ func (fd *Client) TransactWriteItems(ctx context.Context, input *dynamodb.Transa
 				return nil, mapKnownError(tErr)
 			}
 
-			_, err = table.Update(mapDynamoToTypesTransactUpdate(item.Update))
-			if err != nil {
-				if errors.Is(err, interpreter.ErrSyntaxError) {
-					return nil, &smithy.GenericAPIError{Code: "ValidationException", Message: err.Error()}
+			_, opErr := table.Update(mapDynamoToTypesTransactUpdate(item.Update))
+			if opErr != nil {
+				if errors.Is(opErr, interpreter.ErrSyntaxError) {
+					return nil, &smithy.GenericAPIError{Code: "ValidationException", Message: opErr.Error()}
 				}
 
-				return nil, mapKnownError(err)
+				return nil, newTransactionCancelledError(i, n, opErr)
 			}
 
 		case item.Delete != nil:
@@ -746,8 +748,8 @@ func (fd *Client) TransactWriteItems(ctx context.Context, input *dynamodb.Transa
 				return nil, mapKnownError(tErr)
 			}
 
-			if _, err = table.Delete(mapDynamoToTypesTransactDelete(item.Delete)); err != nil {
-				return nil, mapKnownError(err)
+			if _, opErr := table.Delete(mapDynamoToTypesTransactDelete(item.Delete)); opErr != nil {
+				return nil, newTransactionCancelledError(i, n, opErr)
 			}
 
 		case item.ConditionCheck != nil:
@@ -802,7 +804,7 @@ func (fd *Client) TransactWriteItems(ctx context.Context, input *dynamodb.Transa
 					checkErr.Item = stored
 				}
 
-				return nil, mapKnownError(checkErr)
+				return nil, newTransactionCancelledError(i, n, checkErr)
 			}
 
 		default:
@@ -811,6 +813,32 @@ func (fd *Client) TransactWriteItems(ctx context.Context, input *dynamodb.Transa
 	}
 
 	return &dynamodb.TransactWriteItemsOutput{}, nil
+}
+
+func newTransactionCancelledError(i, n int, opErr error) error {
+	var ccf *mtypes.ConditionalCheckFailedException
+	if !errors.As(opErr, &ccf) {
+		return mapKnownError(opErr)
+	}
+
+	reasons := make([]types.CancellationReason, n)
+	for j := range reasons {
+		reasons[j] = types.CancellationReason{Code: aws.String("None")}
+	}
+
+	reasons[i] = types.CancellationReason{
+		Code:    aws.String("ConditionalCheckFailed"),
+		Message: aws.String(core.ErrConditionalRequestFailed.Error()),
+	}
+
+	if ccf.Item != nil {
+		reasons[i].Item = mapTypesToDynamoMapItem(ccf.Item)
+	}
+
+	return &types.TransactionCanceledException{
+		Message:             aws.String("Transaction cancelled, please refer cancellation reasons for specific reasons [ConditionalCheckFailed]"),
+		CancellationReasons: reasons,
+	}
 }
 
 func (fd *Client) getTable(tableName string) (*core.Table, error) {

--- a/aws-v2/client/client.go
+++ b/aws-v2/client/client.go
@@ -657,12 +657,158 @@ func handleBatchWriteRequestError(table string, req types.WriteRequest, unproces
 }
 
 // TransactWriteItems mock response for dynamodb
-func (fd *Client) TransactWriteItems(ctx context.Context, input *dynamodb.TransactWriteItemsInput, opts ...func(*dynamodb.Options)) (*dynamodb.TransactWriteItemsOutput, error) {
+func (fd *Client) TransactWriteItems(ctx context.Context, input *dynamodb.TransactWriteItemsInput, opts ...func(*dynamodb.Options)) (_ *dynamodb.TransactWriteItemsOutput, err error) {
+	fd.mu.Lock()
+	defer fd.mu.Unlock()
+
 	if fd.forceFailureErr != nil {
-		return nil, ErrForcedFailure
+		return nil, fd.forceFailureErr
 	}
 
-	// TODO: Implement transact write
+	snapshots := map[string]core.TableSnapshot{}
+
+	defer func() {
+		if err != nil {
+			for name, snap := range snapshots {
+				fd.tables[name].Restore(snap)
+			}
+		}
+	}()
+
+	for _, item := range input.TransactItems {
+		var tableName string
+
+		switch {
+		case item.Put != nil:
+			tableName = aws.ToString(item.Put.TableName)
+		case item.Update != nil:
+			tableName = aws.ToString(item.Update.TableName)
+		case item.Delete != nil:
+			tableName = aws.ToString(item.Delete.TableName)
+		case item.ConditionCheck != nil:
+			tableName = aws.ToString(item.ConditionCheck.TableName)
+		}
+
+		if _, alreadySnapped := snapshots[tableName]; tableName == "" || alreadySnapped {
+			continue
+		}
+
+		table, tErr := fd.getTable(tableName)
+		if tErr != nil {
+			return nil, mapKnownError(tErr)
+		}
+
+		snapshots[tableName] = table.Snapshot()
+	}
+
+	for _, item := range input.TransactItems {
+		switch {
+		case item.Put != nil:
+			if err = validateExpressionAttributes(item.Put.ExpressionAttributeNames, item.Put.ExpressionAttributeValues, aws.ToString(item.Put.ConditionExpression)); err != nil {
+				return nil, err
+			}
+
+			table, tErr := fd.getTable(aws.ToString(item.Put.TableName))
+			if tErr != nil {
+				return nil, mapKnownError(tErr)
+			}
+
+			if _, err = table.Put(mapDynamoToTypesTransactPut(item.Put)); err != nil {
+				return nil, mapKnownError(err)
+			}
+
+		case item.Update != nil:
+			if err = validateExpressionAttributes(item.Update.ExpressionAttributeNames, item.Update.ExpressionAttributeValues, aws.ToString(item.Update.UpdateExpression), aws.ToString(item.Update.ConditionExpression)); err != nil {
+				return nil, err
+			}
+
+			table, tErr := fd.getTable(aws.ToString(item.Update.TableName))
+			if tErr != nil {
+				return nil, mapKnownError(tErr)
+			}
+
+			_, err = table.Update(mapDynamoToTypesTransactUpdate(item.Update))
+			if err != nil {
+				if errors.Is(err, interpreter.ErrSyntaxError) {
+					return nil, &smithy.GenericAPIError{Code: "ValidationException", Message: err.Error()}
+				}
+
+				return nil, mapKnownError(err)
+			}
+
+		case item.Delete != nil:
+			if err = validateExpressionAttributes(item.Delete.ExpressionAttributeNames, item.Delete.ExpressionAttributeValues, aws.ToString(item.Delete.ConditionExpression)); err != nil {
+				return nil, err
+			}
+
+			table, tErr := fd.getTable(aws.ToString(item.Delete.TableName))
+			if tErr != nil {
+				return nil, mapKnownError(tErr)
+			}
+
+			if _, err = table.Delete(mapDynamoToTypesTransactDelete(item.Delete)); err != nil {
+				return nil, mapKnownError(err)
+			}
+
+		case item.ConditionCheck != nil:
+			if err = validateExpressionAttributes(item.ConditionCheck.ExpressionAttributeNames, item.ConditionCheck.ExpressionAttributeValues, aws.ToString(item.ConditionCheck.ConditionExpression)); err != nil {
+				return nil, err
+			}
+
+			table, tErr := fd.getTable(aws.ToString(item.ConditionCheck.TableName))
+			if tErr != nil {
+				return nil, mapKnownError(tErr)
+			}
+
+			keyMap := mapDynamoToTypesMapItem(item.ConditionCheck.Key)
+			if vErr := mtypes.ValidateItemMap(keyMap); vErr != nil {
+				return nil, mapKnownError(mtypes.NewError("ValidationException", vErr.Error(), nil))
+			}
+
+			if keyErr := table.ValidatePrimaryKeyMap(keyMap); keyErr != nil {
+				return nil, &smithy.GenericAPIError{Code: "ValidationException", Message: keyErr.Error()}
+			}
+
+			key, kErr := table.KeySchema.GetKey(table.AttributesDef, keyMap)
+			if kErr != nil {
+				return nil, &smithy.GenericAPIError{Code: "ValidationException", Message: kErr.Error()}
+			}
+
+			stored := table.Data[key]
+			if stored == nil {
+				stored = map[string]*mtypes.Item{}
+			}
+
+			matchInput := interpreter.MatchInput{
+				TableName:      table.Name,
+				Expression:     aws.ToString(item.ConditionCheck.ConditionExpression),
+				ExpressionType: interpreter.ExpressionTypeConditional,
+				Item:           stored,
+				Aliases:        item.ConditionCheck.ExpressionAttributeNames,
+				Attributes:     mapDynamoToTypesMapItem(item.ConditionCheck.ExpressionAttributeValues),
+			}
+
+			matched, mErr := table.InterpreterMatch(matchInput)
+			if mErr != nil {
+				return nil, &smithy.GenericAPIError{Code: "ValidationException", Message: mErr.Error()}
+			}
+
+			if !matched {
+				checkErr := &mtypes.ConditionalCheckFailedException{
+					MessageText: core.ErrConditionalRequestFailed.Error(),
+				}
+
+				if item.ConditionCheck.ReturnValuesOnConditionCheckFailure == types.ReturnValuesOnConditionCheckFailureAllOld {
+					checkErr.Item = stored
+				}
+
+				return nil, mapKnownError(checkErr)
+			}
+
+		default:
+			return nil, &smithy.GenericAPIError{Code: "ValidationException", Message: "transaction item must include one of Put, Update, Delete, or ConditionCheck"}
+		}
+	}
 
 	return &dynamodb.TransactWriteItemsOutput{}, nil
 }

--- a/aws-v2/client/client_test.go
+++ b/aws-v2/client/client_test.go
@@ -2194,7 +2194,7 @@ func TestTransactWriteItems(t *testing.T) {
 		c.Equal(&dynamodbtypes.AttributeValueMemberS{Value: "Bulbasaur"}, item["name"])
 	})
 
-	t.Run("update", func(t *testing.T) {
+	t.Run("update item", func(t *testing.T) {
 		c := require.New(t)
 		client := NewClient()
 
@@ -2225,7 +2225,7 @@ func TestTransactWriteItems(t *testing.T) {
 		c.Equal(&dynamodbtypes.AttributeValueMemberS{Value: "poison"}, item["second_type"])
 	})
 
-	t.Run("delete", func(t *testing.T) {
+	t.Run("delete item", func(t *testing.T) {
 		c := require.New(t)
 		client := NewClient()
 
@@ -2252,7 +2252,7 @@ func TestTransactWriteItems(t *testing.T) {
 		c.Empty(item)
 	})
 
-	t.Run("condition_check_pass", func(t *testing.T) {
+	t.Run("condition check pass", func(t *testing.T) {
 		c := require.New(t)
 		client := NewClient()
 
@@ -2276,7 +2276,7 @@ func TestTransactWriteItems(t *testing.T) {
 		c.NoError(err)
 	})
 
-	t.Run("condition_check_fail", func(t *testing.T) {
+	t.Run("condition check fail", func(t *testing.T) {
 		c := require.New(t)
 		client := NewClient()
 
@@ -2295,8 +2295,9 @@ func TestTransactWriteItems(t *testing.T) {
 			},
 		})
 
-		var condErr *dynamodbtypes.ConditionalCheckFailedException
-		c.True(errors.As(err, &condErr))
+		var tce *dynamodbtypes.TransactionCanceledException
+		c.True(errors.As(err, &tce))
+		c.Equal("ConditionalCheckFailed", aws.ToString(tce.CancellationReasons[0].Code))
 	})
 
 	t.Run("rollback on failure", func(t *testing.T) {
@@ -2436,8 +2437,8 @@ func TestTransactWriteItems(t *testing.T) {
 			},
 		})
 
-		var condErr *dynamodbtypes.ConditionalCheckFailedException
-		c.True(errors.As(err, &condErr))
+		var tce *dynamodbtypes.TransactionCanceledException
+		c.True(errors.As(err, &tce))
 
 		out, err := client.GetItem(context.Background(), &dynamodb.GetItemInput{
 			TableName: aws.String(secondTable),
@@ -2472,10 +2473,13 @@ func TestTransactWriteItems(t *testing.T) {
 			},
 		})
 
-		var condErr *dynamodbtypes.ConditionalCheckFailedException
-		c.True(errors.As(err, &condErr))
-		c.NotEmpty(condErr.Item)
-		c.Equal(&dynamodbtypes.AttributeValueMemberS{Value: "001"}, condErr.Item["id"])
+		var tce *dynamodbtypes.TransactionCanceledException
+		c.True(errors.As(err, &tce))
+
+		reason := tce.CancellationReasons[0]
+		c.Equal("ConditionalCheckFailed", aws.ToString(reason.Code))
+		c.NotEmpty(reason.Item)
+		c.Equal(&dynamodbtypes.AttributeValueMemberS{Value: "001"}, reason.Item["id"])
 	})
 
 	t.Run("force failure", func(t *testing.T) {

--- a/aws-v2/client/client_test.go
+++ b/aws-v2/client/client_test.go
@@ -2165,346 +2165,713 @@ func TestHandleBatchWriteRequestError(t *testing.T) {
 }
 
 func TestTransactWriteItems(t *testing.T) {
-	t.Run("put item", func(t *testing.T) {
-		c := require.New(t)
-		client := NewClient()
+	t.Run("atomicity", func(t *testing.T) {
+		t.Run("rollback on failure", func(t *testing.T) {
+			c := require.New(t)
+			client := NewClient()
 
-		err := ensurePokemonTable(client)
-		c.NoError(err)
+			err := ensurePokemonTable(client)
+			c.NoError(err)
 
-		output, err := client.TransactWriteItems(context.Background(), &dynamodb.TransactWriteItemsInput{
-			TransactItems: []dynamodbtypes.TransactWriteItem{
-				{
-					Put: &dynamodbtypes.Put{
-						TableName: aws.String(tableName),
-						Item: map[string]dynamodbtypes.AttributeValue{
-							"id":   &dynamodbtypes.AttributeValueMemberS{Value: "001"},
-							"type": &dynamodbtypes.AttributeValueMemberS{Value: "grass"},
-							"name": &dynamodbtypes.AttributeValueMemberS{Value: "Bulbasaur"},
+			_, err = client.TransactWriteItems(context.Background(), &dynamodb.TransactWriteItemsInput{
+				TransactItems: []dynamodbtypes.TransactWriteItem{
+					{
+						Put: &dynamodbtypes.Put{
+							TableName: aws.String(tableName),
+							Item: map[string]dynamodbtypes.AttributeValue{
+								"id":   &dynamodbtypes.AttributeValueMemberS{Value: "rollback-me"},
+								"type": &dynamodbtypes.AttributeValueMemberS{Value: "fire"},
+							},
+						},
+					},
+					{
+						ConditionCheck: &dynamodbtypes.ConditionCheck{
+							TableName:           aws.String(tableName),
+							Key:                 map[string]dynamodbtypes.AttributeValue{"id": &dynamodbtypes.AttributeValueMemberS{Value: "non-existent"}},
+							ConditionExpression: aws.String("attribute_exists(id)"),
 						},
 					},
 				},
-			},
+			})
+			c.Error(err)
+
+			item, err := getPokemon(client, "rollback-me")
+			c.NoError(err)
+			c.Empty(item)
 		})
-		c.NoError(err)
-		c.NotNil(output)
 
-		item, err := getPokemon(client, "001")
-		c.NoError(err)
-		c.Equal(&dynamodbtypes.AttributeValueMemberS{Value: "Bulbasaur"}, item["name"])
-	})
+		t.Run("rollback across tables", func(t *testing.T) {
+			c := require.New(t)
+			client := NewClient()
 
-	t.Run("update item", func(t *testing.T) {
-		c := require.New(t)
-		client := NewClient()
+			err := ensurePokemonTable(client)
+			c.NoError(err)
 
-		err := ensurePokemonTable(client)
-		c.NoError(err)
+			const secondTable = "items"
 
-		err = createPokemon(client, pokemon{ID: "001", Type: "grass", Name: "Bulbasaur"})
-		c.NoError(err)
+			err = AddTable(context.Background(), client, secondTable, "id", "")
+			c.NoError(err)
 
-		_, err = client.TransactWriteItems(context.Background(), &dynamodb.TransactWriteItemsInput{
-			TransactItems: []dynamodbtypes.TransactWriteItem{
-				{
-					Update: &dynamodbtypes.Update{
-						TableName:        aws.String(tableName),
-						Key:              map[string]dynamodbtypes.AttributeValue{"id": &dynamodbtypes.AttributeValueMemberS{Value: "001"}},
-						UpdateExpression: aws.String("SET second_type = :stype"),
-						ExpressionAttributeValues: map[string]dynamodbtypes.AttributeValue{
-							":stype": &dynamodbtypes.AttributeValueMemberS{Value: "poison"},
+			_, err = client.TransactWriteItems(context.Background(), &dynamodb.TransactWriteItemsInput{
+				TransactItems: []dynamodbtypes.TransactWriteItem{
+					{
+						Put: &dynamodbtypes.Put{
+							TableName: aws.String(secondTable),
+							Item: map[string]dynamodbtypes.AttributeValue{
+								"id": &dynamodbtypes.AttributeValueMemberS{Value: "should-rollback"},
+							},
+						},
+					},
+					{
+						ConditionCheck: &dynamodbtypes.ConditionCheck{
+							TableName:           aws.String(tableName),
+							Key:                 map[string]dynamodbtypes.AttributeValue{"id": &dynamodbtypes.AttributeValueMemberS{Value: "non-existent"}},
+							ConditionExpression: aws.String("attribute_exists(id)"),
 						},
 					},
 				},
-			},
-		})
-		c.NoError(err)
+			})
 
-		item, err := getPokemon(client, "001")
-		c.NoError(err)
-		c.Equal(&dynamodbtypes.AttributeValueMemberS{Value: "poison"}, item["second_type"])
-	})
+			var tce *dynamodbtypes.TransactionCanceledException
+			c.True(errors.As(err, &tce))
 
-	t.Run("delete item", func(t *testing.T) {
-		c := require.New(t)
-		client := NewClient()
-
-		err := ensurePokemonTable(client)
-		c.NoError(err)
-
-		err = createPokemon(client, pokemon{ID: "001", Type: "grass", Name: "Bulbasaur"})
-		c.NoError(err)
-
-		_, err = client.TransactWriteItems(context.Background(), &dynamodb.TransactWriteItemsInput{
-			TransactItems: []dynamodbtypes.TransactWriteItem{
-				{
-					Delete: &dynamodbtypes.Delete{
-						TableName: aws.String(tableName),
-						Key:       map[string]dynamodbtypes.AttributeValue{"id": &dynamodbtypes.AttributeValueMemberS{Value: "001"}},
-					},
+			out, err := client.GetItem(context.Background(), &dynamodb.GetItemInput{
+				TableName: aws.String(secondTable),
+				Key: map[string]dynamodbtypes.AttributeValue{
+					"id": &dynamodbtypes.AttributeValueMemberS{Value: "should-rollback"},
 				},
-			},
+			})
+			c.NoError(err)
+			c.Empty(out.Item)
 		})
-		c.NoError(err)
-
-		item, err := getPokemon(client, "001")
-		c.NoError(err)
-		c.Empty(item)
 	})
 
-	t.Run("condition check pass", func(t *testing.T) {
-		c := require.New(t)
-		client := NewClient()
+	t.Run("validation", func(t *testing.T) {
+		t.Run("empty item rejected", func(t *testing.T) {
+			c := require.New(t)
+			client := NewClient()
 
-		err := ensurePokemonTable(client)
-		c.NoError(err)
+			err := ensurePokemonTable(client)
+			c.NoError(err)
 
-		err = createPokemon(client, pokemon{ID: "001", Type: "grass", Name: "Bulbasaur"})
-		c.NoError(err)
+			_, err = client.TransactWriteItems(context.Background(), &dynamodb.TransactWriteItemsInput{
+				TransactItems: []dynamodbtypes.TransactWriteItem{{}},
+			})
 
-		_, err = client.TransactWriteItems(context.Background(), &dynamodb.TransactWriteItemsInput{
-			TransactItems: []dynamodbtypes.TransactWriteItem{
-				{
-					ConditionCheck: &dynamodbtypes.ConditionCheck{
-						TableName:           aws.String(tableName),
-						Key:                 map[string]dynamodbtypes.AttributeValue{"id": &dynamodbtypes.AttributeValueMemberS{Value: "001"}},
-						ConditionExpression: aws.String("attribute_exists(id)"),
+			var apiErr smithy.APIError
+			c.True(errors.As(err, &apiErr))
+			c.Equal("ValidationException", apiErr.ErrorCode())
+		})
+
+		t.Run("duplicate item rejected", func(t *testing.T) {
+			c := require.New(t)
+			client := NewClient()
+
+			err := ensurePokemonTable(client)
+			c.NoError(err)
+
+			_, err = client.TransactWriteItems(context.Background(), &dynamodb.TransactWriteItemsInput{
+				TransactItems: []dynamodbtypes.TransactWriteItem{
+					{
+						Put: &dynamodbtypes.Put{
+							TableName: aws.String(tableName),
+							Item:      map[string]dynamodbtypes.AttributeValue{"id": &dynamodbtypes.AttributeValueMemberS{Value: "001"}},
+						},
 					},
-				},
-			},
-		})
-		c.NoError(err)
-	})
-
-	t.Run("condition check fail", func(t *testing.T) {
-		c := require.New(t)
-		client := NewClient()
-
-		err := ensurePokemonTable(client)
-		c.NoError(err)
-
-		_, err = client.TransactWriteItems(context.Background(), &dynamodb.TransactWriteItemsInput{
-			TransactItems: []dynamodbtypes.TransactWriteItem{
-				{
-					ConditionCheck: &dynamodbtypes.ConditionCheck{
-						TableName:           aws.String(tableName),
-						Key:                 map[string]dynamodbtypes.AttributeValue{"id": &dynamodbtypes.AttributeValueMemberS{Value: "999"}},
-						ConditionExpression: aws.String("attribute_exists(id)"),
-					},
-				},
-			},
-		})
-
-		var tce *dynamodbtypes.TransactionCanceledException
-		c.True(errors.As(err, &tce))
-		c.Equal("ConditionalCheckFailed", aws.ToString(tce.CancellationReasons[0].Code))
-	})
-
-	t.Run("rollback on failure", func(t *testing.T) {
-		c := require.New(t)
-		client := NewClient()
-
-		err := ensurePokemonTable(client)
-		c.NoError(err)
-
-		_, err = client.TransactWriteItems(context.Background(), &dynamodb.TransactWriteItemsInput{
-			TransactItems: []dynamodbtypes.TransactWriteItem{
-				{
-					Put: &dynamodbtypes.Put{
-						TableName: aws.String(tableName),
-						Item: map[string]dynamodbtypes.AttributeValue{
-							"id":   &dynamodbtypes.AttributeValueMemberS{Value: "rollback-me"},
-							"type": &dynamodbtypes.AttributeValueMemberS{Value: "fire"},
+					{
+						Update: &dynamodbtypes.Update{
+							TableName:                 aws.String(tableName),
+							Key:                       map[string]dynamodbtypes.AttributeValue{"id": &dynamodbtypes.AttributeValueMemberS{Value: "001"}},
+							UpdateExpression:          aws.String("SET #n = :n"),
+							ExpressionAttributeNames:  map[string]string{"#n": "name"},
+							ExpressionAttributeValues: map[string]dynamodbtypes.AttributeValue{":n": &dynamodbtypes.AttributeValueMemberS{Value: "Bulbasaur"}},
 						},
 					},
 				},
-				{
-					ConditionCheck: &dynamodbtypes.ConditionCheck{
-						TableName:           aws.String(tableName),
-						Key:                 map[string]dynamodbtypes.AttributeValue{"id": &dynamodbtypes.AttributeValueMemberS{Value: "non-existent"}},
-						ConditionExpression: aws.String("attribute_exists(id)"),
-					},
-				},
-			},
-		})
-		c.Error(err)
+			})
 
-		item, err := getPokemon(client, "rollback-me")
-		c.NoError(err)
-		c.Empty(item)
+			var apiErr smithy.APIError
+			c.True(errors.As(err, &apiErr))
+			c.Equal("ValidationException", apiErr.ErrorCode())
+		})
 	})
 
-	t.Run("emulated server error", func(t *testing.T) {
-		c := require.New(t)
-		client := NewClient()
+	t.Run("error injection", func(t *testing.T) {
+		t.Run("emulated server error", func(t *testing.T) {
+			c := require.New(t)
+			client := NewClient()
 
-		err := ensurePokemonTable(client)
-		c.NoError(err)
+			err := ensurePokemonTable(client)
+			c.NoError(err)
 
-		EmulateFailure(client, FailureConditionInternalServerError)
-		defer EmulateFailure(client, FailureConditionNone)
+			EmulateFailure(client, FailureConditionInternalServerError)
+			defer EmulateFailure(client, FailureConditionNone)
 
-		_, err = client.TransactWriteItems(context.Background(), &dynamodb.TransactWriteItemsInput{
-			TransactItems: []dynamodbtypes.TransactWriteItem{
-				{
-					Put: &dynamodbtypes.Put{
-						TableName: aws.String(tableName),
-						Item: map[string]dynamodbtypes.AttributeValue{
-							"id": &dynamodbtypes.AttributeValueMemberS{Value: "001"},
+			_, err = client.TransactWriteItems(context.Background(), &dynamodb.TransactWriteItemsInput{
+				TransactItems: []dynamodbtypes.TransactWriteItem{
+					{
+						Put: &dynamodbtypes.Put{
+							TableName: aws.String(tableName),
+							Item: map[string]dynamodbtypes.AttributeValue{
+								"id": &dynamodbtypes.AttributeValueMemberS{Value: "001"},
+							},
 						},
 					},
 				},
-			},
+			})
+
+			var internalErr *dynamodbtypes.InternalServerError
+			c.True(errors.As(err, &internalErr))
 		})
 
-		var internalErr *dynamodbtypes.InternalServerError
-		c.True(errors.As(err, &internalErr))
-	})
+		t.Run("force failure", func(t *testing.T) {
+			c := require.New(t)
+			client := NewClient()
 
-	t.Run("unused expression attribute rejected", func(t *testing.T) {
-		c := require.New(t)
-		client := NewClient()
+			err := ensurePokemonTable(client)
+			c.NoError(err)
 
-		err := ensurePokemonTable(client)
-		c.NoError(err)
+			ActiveForceFailure(client)
+			defer DeactiveForceFailure(client)
 
-		_, err = client.TransactWriteItems(context.Background(), &dynamodb.TransactWriteItemsInput{
-			TransactItems: []dynamodbtypes.TransactWriteItem{
-				{
-					Put: &dynamodbtypes.Put{
-						TableName: aws.String(tableName),
-						Item: map[string]dynamodbtypes.AttributeValue{
-							"id": &dynamodbtypes.AttributeValueMemberS{Value: "001"},
-						},
-						ExpressionAttributeValues: map[string]dynamodbtypes.AttributeValue{
-							":unused": &dynamodbtypes.AttributeValueMemberS{Value: "x"},
-						},
-					},
-				},
-			},
-		})
-
-		var apiErr smithy.APIError
-		c.True(errors.As(err, &apiErr))
-		c.Equal("ValidationException", apiErr.ErrorCode())
-	})
-
-	t.Run("empty item rejected", func(t *testing.T) {
-		c := require.New(t)
-		client := NewClient()
-
-		err := ensurePokemonTable(client)
-		c.NoError(err)
-
-		_, err = client.TransactWriteItems(context.Background(), &dynamodb.TransactWriteItemsInput{
-			TransactItems: []dynamodbtypes.TransactWriteItem{{}},
-		})
-
-		var apiErr smithy.APIError
-		c.True(errors.As(err, &apiErr))
-		c.Equal("ValidationException", apiErr.ErrorCode())
-	})
-
-	t.Run("rollback across tables", func(t *testing.T) {
-		c := require.New(t)
-		client := NewClient()
-
-		err := ensurePokemonTable(client)
-		c.NoError(err)
-
-		const secondTable = "items"
-
-		err = AddTable(context.Background(), client, secondTable, "id", "")
-		c.NoError(err)
-
-		_, err = client.TransactWriteItems(context.Background(), &dynamodb.TransactWriteItemsInput{
-			TransactItems: []dynamodbtypes.TransactWriteItem{
-				{
-					Put: &dynamodbtypes.Put{
-						TableName: aws.String(secondTable),
-						Item: map[string]dynamodbtypes.AttributeValue{
-							"id": &dynamodbtypes.AttributeValueMemberS{Value: "should-rollback"},
+			_, err = client.TransactWriteItems(context.Background(), &dynamodb.TransactWriteItemsInput{
+				TransactItems: []dynamodbtypes.TransactWriteItem{
+					{
+						Put: &dynamodbtypes.Put{
+							TableName: aws.String(tableName),
+							Item: map[string]dynamodbtypes.AttributeValue{
+								"id": &dynamodbtypes.AttributeValueMemberS{Value: "001"},
+							},
 						},
 					},
 				},
-				{
-					ConditionCheck: &dynamodbtypes.ConditionCheck{
-						TableName:           aws.String(tableName),
-						Key:                 map[string]dynamodbtypes.AttributeValue{"id": &dynamodbtypes.AttributeValueMemberS{Value: "non-existent"}},
-						ConditionExpression: aws.String("attribute_exists(id)"),
-					},
-				},
-			},
+			})
+			c.Equal(ErrForcedFailure, err)
 		})
-
-		var tce *dynamodbtypes.TransactionCanceledException
-		c.True(errors.As(err, &tce))
-
-		out, err := client.GetItem(context.Background(), &dynamodb.GetItemInput{
-			TableName: aws.String(secondTable),
-			Key: map[string]dynamodbtypes.AttributeValue{
-				"id": &dynamodbtypes.AttributeValueMemberS{Value: "should-rollback"},
-			},
-		})
-		c.NoError(err)
-		c.Empty(out.Item)
 	})
 
-	t.Run("condition check returns old item on fail", func(t *testing.T) {
-		c := require.New(t)
-		client := NewClient()
+	t.Run("put", func(t *testing.T) {
+		t.Run("success", func(t *testing.T) {
+			c := require.New(t)
+			client := NewClient()
 
-		err := ensurePokemonTable(client)
-		c.NoError(err)
+			err := ensurePokemonTable(client)
+			c.NoError(err)
 
-		err = createPokemon(client, pokemon{ID: "001", Type: "grass", Name: "Bulbasaur"})
-		c.NoError(err)
-
-		_, err = client.TransactWriteItems(context.Background(), &dynamodb.TransactWriteItemsInput{
-			TransactItems: []dynamodbtypes.TransactWriteItem{
-				{
-					ConditionCheck: &dynamodbtypes.ConditionCheck{
-						TableName:                           aws.String(tableName),
-						Key:                                 map[string]dynamodbtypes.AttributeValue{"id": &dynamodbtypes.AttributeValueMemberS{Value: "001"}},
-						ConditionExpression:                 aws.String("attribute_not_exists(id)"),
-						ReturnValuesOnConditionCheckFailure: dynamodbtypes.ReturnValuesOnConditionCheckFailureAllOld,
-					},
-				},
-			},
-		})
-
-		var tce *dynamodbtypes.TransactionCanceledException
-		c.True(errors.As(err, &tce))
-
-		reason := tce.CancellationReasons[0]
-		c.Equal("ConditionalCheckFailed", aws.ToString(reason.Code))
-		c.NotEmpty(reason.Item)
-		c.Equal(&dynamodbtypes.AttributeValueMemberS{Value: "001"}, reason.Item["id"])
-	})
-
-	t.Run("force failure", func(t *testing.T) {
-		c := require.New(t)
-		client := NewClient()
-
-		err := ensurePokemonTable(client)
-		c.NoError(err)
-
-		ActiveForceFailure(client)
-		defer DeactiveForceFailure(client)
-
-		_, err = client.TransactWriteItems(context.Background(), &dynamodb.TransactWriteItemsInput{
-			TransactItems: []dynamodbtypes.TransactWriteItem{
-				{
-					Put: &dynamodbtypes.Put{
-						TableName: aws.String(tableName),
-						Item: map[string]dynamodbtypes.AttributeValue{
-							"id": &dynamodbtypes.AttributeValueMemberS{Value: "001"},
+			output, err := client.TransactWriteItems(context.Background(), &dynamodb.TransactWriteItemsInput{
+				TransactItems: []dynamodbtypes.TransactWriteItem{
+					{
+						Put: &dynamodbtypes.Put{
+							TableName: aws.String(tableName),
+							Item: map[string]dynamodbtypes.AttributeValue{
+								"id":   &dynamodbtypes.AttributeValueMemberS{Value: "001"},
+								"type": &dynamodbtypes.AttributeValueMemberS{Value: "grass"},
+								"name": &dynamodbtypes.AttributeValueMemberS{Value: "Bulbasaur"},
+							},
 						},
 					},
 				},
-			},
+			})
+			c.NoError(err)
+			c.NotNil(output)
+
+			item, err := getPokemon(client, "001")
+			c.NoError(err)
+			c.Equal(&dynamodbtypes.AttributeValueMemberS{Value: "Bulbasaur"}, item["name"])
 		})
-		c.Equal(ErrForcedFailure, err)
+
+		t.Run("non-existent table", func(t *testing.T) {
+			c := require.New(t)
+			client := NewClient()
+
+			_, err := client.TransactWriteItems(context.Background(), &dynamodb.TransactWriteItemsInput{
+				TransactItems: []dynamodbtypes.TransactWriteItem{
+					{
+						Put: &dynamodbtypes.Put{
+							TableName: aws.String("non-existent"),
+							Item:      map[string]dynamodbtypes.AttributeValue{"id": &dynamodbtypes.AttributeValueMemberS{Value: "1"}},
+						},
+					},
+				},
+			})
+
+			var notFound *dynamodbtypes.ResourceNotFoundException
+			c.True(errors.As(err, &notFound))
+		})
+
+		t.Run("unused expression attribute", func(t *testing.T) {
+			c := require.New(t)
+			client := NewClient()
+
+			err := ensurePokemonTable(client)
+			c.NoError(err)
+
+			_, err = client.TransactWriteItems(context.Background(), &dynamodb.TransactWriteItemsInput{
+				TransactItems: []dynamodbtypes.TransactWriteItem{
+					{
+						Put: &dynamodbtypes.Put{
+							TableName: aws.String(tableName),
+							Item: map[string]dynamodbtypes.AttributeValue{
+								"id": &dynamodbtypes.AttributeValueMemberS{Value: "001"},
+							},
+							ExpressionAttributeValues: map[string]dynamodbtypes.AttributeValue{
+								":unused": &dynamodbtypes.AttributeValueMemberS{Value: "x"},
+							},
+						},
+					},
+				},
+			})
+
+			var apiErr smithy.APIError
+			c.True(errors.As(err, &apiErr))
+			c.Equal("ValidationException", apiErr.ErrorCode())
+		})
+
+		t.Run("failing condition", func(t *testing.T) {
+			c := require.New(t)
+			client := NewClient()
+
+			err := ensurePokemonTable(client)
+			c.NoError(err)
+
+			err = createPokemon(client, pokemon{ID: "001", Type: "grass", Name: "Bulbasaur"})
+			c.NoError(err)
+
+			_, err = client.TransactWriteItems(context.Background(), &dynamodb.TransactWriteItemsInput{
+				TransactItems: []dynamodbtypes.TransactWriteItem{
+					{
+						Put: &dynamodbtypes.Put{
+							TableName:           aws.String(tableName),
+							Item:                map[string]dynamodbtypes.AttributeValue{"id": &dynamodbtypes.AttributeValueMemberS{Value: "001"}},
+							ConditionExpression: aws.String("attribute_not_exists(id)"),
+						},
+					},
+				},
+			})
+
+			var tce *dynamodbtypes.TransactionCanceledException
+			c.True(errors.As(err, &tce))
+			c.Equal("ConditionalCheckFailed", aws.ToString(tce.CancellationReasons[0].Code))
+		})
+	})
+
+	t.Run("update", func(t *testing.T) {
+		t.Run("success", func(t *testing.T) {
+			c := require.New(t)
+			client := NewClient()
+
+			err := ensurePokemonTable(client)
+			c.NoError(err)
+
+			err = createPokemon(client, pokemon{ID: "001", Type: "grass", Name: "Bulbasaur"})
+			c.NoError(err)
+
+			_, err = client.TransactWriteItems(context.Background(), &dynamodb.TransactWriteItemsInput{
+				TransactItems: []dynamodbtypes.TransactWriteItem{
+					{
+						Update: &dynamodbtypes.Update{
+							TableName:        aws.String(tableName),
+							Key:              map[string]dynamodbtypes.AttributeValue{"id": &dynamodbtypes.AttributeValueMemberS{Value: "001"}},
+							UpdateExpression: aws.String("SET second_type = :stype"),
+							ExpressionAttributeValues: map[string]dynamodbtypes.AttributeValue{
+								":stype": &dynamodbtypes.AttributeValueMemberS{Value: "poison"},
+							},
+						},
+					},
+				},
+			})
+			c.NoError(err)
+
+			item, err := getPokemon(client, "001")
+			c.NoError(err)
+			c.Equal(&dynamodbtypes.AttributeValueMemberS{Value: "poison"}, item["second_type"])
+		})
+
+		t.Run("non-existent table", func(t *testing.T) {
+			c := require.New(t)
+			client := NewClient()
+
+			_, err := client.TransactWriteItems(context.Background(), &dynamodb.TransactWriteItemsInput{
+				TransactItems: []dynamodbtypes.TransactWriteItem{
+					{
+						Update: &dynamodbtypes.Update{
+							TableName:                 aws.String("non-existent"),
+							Key:                       map[string]dynamodbtypes.AttributeValue{"id": &dynamodbtypes.AttributeValueMemberS{Value: "1"}},
+							UpdateExpression:          aws.String("SET #n = :n"),
+							ExpressionAttributeNames:  map[string]string{"#n": "name"},
+							ExpressionAttributeValues: map[string]dynamodbtypes.AttributeValue{":n": &dynamodbtypes.AttributeValueMemberS{Value: "x"}},
+						},
+					},
+				},
+			})
+
+			var notFound *dynamodbtypes.ResourceNotFoundException
+			c.True(errors.As(err, &notFound))
+		})
+
+		t.Run("unused expression attribute", func(t *testing.T) {
+			c := require.New(t)
+			client := NewClient()
+
+			err := ensurePokemonTable(client)
+			c.NoError(err)
+
+			_, err = client.TransactWriteItems(context.Background(), &dynamodb.TransactWriteItemsInput{
+				TransactItems: []dynamodbtypes.TransactWriteItem{
+					{
+						Update: &dynamodbtypes.Update{
+							TableName:                aws.String(tableName),
+							Key:                      map[string]dynamodbtypes.AttributeValue{"id": &dynamodbtypes.AttributeValueMemberS{Value: "001"}},
+							UpdateExpression:         aws.String("SET #n = :n"),
+							ExpressionAttributeNames: map[string]string{"#n": "name"},
+							ExpressionAttributeValues: map[string]dynamodbtypes.AttributeValue{
+								":n":      &dynamodbtypes.AttributeValueMemberS{Value: "Venusaur"},
+								":unused": &dynamodbtypes.AttributeValueMemberS{Value: "x"},
+							},
+						},
+					},
+				},
+			})
+
+			var apiErr smithy.APIError
+			c.True(errors.As(err, &apiErr))
+			c.Equal("ValidationException", apiErr.ErrorCode())
+		})
+
+		t.Run("syntax error", func(t *testing.T) {
+			c := require.New(t)
+			client := NewClient()
+
+			err := ensurePokemonTable(client)
+			c.NoError(err)
+
+			err = createPokemon(client, pokemon{ID: "001", Type: "grass", Name: "Bulbasaur"})
+			c.NoError(err)
+
+			_, err = client.TransactWriteItems(context.Background(), &dynamodb.TransactWriteItemsInput{
+				TransactItems: []dynamodbtypes.TransactWriteItem{
+					{
+						Update: &dynamodbtypes.Update{
+							TableName:                 aws.String(tableName),
+							Key:                       map[string]dynamodbtypes.AttributeValue{"id": &dynamodbtypes.AttributeValueMemberS{Value: "001"}},
+							UpdateExpression:          aws.String("SET #n = :n SET #n = :n"),
+							ExpressionAttributeNames:  map[string]string{"#n": "name"},
+							ExpressionAttributeValues: map[string]dynamodbtypes.AttributeValue{":n": &dynamodbtypes.AttributeValueMemberS{Value: "Venusaur"}},
+						},
+					},
+				},
+			})
+
+			var apiErr smithy.APIError
+			c.True(errors.As(err, &apiErr))
+			c.Equal("ValidationException", apiErr.ErrorCode())
+		})
+
+		t.Run("failing condition", func(t *testing.T) {
+			c := require.New(t)
+			client := NewClient()
+
+			err := ensurePokemonTable(client)
+			c.NoError(err)
+
+			err = createPokemon(client, pokemon{ID: "001", Type: "grass", Name: "Bulbasaur"})
+			c.NoError(err)
+
+			_, err = client.TransactWriteItems(context.Background(), &dynamodb.TransactWriteItemsInput{
+				TransactItems: []dynamodbtypes.TransactWriteItem{
+					{
+						Update: &dynamodbtypes.Update{
+							TableName:                 aws.String(tableName),
+							Key:                       map[string]dynamodbtypes.AttributeValue{"id": &dynamodbtypes.AttributeValueMemberS{Value: "001"}},
+							UpdateExpression:          aws.String("SET #n = :n"),
+							ConditionExpression:       aws.String("attribute_not_exists(id)"),
+							ExpressionAttributeNames:  map[string]string{"#n": "name"},
+							ExpressionAttributeValues: map[string]dynamodbtypes.AttributeValue{":n": &dynamodbtypes.AttributeValueMemberS{Value: "Venusaur"}},
+						},
+					},
+				},
+			})
+
+			var tce *dynamodbtypes.TransactionCanceledException
+			c.True(errors.As(err, &tce))
+			c.Equal("ConditionalCheckFailed", aws.ToString(tce.CancellationReasons[0].Code))
+		})
+	})
+
+	t.Run("delete", func(t *testing.T) {
+		t.Run("success", func(t *testing.T) {
+			c := require.New(t)
+			client := NewClient()
+
+			err := ensurePokemonTable(client)
+			c.NoError(err)
+
+			err = createPokemon(client, pokemon{ID: "001", Type: "grass", Name: "Bulbasaur"})
+			c.NoError(err)
+
+			_, err = client.TransactWriteItems(context.Background(), &dynamodb.TransactWriteItemsInput{
+				TransactItems: []dynamodbtypes.TransactWriteItem{
+					{
+						Delete: &dynamodbtypes.Delete{
+							TableName: aws.String(tableName),
+							Key:       map[string]dynamodbtypes.AttributeValue{"id": &dynamodbtypes.AttributeValueMemberS{Value: "001"}},
+						},
+					},
+				},
+			})
+			c.NoError(err)
+
+			item, err := getPokemon(client, "001")
+			c.NoError(err)
+			c.Empty(item)
+		})
+
+		t.Run("non-existent table", func(t *testing.T) {
+			c := require.New(t)
+			client := NewClient()
+
+			_, err := client.TransactWriteItems(context.Background(), &dynamodb.TransactWriteItemsInput{
+				TransactItems: []dynamodbtypes.TransactWriteItem{
+					{
+						Delete: &dynamodbtypes.Delete{
+							TableName: aws.String("non-existent"),
+							Key:       map[string]dynamodbtypes.AttributeValue{"id": &dynamodbtypes.AttributeValueMemberS{Value: "1"}},
+						},
+					},
+				},
+			})
+
+			var notFound *dynamodbtypes.ResourceNotFoundException
+			c.True(errors.As(err, &notFound))
+		})
+
+		t.Run("unused expression attribute", func(t *testing.T) {
+			c := require.New(t)
+			client := NewClient()
+
+			err := ensurePokemonTable(client)
+			c.NoError(err)
+
+			_, err = client.TransactWriteItems(context.Background(), &dynamodb.TransactWriteItemsInput{
+				TransactItems: []dynamodbtypes.TransactWriteItem{
+					{
+						Delete: &dynamodbtypes.Delete{
+							TableName:                aws.String(tableName),
+							Key:                      map[string]dynamodbtypes.AttributeValue{"id": &dynamodbtypes.AttributeValueMemberS{Value: "001"}},
+							ExpressionAttributeNames: map[string]string{"#unused": "name"},
+						},
+					},
+				},
+			})
+
+			var apiErr smithy.APIError
+			c.True(errors.As(err, &apiErr))
+			c.Equal("ValidationException", apiErr.ErrorCode())
+		})
+
+		t.Run("failing condition", func(t *testing.T) {
+			c := require.New(t)
+			client := NewClient()
+
+			err := ensurePokemonTable(client)
+			c.NoError(err)
+
+			err = createPokemon(client, pokemon{ID: "001", Type: "grass", Name: "Bulbasaur"})
+			c.NoError(err)
+
+			_, err = client.TransactWriteItems(context.Background(), &dynamodb.TransactWriteItemsInput{
+				TransactItems: []dynamodbtypes.TransactWriteItem{
+					{
+						Delete: &dynamodbtypes.Delete{
+							TableName:           aws.String(tableName),
+							Key:                 map[string]dynamodbtypes.AttributeValue{"id": &dynamodbtypes.AttributeValueMemberS{Value: "001"}},
+							ConditionExpression: aws.String("attribute_not_exists(id)"),
+						},
+					},
+				},
+			})
+
+			var tce *dynamodbtypes.TransactionCanceledException
+			c.True(errors.As(err, &tce))
+			c.Equal("ConditionalCheckFailed", aws.ToString(tce.CancellationReasons[0].Code))
+		})
+	})
+
+	t.Run("condition check", func(t *testing.T) {
+		t.Run("pass", func(t *testing.T) {
+			c := require.New(t)
+			client := NewClient()
+
+			err := ensurePokemonTable(client)
+			c.NoError(err)
+
+			err = createPokemon(client, pokemon{ID: "001", Type: "grass", Name: "Bulbasaur"})
+			c.NoError(err)
+
+			_, err = client.TransactWriteItems(context.Background(), &dynamodb.TransactWriteItemsInput{
+				TransactItems: []dynamodbtypes.TransactWriteItem{
+					{
+						ConditionCheck: &dynamodbtypes.ConditionCheck{
+							TableName:           aws.String(tableName),
+							Key:                 map[string]dynamodbtypes.AttributeValue{"id": &dynamodbtypes.AttributeValueMemberS{Value: "001"}},
+							ConditionExpression: aws.String("attribute_exists(id)"),
+						},
+					},
+				},
+			})
+			c.NoError(err)
+		})
+
+		t.Run("fail", func(t *testing.T) {
+			c := require.New(t)
+			client := NewClient()
+
+			err := ensurePokemonTable(client)
+			c.NoError(err)
+
+			_, err = client.TransactWriteItems(context.Background(), &dynamodb.TransactWriteItemsInput{
+				TransactItems: []dynamodbtypes.TransactWriteItem{
+					{
+						ConditionCheck: &dynamodbtypes.ConditionCheck{
+							TableName:           aws.String(tableName),
+							Key:                 map[string]dynamodbtypes.AttributeValue{"id": &dynamodbtypes.AttributeValueMemberS{Value: "999"}},
+							ConditionExpression: aws.String("attribute_exists(id)"),
+						},
+					},
+				},
+			})
+
+			var tce *dynamodbtypes.TransactionCanceledException
+			c.True(errors.As(err, &tce))
+			c.Equal("ConditionalCheckFailed", aws.ToString(tce.CancellationReasons[0].Code))
+		})
+
+		t.Run("returns old item on fail", func(t *testing.T) {
+			c := require.New(t)
+			client := NewClient()
+
+			err := ensurePokemonTable(client)
+			c.NoError(err)
+
+			err = createPokemon(client, pokemon{ID: "001", Type: "grass", Name: "Bulbasaur"})
+			c.NoError(err)
+
+			_, err = client.TransactWriteItems(context.Background(), &dynamodb.TransactWriteItemsInput{
+				TransactItems: []dynamodbtypes.TransactWriteItem{
+					{
+						ConditionCheck: &dynamodbtypes.ConditionCheck{
+							TableName:                           aws.String(tableName),
+							Key:                                 map[string]dynamodbtypes.AttributeValue{"id": &dynamodbtypes.AttributeValueMemberS{Value: "001"}},
+							ConditionExpression:                 aws.String("attribute_not_exists(id)"),
+							ReturnValuesOnConditionCheckFailure: dynamodbtypes.ReturnValuesOnConditionCheckFailureAllOld,
+						},
+					},
+				},
+			})
+
+			var tce *dynamodbtypes.TransactionCanceledException
+			c.True(errors.As(err, &tce))
+
+			reason := tce.CancellationReasons[0]
+			c.Equal("ConditionalCheckFailed", aws.ToString(reason.Code))
+			c.NotEmpty(reason.Item)
+			c.Equal(&dynamodbtypes.AttributeValueMemberS{Value: "001"}, reason.Item["id"])
+		})
+
+		t.Run("non-existent table", func(t *testing.T) {
+			c := require.New(t)
+			client := NewClient()
+
+			_, err := client.TransactWriteItems(context.Background(), &dynamodb.TransactWriteItemsInput{
+				TransactItems: []dynamodbtypes.TransactWriteItem{
+					{
+						ConditionCheck: &dynamodbtypes.ConditionCheck{
+							TableName:           aws.String("non-existent"),
+							Key:                 map[string]dynamodbtypes.AttributeValue{"id": &dynamodbtypes.AttributeValueMemberS{Value: "1"}},
+							ConditionExpression: aws.String("attribute_exists(id)"),
+						},
+					},
+				},
+			})
+
+			var notFound *dynamodbtypes.ResourceNotFoundException
+			c.True(errors.As(err, &notFound))
+		})
+
+		t.Run("wrong key attributes", func(t *testing.T) {
+			c := require.New(t)
+			client := NewClient()
+
+			err := ensurePokemonTable(client)
+			c.NoError(err)
+
+			_, err = client.TransactWriteItems(context.Background(), &dynamodb.TransactWriteItemsInput{
+				TransactItems: []dynamodbtypes.TransactWriteItem{
+					{
+						ConditionCheck: &dynamodbtypes.ConditionCheck{
+							TableName:           aws.String(tableName),
+							Key:                 map[string]dynamodbtypes.AttributeValue{"wrong_attr": &dynamodbtypes.AttributeValueMemberS{Value: "1"}},
+							ConditionExpression: aws.String("attribute_exists(id)"),
+						},
+					},
+				},
+			})
+
+			var apiErr smithy.APIError
+			c.True(errors.As(err, &apiErr))
+			c.Equal("ValidationException", apiErr.ErrorCode())
+		})
+
+		t.Run("wrong key type", func(t *testing.T) {
+			c := require.New(t)
+			client := NewClient()
+
+			err := ensurePokemonTable(client)
+			c.NoError(err)
+
+			_, err = client.TransactWriteItems(context.Background(), &dynamodb.TransactWriteItemsInput{
+				TransactItems: []dynamodbtypes.TransactWriteItem{
+					{
+						ConditionCheck: &dynamodbtypes.ConditionCheck{
+							TableName:           aws.String(tableName),
+							Key:                 map[string]dynamodbtypes.AttributeValue{"id": &dynamodbtypes.AttributeValueMemberN{Value: "1"}},
+							ConditionExpression: aws.String("attribute_exists(id)"),
+						},
+					},
+				},
+			})
+
+			var apiErr smithy.APIError
+			c.True(errors.As(err, &apiErr))
+			c.Equal("ValidationException", apiErr.ErrorCode())
+		})
+
+		t.Run("invalid expression", func(t *testing.T) {
+			c := require.New(t)
+			client := NewClient()
+
+			err := ensurePokemonTable(client)
+			c.NoError(err)
+
+			err = createPokemon(client, pokemon{ID: "001", Type: "grass", Name: "Bulbasaur"})
+			c.NoError(err)
+
+			_, err = client.TransactWriteItems(context.Background(), &dynamodb.TransactWriteItemsInput{
+				TransactItems: []dynamodbtypes.TransactWriteItem{
+					{
+						ConditionCheck: &dynamodbtypes.ConditionCheck{
+							TableName:           aws.String(tableName),
+							Key:                 map[string]dynamodbtypes.AttributeValue{"id": &dynamodbtypes.AttributeValueMemberS{Value: "001"}},
+							ConditionExpression: aws.String("UNKNOWN_FUNCTION(id)"),
+						},
+					},
+				},
+			})
+
+			var apiErr smithy.APIError
+			c.True(errors.As(err, &apiErr))
+			c.Equal("ValidationException", apiErr.ErrorCode())
+		})
 	})
 }
 

--- a/aws-v2/client/client_test.go
+++ b/aws-v2/client/client_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"testing"
-	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -2166,50 +2165,343 @@ func TestHandleBatchWriteRequestError(t *testing.T) {
 }
 
 func TestTransactWriteItems(t *testing.T) {
-	c := require.New(t)
-	client := NewClient()
+	t.Run("put item", func(t *testing.T) {
+		c := require.New(t)
+		client := NewClient()
 
-	err := ensurePokemonTable(client)
-	c.NoError(err)
+		err := ensurePokemonTable(client)
+		c.NoError(err)
 
-	transactItems := []dynamodbtypes.TransactWriteItem{
-		{
-			Update: &dynamodbtypes.Update{
-				Key: map[string]dynamodbtypes.AttributeValue{
-					"id":     &dynamodbtypes.AttributeValueMemberS{Value: "001"},
-					":ntype": &dynamodbtypes.AttributeValueMemberS{Value: "poison"},
-				},
-				TableName:        aws.String(tableName),
-				UpdateExpression: aws.String("SET second_type = :ntype"),
-				ExpressionAttributeNames: map[string]string{
-					"#id": "id",
-				},
-				ExpressionAttributeValues: map[string]dynamodbtypes.AttributeValue{
-					":update": &dynamodbtypes.AttributeValueMemberS{Value: time.Now().Format(time.RFC3339)},
-					":incr": &dynamodbtypes.AttributeValueMemberN{
-						Value: "1",
-					},
-					":initial": &dynamodbtypes.AttributeValueMemberN{
-						Value: "0",
+		output, err := client.TransactWriteItems(context.Background(), &dynamodb.TransactWriteItemsInput{
+			TransactItems: []dynamodbtypes.TransactWriteItem{
+				{
+					Put: &dynamodbtypes.Put{
+						TableName: aws.String(tableName),
+						Item: map[string]dynamodbtypes.AttributeValue{
+							"id":   &dynamodbtypes.AttributeValueMemberS{Value: "001"},
+							"type": &dynamodbtypes.AttributeValueMemberS{Value: "grass"},
+							"name": &dynamodbtypes.AttributeValueMemberS{Value: "Bulbasaur"},
+						},
 					},
 				},
 			},
-		},
-	}
+		})
+		c.NoError(err)
+		c.NotNil(output)
 
-	writeItemsInput := &dynamodb.TransactWriteItemsInput{
-		TransactItems: transactItems,
-	}
+		item, err := getPokemon(client, "001")
+		c.NoError(err)
+		c.Equal(&dynamodbtypes.AttributeValueMemberS{Value: "Bulbasaur"}, item["name"])
+	})
 
-	output, err := client.TransactWriteItems(context.Background(), writeItemsInput)
-	c.NoError(err)
-	c.NotNil(output)
+	t.Run("update", func(t *testing.T) {
+		c := require.New(t)
+		client := NewClient()
 
-	ActiveForceFailure(client)
-	defer DeactiveForceFailure(client)
+		err := ensurePokemonTable(client)
+		c.NoError(err)
 
-	_, err = client.TransactWriteItems(context.Background(), writeItemsInput)
-	c.Equal(ErrForcedFailure, err)
+		err = createPokemon(client, pokemon{ID: "001", Type: "grass", Name: "Bulbasaur"})
+		c.NoError(err)
+
+		_, err = client.TransactWriteItems(context.Background(), &dynamodb.TransactWriteItemsInput{
+			TransactItems: []dynamodbtypes.TransactWriteItem{
+				{
+					Update: &dynamodbtypes.Update{
+						TableName:        aws.String(tableName),
+						Key:              map[string]dynamodbtypes.AttributeValue{"id": &dynamodbtypes.AttributeValueMemberS{Value: "001"}},
+						UpdateExpression: aws.String("SET second_type = :stype"),
+						ExpressionAttributeValues: map[string]dynamodbtypes.AttributeValue{
+							":stype": &dynamodbtypes.AttributeValueMemberS{Value: "poison"},
+						},
+					},
+				},
+			},
+		})
+		c.NoError(err)
+
+		item, err := getPokemon(client, "001")
+		c.NoError(err)
+		c.Equal(&dynamodbtypes.AttributeValueMemberS{Value: "poison"}, item["second_type"])
+	})
+
+	t.Run("delete", func(t *testing.T) {
+		c := require.New(t)
+		client := NewClient()
+
+		err := ensurePokemonTable(client)
+		c.NoError(err)
+
+		err = createPokemon(client, pokemon{ID: "001", Type: "grass", Name: "Bulbasaur"})
+		c.NoError(err)
+
+		_, err = client.TransactWriteItems(context.Background(), &dynamodb.TransactWriteItemsInput{
+			TransactItems: []dynamodbtypes.TransactWriteItem{
+				{
+					Delete: &dynamodbtypes.Delete{
+						TableName: aws.String(tableName),
+						Key:       map[string]dynamodbtypes.AttributeValue{"id": &dynamodbtypes.AttributeValueMemberS{Value: "001"}},
+					},
+				},
+			},
+		})
+		c.NoError(err)
+
+		item, err := getPokemon(client, "001")
+		c.NoError(err)
+		c.Empty(item)
+	})
+
+	t.Run("condition_check_pass", func(t *testing.T) {
+		c := require.New(t)
+		client := NewClient()
+
+		err := ensurePokemonTable(client)
+		c.NoError(err)
+
+		err = createPokemon(client, pokemon{ID: "001", Type: "grass", Name: "Bulbasaur"})
+		c.NoError(err)
+
+		_, err = client.TransactWriteItems(context.Background(), &dynamodb.TransactWriteItemsInput{
+			TransactItems: []dynamodbtypes.TransactWriteItem{
+				{
+					ConditionCheck: &dynamodbtypes.ConditionCheck{
+						TableName:           aws.String(tableName),
+						Key:                 map[string]dynamodbtypes.AttributeValue{"id": &dynamodbtypes.AttributeValueMemberS{Value: "001"}},
+						ConditionExpression: aws.String("attribute_exists(id)"),
+					},
+				},
+			},
+		})
+		c.NoError(err)
+	})
+
+	t.Run("condition_check_fail", func(t *testing.T) {
+		c := require.New(t)
+		client := NewClient()
+
+		err := ensurePokemonTable(client)
+		c.NoError(err)
+
+		_, err = client.TransactWriteItems(context.Background(), &dynamodb.TransactWriteItemsInput{
+			TransactItems: []dynamodbtypes.TransactWriteItem{
+				{
+					ConditionCheck: &dynamodbtypes.ConditionCheck{
+						TableName:           aws.String(tableName),
+						Key:                 map[string]dynamodbtypes.AttributeValue{"id": &dynamodbtypes.AttributeValueMemberS{Value: "999"}},
+						ConditionExpression: aws.String("attribute_exists(id)"),
+					},
+				},
+			},
+		})
+
+		var condErr *dynamodbtypes.ConditionalCheckFailedException
+		c.True(errors.As(err, &condErr))
+	})
+
+	t.Run("rollback on failure", func(t *testing.T) {
+		c := require.New(t)
+		client := NewClient()
+
+		err := ensurePokemonTable(client)
+		c.NoError(err)
+
+		_, err = client.TransactWriteItems(context.Background(), &dynamodb.TransactWriteItemsInput{
+			TransactItems: []dynamodbtypes.TransactWriteItem{
+				{
+					Put: &dynamodbtypes.Put{
+						TableName: aws.String(tableName),
+						Item: map[string]dynamodbtypes.AttributeValue{
+							"id":   &dynamodbtypes.AttributeValueMemberS{Value: "rollback-me"},
+							"type": &dynamodbtypes.AttributeValueMemberS{Value: "fire"},
+						},
+					},
+				},
+				{
+					ConditionCheck: &dynamodbtypes.ConditionCheck{
+						TableName:           aws.String(tableName),
+						Key:                 map[string]dynamodbtypes.AttributeValue{"id": &dynamodbtypes.AttributeValueMemberS{Value: "non-existent"}},
+						ConditionExpression: aws.String("attribute_exists(id)"),
+					},
+				},
+			},
+		})
+		c.Error(err)
+
+		item, err := getPokemon(client, "rollback-me")
+		c.NoError(err)
+		c.Empty(item)
+	})
+
+	t.Run("emulated server error", func(t *testing.T) {
+		c := require.New(t)
+		client := NewClient()
+
+		err := ensurePokemonTable(client)
+		c.NoError(err)
+
+		EmulateFailure(client, FailureConditionInternalServerError)
+		defer EmulateFailure(client, FailureConditionNone)
+
+		_, err = client.TransactWriteItems(context.Background(), &dynamodb.TransactWriteItemsInput{
+			TransactItems: []dynamodbtypes.TransactWriteItem{
+				{
+					Put: &dynamodbtypes.Put{
+						TableName: aws.String(tableName),
+						Item: map[string]dynamodbtypes.AttributeValue{
+							"id": &dynamodbtypes.AttributeValueMemberS{Value: "001"},
+						},
+					},
+				},
+			},
+		})
+
+		var internalErr *dynamodbtypes.InternalServerError
+		c.True(errors.As(err, &internalErr))
+	})
+
+	t.Run("unused expression attribute rejected", func(t *testing.T) {
+		c := require.New(t)
+		client := NewClient()
+
+		err := ensurePokemonTable(client)
+		c.NoError(err)
+
+		_, err = client.TransactWriteItems(context.Background(), &dynamodb.TransactWriteItemsInput{
+			TransactItems: []dynamodbtypes.TransactWriteItem{
+				{
+					Put: &dynamodbtypes.Put{
+						TableName: aws.String(tableName),
+						Item: map[string]dynamodbtypes.AttributeValue{
+							"id": &dynamodbtypes.AttributeValueMemberS{Value: "001"},
+						},
+						ExpressionAttributeValues: map[string]dynamodbtypes.AttributeValue{
+							":unused": &dynamodbtypes.AttributeValueMemberS{Value: "x"},
+						},
+					},
+				},
+			},
+		})
+
+		var apiErr smithy.APIError
+		c.True(errors.As(err, &apiErr))
+		c.Equal("ValidationException", apiErr.ErrorCode())
+	})
+
+	t.Run("empty item rejected", func(t *testing.T) {
+		c := require.New(t)
+		client := NewClient()
+
+		err := ensurePokemonTable(client)
+		c.NoError(err)
+
+		_, err = client.TransactWriteItems(context.Background(), &dynamodb.TransactWriteItemsInput{
+			TransactItems: []dynamodbtypes.TransactWriteItem{{}},
+		})
+
+		var apiErr smithy.APIError
+		c.True(errors.As(err, &apiErr))
+		c.Equal("ValidationException", apiErr.ErrorCode())
+	})
+
+	t.Run("rollback across tables", func(t *testing.T) {
+		c := require.New(t)
+		client := NewClient()
+
+		err := ensurePokemonTable(client)
+		c.NoError(err)
+
+		const secondTable = "items"
+
+		err = AddTable(context.Background(), client, secondTable, "id", "")
+		c.NoError(err)
+
+		_, err = client.TransactWriteItems(context.Background(), &dynamodb.TransactWriteItemsInput{
+			TransactItems: []dynamodbtypes.TransactWriteItem{
+				{
+					Put: &dynamodbtypes.Put{
+						TableName: aws.String(secondTable),
+						Item: map[string]dynamodbtypes.AttributeValue{
+							"id": &dynamodbtypes.AttributeValueMemberS{Value: "should-rollback"},
+						},
+					},
+				},
+				{
+					ConditionCheck: &dynamodbtypes.ConditionCheck{
+						TableName:           aws.String(tableName),
+						Key:                 map[string]dynamodbtypes.AttributeValue{"id": &dynamodbtypes.AttributeValueMemberS{Value: "non-existent"}},
+						ConditionExpression: aws.String("attribute_exists(id)"),
+					},
+				},
+			},
+		})
+
+		var condErr *dynamodbtypes.ConditionalCheckFailedException
+		c.True(errors.As(err, &condErr))
+
+		out, err := client.GetItem(context.Background(), &dynamodb.GetItemInput{
+			TableName: aws.String(secondTable),
+			Key: map[string]dynamodbtypes.AttributeValue{
+				"id": &dynamodbtypes.AttributeValueMemberS{Value: "should-rollback"},
+			},
+		})
+		c.NoError(err)
+		c.Empty(out.Item)
+	})
+
+	t.Run("condition check returns old item on fail", func(t *testing.T) {
+		c := require.New(t)
+		client := NewClient()
+
+		err := ensurePokemonTable(client)
+		c.NoError(err)
+
+		err = createPokemon(client, pokemon{ID: "001", Type: "grass", Name: "Bulbasaur"})
+		c.NoError(err)
+
+		_, err = client.TransactWriteItems(context.Background(), &dynamodb.TransactWriteItemsInput{
+			TransactItems: []dynamodbtypes.TransactWriteItem{
+				{
+					ConditionCheck: &dynamodbtypes.ConditionCheck{
+						TableName:                           aws.String(tableName),
+						Key:                                 map[string]dynamodbtypes.AttributeValue{"id": &dynamodbtypes.AttributeValueMemberS{Value: "001"}},
+						ConditionExpression:                 aws.String("attribute_not_exists(id)"),
+						ReturnValuesOnConditionCheckFailure: dynamodbtypes.ReturnValuesOnConditionCheckFailureAllOld,
+					},
+				},
+			},
+		})
+
+		var condErr *dynamodbtypes.ConditionalCheckFailedException
+		c.True(errors.As(err, &condErr))
+		c.NotEmpty(condErr.Item)
+		c.Equal(&dynamodbtypes.AttributeValueMemberS{Value: "001"}, condErr.Item["id"])
+	})
+
+	t.Run("force failure", func(t *testing.T) {
+		c := require.New(t)
+		client := NewClient()
+
+		err := ensurePokemonTable(client)
+		c.NoError(err)
+
+		ActiveForceFailure(client)
+		defer DeactiveForceFailure(client)
+
+		_, err = client.TransactWriteItems(context.Background(), &dynamodb.TransactWriteItemsInput{
+			TransactItems: []dynamodbtypes.TransactWriteItem{
+				{
+					Put: &dynamodbtypes.Put{
+						TableName: aws.String(tableName),
+						Item: map[string]dynamodbtypes.AttributeValue{
+							"id": &dynamodbtypes.AttributeValueMemberS{Value: "001"},
+						},
+					},
+				},
+			},
+		})
+		c.Equal(ErrForcedFailure, err)
+	})
 }
 
 func TestCheckTableName(t *testing.T) {

--- a/aws-v2/client/mapper.go
+++ b/aws-v2/client/mapper.go
@@ -335,6 +335,50 @@ func mapDynamoToTypesDeleteItemInput(input *dynamodb.DeleteItemInput) *types.Del
 	}
 }
 
+func mapDynamoToTypesTransactPut(input *dynamodbtypes.Put) *types.PutItemInput {
+	if input == nil {
+		return nil
+	}
+
+	return &types.PutItemInput{
+		ConditionExpression:       input.ConditionExpression,
+		ExpressionAttributeNames:  input.ExpressionAttributeNames,
+		ExpressionAttributeValues: mapDynamoToTypesMapItem(input.ExpressionAttributeValues),
+		Item:                      mapDynamoToTypesMapItem(input.Item),
+		TableName:                 input.TableName,
+	}
+}
+
+func mapDynamoToTypesTransactUpdate(input *dynamodbtypes.Update) *types.UpdateItemInput {
+	if input == nil {
+		return nil
+	}
+
+	return &types.UpdateItemInput{
+		ConditionExpression:                 input.ConditionExpression,
+		ExpressionAttributeNames:            input.ExpressionAttributeNames,
+		ExpressionAttributeValues:           mapDynamoToTypesMapItem(input.ExpressionAttributeValues),
+		Key:                                 mapDynamoToTypesMapItem(input.Key),
+		TableName:                           input.TableName,
+		UpdateExpression:                    aws.ToString(input.UpdateExpression),
+		ReturnValuesOnConditionCheckFailure: toString(string(input.ReturnValuesOnConditionCheckFailure)),
+	}
+}
+
+func mapDynamoToTypesTransactDelete(input *dynamodbtypes.Delete) *types.DeleteItemInput {
+	if input == nil {
+		return nil
+	}
+
+	return &types.DeleteItemInput{
+		ConditionExpression:       input.ConditionExpression,
+		ExpressionAttributeNames:  mapDynamoToTypesStringMap(input.ExpressionAttributeNames),
+		ExpressionAttributeValues: mapDynamoToTypesMapItem(input.ExpressionAttributeValues),
+		Key:                       mapDynamoToTypesMapItem(input.Key),
+		TableName:                 input.TableName,
+	}
+}
+
 func mapDynamoToTypesExpectedAttributeValue(input dynamodbtypes.ExpectedAttributeValue) *types.ExpectedAttributeValue {
 	return &types.ExpectedAttributeValue{
 		AttributeValueList: mapDynamoToTypesSliceItem(input.AttributeValueList),

--- a/aws-v2/client/mapper_test.go
+++ b/aws-v2/client/mapper_test.go
@@ -134,3 +134,11 @@ func TestMapDynamoToTypesExpectedAttributeValue(t *testing.T) {
 	keySchemaElementsOutput = mapTypesToDynamoKeySchemaElementsPointer([]*types.KeySchemaElement{{AttributeName: "test"}})
 	c.Len(keySchemaElementsOutput, 1)
 }
+
+func TestMapDynamoToTypesTransactNil(t *testing.T) {
+	c := require.New(t)
+
+	c.Nil(mapDynamoToTypesTransactPut(nil))
+	c.Nil(mapDynamoToTypesTransactUpdate(nil))
+	c.Nil(mapDynamoToTypesTransactDelete(nil))
+}

--- a/core/index.go
+++ b/core/index.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"maps"
 	"sort"
 
 	"github.com/truora/minidyn/types"
@@ -38,6 +39,26 @@ func newIndex(t *Table, typ indexType, ks keySchema) *index {
 func (i *index) Clear() {
 	i.sortedKeys = []string{}
 	i.refs = map[string]string{}
+}
+
+type indexSnapshot struct {
+	sortedKeys []string
+	refs       map[string]string
+}
+
+func (i *index) snapshot() indexSnapshot {
+	keys := make([]string, len(i.sortedKeys))
+	copy(keys, i.sortedKeys)
+
+	refs := make(map[string]string, len(i.refs))
+	maps.Copy(refs, i.refs)
+
+	return indexSnapshot{sortedKeys: keys, refs: refs}
+}
+
+func (i *index) restore(s indexSnapshot) {
+	i.sortedKeys = s.sortedKeys
+	i.refs = s.refs
 }
 
 func (i *index) putData(key string, item map[string]*types.Item) error {

--- a/core/table.go
+++ b/core/table.go
@@ -638,7 +638,7 @@ func (t *Table) Put(input *types.PutItemInput) (map[string]*types.Item, error) {
 		}
 
 		if !matched {
-			return item, types.NewError("ConditionalCheckFailedException", ErrConditionalRequestFailed.Error(), nil)
+			return item, &types.ConditionalCheckFailedException{MessageText: ErrConditionalRequestFailed.Error()}
 		}
 	}
 
@@ -908,7 +908,7 @@ func (t *Table) Delete(input *types.DeleteItemInput) (map[string]*types.Item, er
 		}
 
 		if !matched {
-			return nil, types.NewError("ConditionalCheckFailedException", ErrConditionalRequestFailed.Error(), nil)
+			return nil, &types.ConditionalCheckFailedException{MessageText: ErrConditionalRequestFailed.Error()}
 		}
 	}
 

--- a/core/table.go
+++ b/core/table.go
@@ -469,7 +469,8 @@ func (t *Table) getLastKey(item map[string]*types.Item, limit, count, scanned, k
 	return key
 }
 
-func (t *Table) interpreterMatch(input interpreter.MatchInput) (bool, error) {
+// InterpreterMatch evaluates a match expression against an item
+func (t *Table) InterpreterMatch(input interpreter.MatchInput) (bool, error) {
 	if t.UseNativeInterpreter {
 		matched, err := t.NativeInterpreter.Match(input)
 		if err == nil {
@@ -492,7 +493,7 @@ func (t *Table) matchKey(input QueryInput, item map[string]*types.Item) (interpr
 	if input.KeyConditionExpression != "" {
 		var err error
 
-		matched, err = t.interpreterMatch(interpreter.MatchInput{
+		matched, err = t.InterpreterMatch(interpreter.MatchInput{
 			TableName:      t.Name,
 			Expression:     input.KeyConditionExpression,
 			ExpressionType: interpreter.ExpressionTypeKey,
@@ -508,7 +509,7 @@ func (t *Table) matchKey(input QueryInput, item map[string]*types.Item) (interpr
 
 	if input.FilterExpression != "" {
 		if matched {
-			m, err := t.interpreterMatch(interpreter.MatchInput{
+			m, err := t.InterpreterMatch(interpreter.MatchInput{
 				TableName:      t.Name,
 				Expression:     input.FilterExpression,
 				ExpressionType: interpreter.ExpressionTypeFilter,
@@ -527,7 +528,7 @@ func (t *Table) matchKey(input QueryInput, item map[string]*types.Item) (interpr
 	if input.ConditionExpression != nil && *input.ConditionExpression != "" {
 		var err error
 
-		matched, err = t.interpreterMatch(interpreter.MatchInput{
+		matched, err = t.InterpreterMatch(interpreter.MatchInput{
 			TableName:      t.Name,
 			Expression:     *input.ConditionExpression,
 			ExpressionType: interpreter.ExpressionTypeConditional,
@@ -567,6 +568,43 @@ func (t *Table) getItem(key string) map[string]*types.Item {
 func (t *Table) Clear() {
 	t.SortedKeys = []string{}
 	t.Data = map[string]map[string]*types.Item{}
+}
+
+// TableSnapshot captures a point-in-time copy of mutable table state for transactional rollback
+type TableSnapshot struct {
+	data       map[string]map[string]*types.Item
+	sortedKeys []string
+	indexes    map[string]indexSnapshot
+}
+
+// Snapshot returns a deep copy of the table's mutable state
+func (t *Table) Snapshot() TableSnapshot {
+	data := make(map[string]map[string]*types.Item, len(t.Data))
+	for k, v := range t.Data {
+		data[k] = deepCopyItemMap(v)
+	}
+
+	keys := make([]string, len(t.SortedKeys))
+	copy(keys, t.SortedKeys)
+
+	indexes := make(map[string]indexSnapshot, len(t.Indexes))
+	for name, idx := range t.Indexes {
+		indexes[name] = idx.snapshot()
+	}
+
+	return TableSnapshot{data: data, sortedKeys: keys, indexes: indexes}
+}
+
+// Restore replaces the table's mutable state with a previously taken snapshot
+func (t *Table) Restore(s TableSnapshot) {
+	t.Data = s.data
+	t.SortedKeys = s.sortedKeys
+
+	for name, idx := range t.Indexes {
+		if snap, ok := s.indexes[name]; ok {
+			idx.restore(snap)
+		}
+	}
 }
 
 // Put puts items into table

--- a/core/table_test.go
+++ b/core/table_test.go
@@ -1087,7 +1087,7 @@ func TestInterpreterMatch(t *testing.T) {
 		ExpressionType: interpreter.ExpressionTypeConditional,
 	}
 
-	matched, err := newTable.interpreterMatch(matchInput)
+	matched, err := newTable.InterpreterMatch(matchInput)
 	c.NoError(err)
 	c.True(matched)
 
@@ -1095,13 +1095,13 @@ func TestInterpreterMatch(t *testing.T) {
 		TableName: tableName,
 	}
 
-	_, err = newTable.interpreterMatch(matchInput)
+	_, err = newTable.InterpreterMatch(matchInput)
 	c.Error(err)
 
 	newTable.UseNativeInterpreter = false
 	matchInput.Expression = "bad_expression(id)"
 
-	_, err = newTable.interpreterMatch(matchInput)
+	_, err = newTable.InterpreterMatch(matchInput)
 	c.Error(err)
 }
 

--- a/core/table_test.go
+++ b/core/table_test.go
@@ -1251,3 +1251,62 @@ func TestSearchDataWithProjectionExpression(t *testing.T) {
 	c.Equal("bar", *items[0]["foo"].S)
 	c.Contains(lastKey, "id")
 }
+
+func TestSnapshot(t *testing.T) {
+	c := require.New(t)
+
+	table, err := createPokemonTable()
+	c.NoError(err)
+
+	item := createPokemon(pokemon{ID: "001", Type: "grass", Name: "Bulbasaur"})
+	_, err = table.Put(&types.PutItemInput{
+		TableName: aws.String(tableName),
+		Item:      item,
+	})
+	c.NoError(err)
+
+	snap := table.Snapshot()
+
+	_, err = table.Delete(&types.DeleteItemInput{
+		TableName: aws.String(tableName),
+		Key: map[string]*types.Item{
+			"id":   {S: aws.String("001")},
+			"name": {S: aws.String("Bulbasaur")},
+		},
+	})
+	c.NoError(err)
+
+	c.Empty(table.Data)
+	c.NotEmpty(snap)
+}
+
+func TestRestore(t *testing.T) {
+	c := require.New(t)
+
+	table, err := createPokemonTable()
+	c.NoError(err)
+
+	itemA := createPokemon(pokemon{ID: "001", Type: "grass", Name: "Bulbasaur"})
+	_, err = table.Put(&types.PutItemInput{
+		TableName: aws.String(tableName),
+		Item:      itemA,
+	})
+	c.NoError(err)
+
+	snap := table.Snapshot()
+
+	itemB := createPokemon(pokemon{ID: "004", Type: "fire", Name: "Charmander"})
+	_, err = table.Put(&types.PutItemInput{
+		TableName: aws.String(tableName),
+		Item:      itemB,
+	})
+	c.NoError(err)
+
+	c.Len(table.Data, 2)
+
+	table.Restore(snap)
+
+	c.Len(table.Data, 1)
+	c.Contains(table.Data, "001.Bulbasaur")
+	c.NotContains(table.Data, "004.Charmander")
+}

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -27,18 +27,12 @@ var sdkErrUnusedExprAttrNamesKeysRE = regexp.MustCompile(
 	`ExpressionAttributeNames can only be specified when using expressions: keys: \{[^}]+\}`,
 )
 
-// DynamoDB Local appends ": keys: {:...}" to the unused ExpressionAttributeValues message.
-// Minidyn emits the shorter form. Normalise to the shared prefix.
-var sdkErrUnusedExprAttrValuesKeysRE = regexp.MustCompile(
-	`(Value provided in ExpressionAttributeValues unused in expressions): keys: \{[^}]+\}`,
-)
-
-// DynamoDB Local uses "ExpressionAttributeValues can only be specified when using expressions: ..."
-// for the case where ExpressionAttributeValues is given but no expression is present.
-// Minidyn uses "Value provided in ExpressionAttributeValues unused in expressions" for the same case.
-// Normalise DynamoDB Local's phrasing to minidyn's so parity comparisons succeed.
-var sdkErrExprAttrValuesNoExprRE = regexp.MustCompile(
-	`ExpressionAttributeValues can only be specified when using expressions[^"]*`,
+// DynamoDB Local appends ": <ExpressionType> is null" to the "ExpressionAttributeValues can
+// only be specified when using expressions" message (e.g. ": ConditionExpression is null").
+// Minidyn omits this suffix because the generic validation helper is not aware of the
+// calling operation's expression type. Strip it so both sides compare equal.
+var sdkErrExprAttrValuesNullExprRE = regexp.MustCompile(
+	`(ExpressionAttributeValues can only be specified when using expressions): \w+Expression is null`,
 )
 
 // normalizeSDKErrorString makes minidyn and DynamoDB Local operation errors comparable by
@@ -54,11 +48,7 @@ func normalizeSDKErrorString(s string) string {
 	s = sdkErrUnusedExprAttrNamesKeysRE.ReplaceAllString(s,
 		"ExpressionAttributeNames can only be specified when using expressions")
 
-	s = sdkErrUnusedExprAttrValuesKeysRE.ReplaceAllString(s,
-		"$1")
-
-	s = sdkErrExprAttrValuesNoExprRE.ReplaceAllString(s,
-		"Value provided in ExpressionAttributeValues unused in expressions")
+	s = sdkErrExprAttrValuesNullExprRE.ReplaceAllString(s, "$1")
 
 	return s
 }

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -27,6 +27,20 @@ var sdkErrUnusedExprAttrNamesKeysRE = regexp.MustCompile(
 	`ExpressionAttributeNames can only be specified when using expressions: keys: \{[^}]+\}`,
 )
 
+// DynamoDB Local appends ": keys: {:...}" to the unused ExpressionAttributeValues message.
+// Minidyn emits the shorter form. Normalise to the shared prefix.
+var sdkErrUnusedExprAttrValuesKeysRE = regexp.MustCompile(
+	`(Value provided in ExpressionAttributeValues unused in expressions): keys: \{[^}]+\}`,
+)
+
+// DynamoDB Local uses "ExpressionAttributeValues can only be specified when using expressions: ..."
+// for the case where ExpressionAttributeValues is given but no expression is present.
+// Minidyn uses "Value provided in ExpressionAttributeValues unused in expressions" for the same case.
+// Normalise DynamoDB Local's phrasing to minidyn's so parity comparisons succeed.
+var sdkErrExprAttrValuesNoExprRE = regexp.MustCompile(
+	`ExpressionAttributeValues can only be specified when using expressions[^"]*`,
+)
+
 // normalizeSDKErrorString makes minidyn and DynamoDB Local operation errors comparable by
 // stripping request IDs and DynamoDB-Local-specific validation suffixes.
 func normalizeSDKErrorString(s string) string {
@@ -39,6 +53,12 @@ func normalizeSDKErrorString(s string) string {
 
 	s = sdkErrUnusedExprAttrNamesKeysRE.ReplaceAllString(s,
 		"ExpressionAttributeNames can only be specified when using expressions")
+
+	s = sdkErrUnusedExprAttrValuesKeysRE.ReplaceAllString(s,
+		"$1")
+
+	s = sdkErrExprAttrValuesNoExprRE.ReplaceAllString(s,
+		"Value provided in ExpressionAttributeValues unused in expressions")
 
 	return s
 }

--- a/e2e/parity_transact_test.go
+++ b/e2e/parity_transact_test.go
@@ -1,0 +1,313 @@
+package e2e
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	dynamodbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestE2E_TransactWrite(t *testing.T) {
+	tests := []struct {
+		name string
+		fn   func(t *testing.T, client *dynamodb.Client) any
+	}{
+		{
+			name: "TransactPut",
+			fn: func(t *testing.T, client *dynamodb.Client) any {
+				t.Helper()
+				ctx := context.Background()
+
+				parityCreatePokemonTable(ctx, t, client)
+
+				_, err := client.TransactWriteItems(ctx, &dynamodb.TransactWriteItemsInput{
+					TransactItems: []dynamodbtypes.TransactWriteItem{
+						{Put: &dynamodbtypes.Put{
+							TableName: aws.String(parityPokemonTable),
+							Item: map[string]dynamodbtypes.AttributeValue{
+								"id":   &dynamodbtypes.AttributeValueMemberS{Value: "001"},
+								"name": &dynamodbtypes.AttributeValueMemberS{Value: "Bulbasaur"},
+							},
+						}},
+					},
+				})
+				require.NoError(t, err)
+
+				out, err := client.GetItem(ctx, &dynamodb.GetItemInput{
+					TableName: aws.String(parityPokemonTable),
+					Key: map[string]dynamodbtypes.AttributeValue{
+						"id": &dynamodbtypes.AttributeValueMemberS{Value: "001"},
+					},
+				})
+				require.NoError(t, err)
+
+				return []any{out.Item["id"], out.Item["name"]}
+			},
+		},
+		{
+			name: "TransactUpdate",
+			fn: func(t *testing.T, client *dynamodb.Client) any {
+				t.Helper()
+				ctx := context.Background()
+
+				parityCreatePokemonTable(ctx, t, client)
+				parityCreatePokemon(ctx, t, client, parityPokemon{ID: "001", Type: "grass", Name: "Bulbasaur"})
+
+				_, err := client.TransactWriteItems(ctx, &dynamodb.TransactWriteItemsInput{
+					TransactItems: []dynamodbtypes.TransactWriteItem{
+						{Update: &dynamodbtypes.Update{
+							TableName:        aws.String(parityPokemonTable),
+							Key:              map[string]dynamodbtypes.AttributeValue{"id": &dynamodbtypes.AttributeValueMemberS{Value: "001"}},
+							UpdateExpression: aws.String("SET second_type = :stype"),
+							ExpressionAttributeValues: map[string]dynamodbtypes.AttributeValue{
+								":stype": &dynamodbtypes.AttributeValueMemberS{Value: "poison"},
+							},
+						}},
+					},
+				})
+				require.NoError(t, err)
+
+				out, err := client.GetItem(ctx, &dynamodb.GetItemInput{
+					TableName: aws.String(parityPokemonTable),
+					Key: map[string]dynamodbtypes.AttributeValue{
+						"id": &dynamodbtypes.AttributeValueMemberS{Value: "001"},
+					},
+				})
+				require.NoError(t, err)
+
+				return out.Item["second_type"]
+			},
+		},
+		{
+			name: "TransactDelete",
+			fn: func(t *testing.T, client *dynamodb.Client) any {
+				t.Helper()
+				ctx := context.Background()
+
+				parityCreatePokemonTable(ctx, t, client)
+				parityCreatePokemon(ctx, t, client, parityPokemon{ID: "001", Type: "grass", Name: "Bulbasaur"})
+
+				_, err := client.TransactWriteItems(ctx, &dynamodb.TransactWriteItemsInput{
+					TransactItems: []dynamodbtypes.TransactWriteItem{
+						{Delete: &dynamodbtypes.Delete{
+							TableName: aws.String(parityPokemonTable),
+							Key: map[string]dynamodbtypes.AttributeValue{
+								"id": &dynamodbtypes.AttributeValueMemberS{Value: "001"},
+							},
+						}},
+					},
+				})
+				require.NoError(t, err)
+
+				out, err := client.GetItem(ctx, &dynamodb.GetItemInput{
+					TableName: aws.String(parityPokemonTable),
+					Key: map[string]dynamodbtypes.AttributeValue{
+						"id": &dynamodbtypes.AttributeValueMemberS{Value: "001"},
+					},
+				})
+				require.NoError(t, err)
+
+				return len(out.Item) == 0
+			},
+		},
+		{
+			name: "TransactConditionCheckPass",
+			fn: func(t *testing.T, client *dynamodb.Client) any {
+				t.Helper()
+				ctx := context.Background()
+
+				parityCreatePokemonTable(ctx, t, client)
+				parityCreatePokemon(ctx, t, client, parityPokemon{ID: "001", Type: "grass", Name: "Bulbasaur"})
+
+				_, err := client.TransactWriteItems(ctx, &dynamodb.TransactWriteItemsInput{
+					TransactItems: []dynamodbtypes.TransactWriteItem{
+						{ConditionCheck: &dynamodbtypes.ConditionCheck{
+							TableName:           aws.String(parityPokemonTable),
+							Key:                 map[string]dynamodbtypes.AttributeValue{"id": &dynamodbtypes.AttributeValueMemberS{Value: "001"}},
+							ConditionExpression: aws.String("attribute_exists(id)"),
+						}},
+					},
+				})
+				require.NoError(t, err)
+
+				return true
+			},
+		},
+		{
+			name: "TransactConditionCheckFail",
+			fn: func(t *testing.T, client *dynamodb.Client) any {
+				t.Helper()
+				ctx := context.Background()
+
+				parityCreatePokemonTable(ctx, t, client)
+
+				_, err := client.TransactWriteItems(ctx, &dynamodb.TransactWriteItemsInput{
+					TransactItems: []dynamodbtypes.TransactWriteItem{
+						{ConditionCheck: &dynamodbtypes.ConditionCheck{
+							TableName:           aws.String(parityPokemonTable),
+							Key:                 map[string]dynamodbtypes.AttributeValue{"id": &dynamodbtypes.AttributeValueMemberS{Value: "999"}},
+							ConditionExpression: aws.String("attribute_exists(id)"),
+						}},
+					},
+				})
+				require.Error(t, err)
+
+				return normalizeSDKErrorString(err.Error())
+			},
+		},
+		{
+			name: "TransactRollbackOnFailure",
+			fn: func(t *testing.T, client *dynamodb.Client) any {
+				t.Helper()
+				ctx := context.Background()
+
+				parityCreatePokemonTable(ctx, t, client)
+
+				_, err := client.TransactWriteItems(ctx, &dynamodb.TransactWriteItemsInput{
+					TransactItems: []dynamodbtypes.TransactWriteItem{
+						{Put: &dynamodbtypes.Put{
+							TableName: aws.String(parityPokemonTable),
+							Item: map[string]dynamodbtypes.AttributeValue{
+								"id":   &dynamodbtypes.AttributeValueMemberS{Value: "rollback-me"},
+								"type": &dynamodbtypes.AttributeValueMemberS{Value: "fire"},
+							},
+						}},
+						{ConditionCheck: &dynamodbtypes.ConditionCheck{
+							TableName:           aws.String(parityPokemonTable),
+							Key:                 map[string]dynamodbtypes.AttributeValue{"id": &dynamodbtypes.AttributeValueMemberS{Value: "non-existent"}},
+							ConditionExpression: aws.String("attribute_exists(id)"),
+						}},
+					},
+				})
+				require.Error(t, err)
+
+				out, err := client.GetItem(ctx, &dynamodb.GetItemInput{
+					TableName: aws.String(parityPokemonTable),
+					Key: map[string]dynamodbtypes.AttributeValue{
+						"id": &dynamodbtypes.AttributeValueMemberS{Value: "rollback-me"},
+					},
+				})
+				require.NoError(t, err)
+
+				return len(out.Item) == 0
+			},
+		},
+		{
+			name: "TransactRollbackAcrossTables",
+			fn: func(t *testing.T, client *dynamodb.Client) any {
+				t.Helper()
+				ctx := context.Background()
+
+				parityCreatePokemonTable(ctx, t, client)
+
+				const secondTable = "transact-items"
+
+				_, err := client.CreateTable(ctx, &dynamodb.CreateTableInput{
+					TableName: aws.String(secondTable),
+					KeySchema: []dynamodbtypes.KeySchemaElement{
+						{AttributeName: aws.String("id"), KeyType: dynamodbtypes.KeyTypeHash},
+					},
+					AttributeDefinitions: []dynamodbtypes.AttributeDefinition{
+						{AttributeName: aws.String("id"), AttributeType: dynamodbtypes.ScalarAttributeTypeS},
+					},
+					BillingMode: dynamodbtypes.BillingModePayPerRequest,
+				})
+				require.NoError(t, err)
+
+				_, err = client.TransactWriteItems(ctx, &dynamodb.TransactWriteItemsInput{
+					TransactItems: []dynamodbtypes.TransactWriteItem{
+						{Put: &dynamodbtypes.Put{
+							TableName: aws.String(secondTable),
+							Item: map[string]dynamodbtypes.AttributeValue{
+								"id": &dynamodbtypes.AttributeValueMemberS{Value: "should-rollback"},
+							},
+						}},
+						{ConditionCheck: &dynamodbtypes.ConditionCheck{
+							TableName:           aws.String(parityPokemonTable),
+							Key:                 map[string]dynamodbtypes.AttributeValue{"id": &dynamodbtypes.AttributeValueMemberS{Value: "non-existent"}},
+							ConditionExpression: aws.String("attribute_exists(id)"),
+						}},
+					},
+				})
+				require.Error(t, err)
+
+				out, err := client.GetItem(ctx, &dynamodb.GetItemInput{
+					TableName: aws.String(secondTable),
+					Key: map[string]dynamodbtypes.AttributeValue{
+						"id": &dynamodbtypes.AttributeValueMemberS{Value: "should-rollback"},
+					},
+				})
+				require.NoError(t, err)
+
+				return len(out.Item) == 0
+			},
+		},
+		{
+			name: "TransactConditionCheckReturnAllOld",
+			fn: func(t *testing.T, client *dynamodb.Client) any {
+				t.Helper()
+				ctx := context.Background()
+
+				parityCreatePokemonTable(ctx, t, client)
+				parityCreatePokemon(ctx, t, client, parityPokemon{ID: "001", Type: "grass", Name: "Bulbasaur"})
+
+				_, err := client.TransactWriteItems(ctx, &dynamodb.TransactWriteItemsInput{
+					TransactItems: []dynamodbtypes.TransactWriteItem{
+						{ConditionCheck: &dynamodbtypes.ConditionCheck{
+							TableName:                           aws.String(parityPokemonTable),
+							Key:                                 map[string]dynamodbtypes.AttributeValue{"id": &dynamodbtypes.AttributeValueMemberS{Value: "001"}},
+							ConditionExpression:                 aws.String("attribute_not_exists(id)"),
+							ReturnValuesOnConditionCheckFailure: dynamodbtypes.ReturnValuesOnConditionCheckFailureAllOld,
+						}},
+					},
+				})
+				require.Error(t, err)
+
+				var tce *dynamodbtypes.TransactionCanceledException
+				require.ErrorAs(t, err, &tce)
+				require.Len(t, tce.CancellationReasons, 1)
+
+				reason := tce.CancellationReasons[0]
+				idAttr, _ := reason.Item["id"].(*dynamodbtypes.AttributeValueMemberS)
+				require.NotNil(t, idAttr, "CancellationReasons[0].Item must contain the old item")
+
+				return idAttr.Value
+			},
+		},
+		{
+			name: "TransactUnusedExpressionAttribute",
+			fn: func(t *testing.T, client *dynamodb.Client) any {
+				t.Helper()
+				ctx := context.Background()
+
+				parityCreatePokemonTable(ctx, t, client)
+
+				_, err := client.TransactWriteItems(ctx, &dynamodb.TransactWriteItemsInput{
+					TransactItems: []dynamodbtypes.TransactWriteItem{
+						{Put: &dynamodbtypes.Put{
+							TableName: aws.String(parityPokemonTable),
+							Item: map[string]dynamodbtypes.AttributeValue{
+								"id": &dynamodbtypes.AttributeValueMemberS{Value: "001"},
+							},
+							ExpressionAttributeValues: map[string]dynamodbtypes.AttributeValue{
+								":unused": &dynamodbtypes.AttributeValueMemberS{Value: "x"},
+							},
+						}},
+					},
+				})
+				require.Error(t, err)
+
+				return normalizeSDKErrorString(err.Error())
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			RunE2E(t, tt.fn)
+		})
+	}
+}

--- a/e2e/parity_transact_test.go
+++ b/e2e/parity_transact_test.go
@@ -278,6 +278,82 @@ func TestE2E_TransactWrite(t *testing.T) {
 			},
 		},
 		{
+			name: "TransactDuplicateItem",
+			fn: func(t *testing.T, client *dynamodb.Client) any {
+				t.Helper()
+				ctx := context.Background()
+
+				parityCreatePokemonTable(ctx, t, client)
+
+				_, err := client.TransactWriteItems(ctx, &dynamodb.TransactWriteItemsInput{
+					TransactItems: []dynamodbtypes.TransactWriteItem{
+						{Put: &dynamodbtypes.Put{
+							TableName: aws.String(parityPokemonTable),
+							Item: map[string]dynamodbtypes.AttributeValue{
+								"id": &dynamodbtypes.AttributeValueMemberS{Value: "001"},
+							},
+						}},
+						{Update: &dynamodbtypes.Update{
+							TableName:                 aws.String(parityPokemonTable),
+							Key:                       map[string]dynamodbtypes.AttributeValue{"id": &dynamodbtypes.AttributeValueMemberS{Value: "001"}},
+							UpdateExpression:          aws.String("SET #n = :n"),
+							ExpressionAttributeNames:  map[string]string{"#n": "name"},
+							ExpressionAttributeValues: map[string]dynamodbtypes.AttributeValue{":n": &dynamodbtypes.AttributeValueMemberS{Value: "Bulbasaur"}},
+						}},
+					},
+				})
+				require.Error(t, err)
+
+				return normalizeSDKErrorString(err.Error())
+			},
+		},
+		{
+			name: "TransactPutConditionFail",
+			fn: func(t *testing.T, client *dynamodb.Client) any {
+				t.Helper()
+				ctx := context.Background()
+
+				parityCreatePokemonTable(ctx, t, client)
+				parityCreatePokemon(ctx, t, client, parityPokemon{ID: "001", Type: "grass", Name: "Bulbasaur"})
+
+				_, err := client.TransactWriteItems(ctx, &dynamodb.TransactWriteItemsInput{
+					TransactItems: []dynamodbtypes.TransactWriteItem{
+						{Put: &dynamodbtypes.Put{
+							TableName:           aws.String(parityPokemonTable),
+							Item:                map[string]dynamodbtypes.AttributeValue{"id": &dynamodbtypes.AttributeValueMemberS{Value: "001"}},
+							ConditionExpression: aws.String("attribute_not_exists(id)"),
+						}},
+					},
+				})
+				require.Error(t, err)
+
+				return normalizeSDKErrorString(err.Error())
+			},
+		},
+		{
+			name: "TransactDeleteConditionFail",
+			fn: func(t *testing.T, client *dynamodb.Client) any {
+				t.Helper()
+				ctx := context.Background()
+
+				parityCreatePokemonTable(ctx, t, client)
+				parityCreatePokemon(ctx, t, client, parityPokemon{ID: "001", Type: "grass", Name: "Bulbasaur"})
+
+				_, err := client.TransactWriteItems(ctx, &dynamodb.TransactWriteItemsInput{
+					TransactItems: []dynamodbtypes.TransactWriteItem{
+						{Delete: &dynamodbtypes.Delete{
+							TableName:           aws.String(parityPokemonTable),
+							Key:                 map[string]dynamodbtypes.AttributeValue{"id": &dynamodbtypes.AttributeValueMemberS{Value: "001"}},
+							ConditionExpression: aws.String("attribute_not_exists(id)"),
+						}},
+					},
+				})
+				require.Error(t, err)
+
+				return normalizeSDKErrorString(err.Error())
+			},
+		},
+		{
 			name: "TransactUnusedExpressionAttribute",
 			fn: func(t *testing.T, client *dynamodb.Client) any {
 				t.Helper()

--- a/server/client.go
+++ b/server/client.go
@@ -534,6 +534,210 @@ func (c *Client) BatchWriteItem(ctx context.Context, input *BatchWriteItemInput)
 	return &BatchWriteItemOutput{UnprocessedItems: unprocessed}, nil
 }
 
+// TransactWriteItems executes a set of Put, Update, Delete, and ConditionCheck operations atomically.
+// If any operation fails the entire transaction is  rolled back via table snapshots captured before execution begins.
+func (c *Client) TransactWriteItems(ctx context.Context, input *TransactWriteItemsInput) (_ *TransactWriteItemsOutput, err error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.forceFailureErr != nil {
+		return nil, c.forceFailureErr
+	}
+
+	snapshots := map[string]core.TableSnapshot{}
+
+	defer func() {
+		if err != nil {
+			for name, snap := range snapshots {
+				c.tables[name].Restore(snap)
+			}
+		}
+	}()
+
+	for _, item := range input.TransactItems {
+		var tableName string
+
+		switch {
+		case item.Put != nil:
+			tableName = aws.ToString(item.Put.TableName)
+		case item.Update != nil:
+			tableName = aws.ToString(item.Update.TableName)
+		case item.Delete != nil:
+			tableName = aws.ToString(item.Delete.TableName)
+		case item.ConditionCheck != nil:
+			tableName = aws.ToString(item.ConditionCheck.TableName)
+		}
+
+		if _, alreadySnapped := snapshots[tableName]; tableName == "" || alreadySnapped {
+			continue
+		}
+
+		table, tErr := c.getTable(tableName)
+		if tErr != nil {
+			return nil, mapKnownError(tErr)
+		}
+
+		snapshots[tableName] = table.Snapshot()
+	}
+
+	n := len(input.TransactItems)
+
+	for i, item := range input.TransactItems {
+		switch {
+		case item.Put != nil:
+			if err = validateExpressionAttributes(item.Put.ExpressionAttributeNames, keysFromAttributeValueMap(item.Put.ExpressionAttributeValues), aws.ToString(item.Put.ConditionExpression)); err != nil {
+				return nil, err
+			}
+
+			table, tErr := c.getTable(aws.ToString(item.Put.TableName))
+			if tErr != nil {
+				return nil, mapKnownError(tErr)
+			}
+
+			if _, opErr := table.Put(&types.PutItemInput{
+				TableName:                 item.Put.TableName,
+				ConditionExpression:       item.Put.ConditionExpression,
+				ExpressionAttributeNames:  item.Put.ExpressionAttributeNames,
+				ExpressionAttributeValues: mapAttributeValueMapToTypes(item.Put.ExpressionAttributeValues),
+				Item:                      mapAttributeValueMapToTypes(item.Put.Item),
+			}); opErr != nil {
+				return nil, newServerTransactionCancelledError(i, n, opErr)
+			}
+
+		case item.Update != nil:
+			if err = validateExpressionAttributes(item.Update.ExpressionAttributeNames, keysFromAttributeValueMap(item.Update.ExpressionAttributeValues), aws.ToString(item.Update.UpdateExpression), aws.ToString(item.Update.ConditionExpression)); err != nil {
+				return nil, err
+			}
+
+			table, tErr := c.getTable(aws.ToString(item.Update.TableName))
+			if tErr != nil {
+				return nil, mapKnownError(tErr)
+			}
+
+			_, opErr := table.Update(&types.UpdateItemInput{
+				TableName:                           item.Update.TableName,
+				ConditionExpression:                 item.Update.ConditionExpression,
+				ExpressionAttributeNames:            item.Update.ExpressionAttributeNames,
+				ExpressionAttributeValues:           mapAttributeValueMapToTypes(item.Update.ExpressionAttributeValues),
+				Key:                                 mapAttributeValueMapToTypes(item.Update.Key),
+				UpdateExpression:                    aws.ToString(item.Update.UpdateExpression),
+				ReturnValuesOnConditionCheckFailure: toStringPtr(string(item.Update.ReturnValuesOnConditionCheckFailure)),
+			})
+			if opErr != nil {
+				if errors.Is(opErr, interpreter.ErrSyntaxError) {
+					return nil, &smithy.GenericAPIError{Code: "ValidationException", Message: opErr.Error()}
+				}
+
+				return nil, newServerTransactionCancelledError(i, n, opErr)
+			}
+
+		case item.Delete != nil:
+			if err = validateExpressionAttributes(item.Delete.ExpressionAttributeNames, keysFromAttributeValueMap(item.Delete.ExpressionAttributeValues), aws.ToString(item.Delete.ConditionExpression)); err != nil {
+				return nil, err
+			}
+
+			table, tErr := c.getTable(aws.ToString(item.Delete.TableName))
+			if tErr != nil {
+				return nil, mapKnownError(tErr)
+			}
+
+			if _, opErr := table.Delete(&types.DeleteItemInput{
+				TableName:                 item.Delete.TableName,
+				ConditionExpression:       item.Delete.ConditionExpression,
+				ExpressionAttributeNames:  toStringPtrMap(item.Delete.ExpressionAttributeNames),
+				ExpressionAttributeValues: mapAttributeValueMapToTypes(item.Delete.ExpressionAttributeValues),
+				Key:                       mapAttributeValueMapToTypes(item.Delete.Key),
+			}); opErr != nil {
+				return nil, newServerTransactionCancelledError(i, n, opErr)
+			}
+
+		case item.ConditionCheck != nil:
+			if err = validateExpressionAttributes(item.ConditionCheck.ExpressionAttributeNames, keysFromAttributeValueMap(item.ConditionCheck.ExpressionAttributeValues), aws.ToString(item.ConditionCheck.ConditionExpression)); err != nil {
+				return nil, err
+			}
+
+			table, tErr := c.getTable(aws.ToString(item.ConditionCheck.TableName))
+			if tErr != nil {
+				return nil, mapKnownError(tErr)
+			}
+
+			keyMap := mapAttributeValueMapToTypes(item.ConditionCheck.Key)
+			if vErr := types.ValidateItemMap(keyMap); vErr != nil {
+				return nil, mapKnownError(types.NewError("ValidationException", vErr.Error(), nil))
+			}
+
+			if keyErr := table.ValidatePrimaryKeyMap(keyMap); keyErr != nil {
+				return nil, &smithy.GenericAPIError{Code: "ValidationException", Message: keyErr.Error()}
+			}
+
+			key, kErr := table.KeySchema.GetKey(table.AttributesDef, keyMap)
+			if kErr != nil {
+				return nil, &smithy.GenericAPIError{Code: "ValidationException", Message: kErr.Error()}
+			}
+
+			stored := table.Data[key]
+			if stored == nil {
+				stored = map[string]*types.Item{}
+			}
+
+			matched, mErr := table.InterpreterMatch(interpreter.MatchInput{
+				TableName:      table.Name,
+				Expression:     aws.ToString(item.ConditionCheck.ConditionExpression),
+				ExpressionType: interpreter.ExpressionTypeConditional,
+				Item:           stored,
+				Aliases:        item.ConditionCheck.ExpressionAttributeNames,
+				Attributes:     mapAttributeValueMapToTypes(item.ConditionCheck.ExpressionAttributeValues),
+			})
+			if mErr != nil {
+				return nil, &smithy.GenericAPIError{Code: "ValidationException", Message: mErr.Error()}
+			}
+
+			if !matched {
+				checkErr := &types.ConditionalCheckFailedException{
+					MessageText: core.ErrConditionalRequestFailed.Error(),
+				}
+
+				if item.ConditionCheck.ReturnValuesOnConditionCheckFailure == ddbtypes.ReturnValuesOnConditionCheckFailureAllOld {
+					checkErr.Item = stored
+				}
+
+				return nil, newServerTransactionCancelledError(i, n, checkErr)
+			}
+
+		default:
+			return nil, &smithy.GenericAPIError{Code: "ValidationException", Message: "transaction item must include one of Put, Update, Delete, or ConditionCheck"}
+		}
+	}
+
+	return &TransactWriteItemsOutput{}, nil
+}
+
+func newServerTransactionCancelledError(i, n int, opErr error) error {
+	var ccf *types.ConditionalCheckFailedException
+	if !errors.As(opErr, &ccf) {
+		return mapKnownError(opErr)
+	}
+
+	reasons := make([]ddbtypes.CancellationReason, n)
+	for j := range reasons {
+		reasons[j] = ddbtypes.CancellationReason{Code: aws.String("None")}
+	}
+
+	reasons[i] = ddbtypes.CancellationReason{
+		Code:    aws.String("ConditionalCheckFailed"),
+		Message: aws.String(core.ErrConditionalRequestFailed.Error()),
+	}
+
+	if ccf.Item != nil {
+		reasons[i].Item = mapTypesMapToDDBAttributeValue(ccf.Item)
+	}
+
+	return &ddbtypes.TransactionCanceledException{
+		Message:             aws.String("Transaction cancelled, please refer cancellation reasons for specific reasons [ConditionalCheckFailed]"),
+		CancellationReasons: reasons,
+	}
+}
+
 // Utilities
 func mapTypesSliceToAttributeValue(items []map[string]*types.Item) []map[string]*AttributeValue {
 	if len(items) == 0 {

--- a/server/client.go
+++ b/server/client.go
@@ -534,9 +534,61 @@ func (c *Client) BatchWriteItem(ctx context.Context, input *BatchWriteItemInput)
 	return &BatchWriteItemOutput{UnprocessedItems: unprocessed}, nil
 }
 
+func (c *Client) prepareTransact(items []TransactWriteItem) (map[string]core.TableSnapshot, error) {
+	snapshots := map[string]core.TableSnapshot{}
+	seenKeys := make(map[string]struct{}, len(items))
+
+	for _, item := range items {
+		var tableName string
+		var rawKeyMap map[string]*AttributeValue
+
+		switch {
+		case item.Put != nil:
+			tableName, rawKeyMap = aws.ToString(item.Put.TableName), item.Put.Item
+		case item.Update != nil:
+			tableName, rawKeyMap = aws.ToString(item.Update.TableName), item.Update.Key
+		case item.Delete != nil:
+			tableName, rawKeyMap = aws.ToString(item.Delete.TableName), item.Delete.Key
+		case item.ConditionCheck != nil:
+			tableName, rawKeyMap = aws.ToString(item.ConditionCheck.TableName), item.ConditionCheck.Key
+		}
+
+		if tableName == "" {
+			continue
+		}
+
+		if _, alreadySnapped := snapshots[tableName]; !alreadySnapped {
+			table, err := c.getTable(tableName)
+			if err != nil {
+				return nil, mapKnownError(err)
+			}
+
+			snapshots[tableName] = table.Snapshot()
+		}
+
+		table := c.tables[tableName]
+		internalKeyMap := mapAttributeValueMapToTypes(rawKeyMap)
+
+		if key, err := table.KeySchema.GetKey(table.AttributesDef, internalKeyMap); err == nil {
+			id := tableName + "|" + key
+
+			if _, exists := seenKeys[id]; exists {
+				return nil, &smithy.GenericAPIError{
+					Code:    "ValidationException",
+					Message: "Transaction request cannot include multiple operations on one item",
+				}
+			}
+
+			seenKeys[id] = struct{}{}
+		}
+	}
+
+	return snapshots, nil
+}
+
 // TransactWriteItems executes a set of Put, Update, Delete, and ConditionCheck operations atomically.
 // If any operation fails the entire transaction is  rolled back via table snapshots captured before execution begins.
-func (c *Client) TransactWriteItems(ctx context.Context, input *TransactWriteItemsInput) (_ *TransactWriteItemsOutput, err error) {
+func (c *Client) TransactWriteItems(ctx context.Context, input *TransactWriteItemsInput) (*TransactWriteItemsOutput, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -544,172 +596,178 @@ func (c *Client) TransactWriteItems(ctx context.Context, input *TransactWriteIte
 		return nil, c.forceFailureErr
 	}
 
-	snapshots := map[string]core.TableSnapshot{}
+	snapshots, err := c.prepareTransact(input.TransactItems)
+	if err != nil {
+		return nil, err
+	}
+
+	var execErr error
 
 	defer func() {
-		if err != nil {
+		if execErr != nil {
 			for name, snap := range snapshots {
 				c.tables[name].Restore(snap)
 			}
 		}
 	}()
 
-	for _, item := range input.TransactItems {
-		var tableName string
-
-		switch {
-		case item.Put != nil:
-			tableName = aws.ToString(item.Put.TableName)
-		case item.Update != nil:
-			tableName = aws.ToString(item.Update.TableName)
-		case item.Delete != nil:
-			tableName = aws.ToString(item.Delete.TableName)
-		case item.ConditionCheck != nil:
-			tableName = aws.ToString(item.ConditionCheck.TableName)
-		}
-
-		if _, alreadySnapped := snapshots[tableName]; tableName == "" || alreadySnapped {
-			continue
-		}
-
-		table, tErr := c.getTable(tableName)
-		if tErr != nil {
-			return nil, mapKnownError(tErr)
-		}
-
-		snapshots[tableName] = table.Snapshot()
-	}
-
 	n := len(input.TransactItems)
 
 	for i, item := range input.TransactItems {
-		switch {
-		case item.Put != nil:
-			if err = validateExpressionAttributes(item.Put.ExpressionAttributeNames, keysFromAttributeValueMap(item.Put.ExpressionAttributeValues), aws.ToString(item.Put.ConditionExpression)); err != nil {
-				return nil, err
-			}
-
-			table, tErr := c.getTable(aws.ToString(item.Put.TableName))
-			if tErr != nil {
-				return nil, mapKnownError(tErr)
-			}
-
-			if _, opErr := table.Put(&types.PutItemInput{
-				TableName:                 item.Put.TableName,
-				ConditionExpression:       item.Put.ConditionExpression,
-				ExpressionAttributeNames:  item.Put.ExpressionAttributeNames,
-				ExpressionAttributeValues: mapAttributeValueMapToTypes(item.Put.ExpressionAttributeValues),
-				Item:                      mapAttributeValueMapToTypes(item.Put.Item),
-			}); opErr != nil {
-				return nil, newServerTransactionCancelledError(i, n, opErr)
-			}
-
-		case item.Update != nil:
-			if err = validateExpressionAttributes(item.Update.ExpressionAttributeNames, keysFromAttributeValueMap(item.Update.ExpressionAttributeValues), aws.ToString(item.Update.UpdateExpression), aws.ToString(item.Update.ConditionExpression)); err != nil {
-				return nil, err
-			}
-
-			table, tErr := c.getTable(aws.ToString(item.Update.TableName))
-			if tErr != nil {
-				return nil, mapKnownError(tErr)
-			}
-
-			_, opErr := table.Update(&types.UpdateItemInput{
-				TableName:                           item.Update.TableName,
-				ConditionExpression:                 item.Update.ConditionExpression,
-				ExpressionAttributeNames:            item.Update.ExpressionAttributeNames,
-				ExpressionAttributeValues:           mapAttributeValueMapToTypes(item.Update.ExpressionAttributeValues),
-				Key:                                 mapAttributeValueMapToTypes(item.Update.Key),
-				UpdateExpression:                    aws.ToString(item.Update.UpdateExpression),
-				ReturnValuesOnConditionCheckFailure: toStringPtr(string(item.Update.ReturnValuesOnConditionCheckFailure)),
-			})
-			if opErr != nil {
-				if errors.Is(opErr, interpreter.ErrSyntaxError) {
-					return nil, &smithy.GenericAPIError{Code: "ValidationException", Message: opErr.Error()}
-				}
-
-				return nil, newServerTransactionCancelledError(i, n, opErr)
-			}
-
-		case item.Delete != nil:
-			if err = validateExpressionAttributes(item.Delete.ExpressionAttributeNames, keysFromAttributeValueMap(item.Delete.ExpressionAttributeValues), aws.ToString(item.Delete.ConditionExpression)); err != nil {
-				return nil, err
-			}
-
-			table, tErr := c.getTable(aws.ToString(item.Delete.TableName))
-			if tErr != nil {
-				return nil, mapKnownError(tErr)
-			}
-
-			if _, opErr := table.Delete(&types.DeleteItemInput{
-				TableName:                 item.Delete.TableName,
-				ConditionExpression:       item.Delete.ConditionExpression,
-				ExpressionAttributeNames:  toStringPtrMap(item.Delete.ExpressionAttributeNames),
-				ExpressionAttributeValues: mapAttributeValueMapToTypes(item.Delete.ExpressionAttributeValues),
-				Key:                       mapAttributeValueMapToTypes(item.Delete.Key),
-			}); opErr != nil {
-				return nil, newServerTransactionCancelledError(i, n, opErr)
-			}
-
-		case item.ConditionCheck != nil:
-			if err = validateExpressionAttributes(item.ConditionCheck.ExpressionAttributeNames, keysFromAttributeValueMap(item.ConditionCheck.ExpressionAttributeValues), aws.ToString(item.ConditionCheck.ConditionExpression)); err != nil {
-				return nil, err
-			}
-
-			table, tErr := c.getTable(aws.ToString(item.ConditionCheck.TableName))
-			if tErr != nil {
-				return nil, mapKnownError(tErr)
-			}
-
-			keyMap := mapAttributeValueMapToTypes(item.ConditionCheck.Key)
-			if vErr := types.ValidateItemMap(keyMap); vErr != nil {
-				return nil, mapKnownError(types.NewError("ValidationException", vErr.Error(), nil))
-			}
-
-			if keyErr := table.ValidatePrimaryKeyMap(keyMap); keyErr != nil {
-				return nil, &smithy.GenericAPIError{Code: "ValidationException", Message: keyErr.Error()}
-			}
-
-			key, kErr := table.KeySchema.GetKey(table.AttributesDef, keyMap)
-			if kErr != nil {
-				return nil, &smithy.GenericAPIError{Code: "ValidationException", Message: kErr.Error()}
-			}
-
-			stored := table.Data[key]
-			if stored == nil {
-				stored = map[string]*types.Item{}
-			}
-
-			matched, mErr := table.InterpreterMatch(interpreter.MatchInput{
-				TableName:      table.Name,
-				Expression:     aws.ToString(item.ConditionCheck.ConditionExpression),
-				ExpressionType: interpreter.ExpressionTypeConditional,
-				Item:           stored,
-				Aliases:        item.ConditionCheck.ExpressionAttributeNames,
-				Attributes:     mapAttributeValueMapToTypes(item.ConditionCheck.ExpressionAttributeValues),
-			})
-			if mErr != nil {
-				return nil, &smithy.GenericAPIError{Code: "ValidationException", Message: mErr.Error()}
-			}
-
-			if !matched {
-				checkErr := &types.ConditionalCheckFailedException{
-					MessageText: core.ErrConditionalRequestFailed.Error(),
-				}
-
-				if item.ConditionCheck.ReturnValuesOnConditionCheckFailure == ddbtypes.ReturnValuesOnConditionCheckFailureAllOld {
-					checkErr.Item = stored
-				}
-
-				return nil, newServerTransactionCancelledError(i, n, checkErr)
-			}
-
-		default:
-			return nil, &smithy.GenericAPIError{Code: "ValidationException", Message: "transaction item must include one of Put, Update, Delete, or ConditionCheck"}
+		execErr = c.runTransactItem(i, n, item)
+		if execErr != nil {
+			return nil, execErr
 		}
 	}
 
 	return &TransactWriteItemsOutput{}, nil
+}
+
+func (c *Client) runTransactItem(i, n int, item TransactWriteItem) error {
+	switch {
+	case item.Put != nil:
+		return c.runTransactPut(i, n, item.Put)
+	case item.Update != nil:
+		return c.runTransactUpdate(i, n, item.Update)
+	case item.Delete != nil:
+		return c.runTransactDelete(i, n, item.Delete)
+	case item.ConditionCheck != nil:
+		return c.runTransactConditionCheck(i, n, item.ConditionCheck)
+	default:
+		return &smithy.GenericAPIError{Code: "ValidationException", Message: "transaction item must include one of Put, Update, Delete, or ConditionCheck"}
+	}
+}
+
+func (c *Client) runTransactPut(i, n int, put *Put) error {
+	if vErr := validateExpressionAttributes(put.ExpressionAttributeNames, keysFromAttributeValueMap(put.ExpressionAttributeValues), aws.ToString(put.ConditionExpression)); vErr != nil {
+		return vErr
+	}
+
+	table, tErr := c.getTable(aws.ToString(put.TableName))
+	if tErr != nil {
+		return mapKnownError(tErr)
+	}
+
+	if _, opErr := table.Put(&types.PutItemInput{
+		TableName:                 put.TableName,
+		ConditionExpression:       put.ConditionExpression,
+		ExpressionAttributeNames:  put.ExpressionAttributeNames,
+		ExpressionAttributeValues: mapAttributeValueMapToTypes(put.ExpressionAttributeValues),
+		Item:                      mapAttributeValueMapToTypes(put.Item),
+	}); opErr != nil {
+		return newServerTransactionCancelledError(i, n, opErr)
+	}
+
+	return nil
+}
+
+func (c *Client) runTransactUpdate(i, n int, update *Update) error {
+	if vErr := validateExpressionAttributes(update.ExpressionAttributeNames, keysFromAttributeValueMap(update.ExpressionAttributeValues), aws.ToString(update.UpdateExpression), aws.ToString(update.ConditionExpression)); vErr != nil {
+		return vErr
+	}
+
+	table, tErr := c.getTable(aws.ToString(update.TableName))
+	if tErr != nil {
+		return mapKnownError(tErr)
+	}
+
+	_, opErr := table.Update(&types.UpdateItemInput{
+		TableName:                           update.TableName,
+		ConditionExpression:                 update.ConditionExpression,
+		ExpressionAttributeNames:            update.ExpressionAttributeNames,
+		ExpressionAttributeValues:           mapAttributeValueMapToTypes(update.ExpressionAttributeValues),
+		Key:                                 mapAttributeValueMapToTypes(update.Key),
+		UpdateExpression:                    aws.ToString(update.UpdateExpression),
+		ReturnValuesOnConditionCheckFailure: toStringPtr(string(update.ReturnValuesOnConditionCheckFailure)),
+	})
+	if opErr != nil {
+		if errors.Is(opErr, interpreter.ErrSyntaxError) {
+			return &smithy.GenericAPIError{Code: "ValidationException", Message: opErr.Error()}
+		}
+
+		return newServerTransactionCancelledError(i, n, opErr)
+	}
+
+	return nil
+}
+
+func (c *Client) runTransactDelete(i, n int, del *Delete) error {
+	if vErr := validateExpressionAttributes(del.ExpressionAttributeNames, keysFromAttributeValueMap(del.ExpressionAttributeValues), aws.ToString(del.ConditionExpression)); vErr != nil {
+		return vErr
+	}
+
+	table, tErr := c.getTable(aws.ToString(del.TableName))
+	if tErr != nil {
+		return mapKnownError(tErr)
+	}
+
+	if _, opErr := table.Delete(&types.DeleteItemInput{
+		TableName:                 del.TableName,
+		ConditionExpression:       del.ConditionExpression,
+		ExpressionAttributeNames:  toStringPtrMap(del.ExpressionAttributeNames),
+		ExpressionAttributeValues: mapAttributeValueMapToTypes(del.ExpressionAttributeValues),
+		Key:                       mapAttributeValueMapToTypes(del.Key),
+	}); opErr != nil {
+		return newServerTransactionCancelledError(i, n, opErr)
+	}
+
+	return nil
+}
+
+func (c *Client) runTransactConditionCheck(i, n int, check *ConditionCheck) error {
+	if vErr := validateExpressionAttributes(check.ExpressionAttributeNames, keysFromAttributeValueMap(check.ExpressionAttributeValues), aws.ToString(check.ConditionExpression)); vErr != nil {
+		return vErr
+	}
+
+	table, tErr := c.getTable(aws.ToString(check.TableName))
+	if tErr != nil {
+		return mapKnownError(tErr)
+	}
+
+	keyMap := mapAttributeValueMapToTypes(check.Key)
+	if vErr := types.ValidateItemMap(keyMap); vErr != nil {
+		return mapKnownError(types.NewError("ValidationException", vErr.Error(), nil))
+	}
+
+	if keyErr := table.ValidatePrimaryKeyMap(keyMap); keyErr != nil {
+		return &smithy.GenericAPIError{Code: "ValidationException", Message: keyErr.Error()}
+	}
+
+	key, kErr := table.KeySchema.GetKey(table.AttributesDef, keyMap)
+	if kErr != nil {
+		return &smithy.GenericAPIError{Code: "ValidationException", Message: kErr.Error()}
+	}
+
+	stored := table.Data[key]
+	if stored == nil {
+		stored = map[string]*types.Item{}
+	}
+
+	matched, mErr := table.InterpreterMatch(interpreter.MatchInput{
+		TableName:      table.Name,
+		Expression:     aws.ToString(check.ConditionExpression),
+		ExpressionType: interpreter.ExpressionTypeConditional,
+		Item:           stored,
+		Aliases:        check.ExpressionAttributeNames,
+		Attributes:     mapAttributeValueMapToTypes(check.ExpressionAttributeValues),
+	})
+	if mErr != nil {
+		return &smithy.GenericAPIError{Code: "ValidationException", Message: mErr.Error()}
+	}
+
+	if !matched {
+		checkErr := &types.ConditionalCheckFailedException{
+			MessageText: core.ErrConditionalRequestFailed.Error(),
+		}
+
+		if check.ReturnValuesOnConditionCheckFailure == ddbtypes.ReturnValuesOnConditionCheckFailureAllOld {
+			checkErr.Item = stored
+		}
+
+		return newServerTransactionCancelledError(i, n, checkErr)
+	}
+
+	return nil
 }
 
 func newServerTransactionCancelledError(i, n int, opErr error) error {

--- a/server/expression_attributes.go
+++ b/server/expression_attributes.go
@@ -3,6 +3,7 @@ package server
 import (
 	"fmt"
 	"regexp"
+	"sort"
 	"strings"
 
 	"github.com/aws/smithy-go"
@@ -12,11 +13,12 @@ import (
 )
 
 const (
-	expressionAttributeNamesOnlyWithExpressionsMsg = "ExpressionAttributeNames can only be specified when using expressions"
-	unusedExpressionAttributeNamesMsg              = "Value provided in ExpressionAttributeNames unused in expressions"
-	unusedExpressionAttributeValuesMsg             = "Value provided in ExpressionAttributeValues unused in expressions"
-	invalidExpressionAttributeName                 = "ExpressionAttributeNames contains invalid key"
-	invalidExpressionAttributeValue                = "ExpressionAttributeValues contains invalid key"
+	expressionAttributeNamesOnlyWithExpressionsMsg  = "ExpressionAttributeNames can only be specified when using expressions"
+	expressionAttributeValuesOnlyWithExpressionsMsg = "ExpressionAttributeValues can only be specified when using expressions"
+	unusedExpressionAttributeNamesMsg               = "Value provided in ExpressionAttributeNames unused in expressions"
+	unusedExpressionAttributeValuesMsg              = "Value provided in ExpressionAttributeValues unused in expressions"
+	invalidExpressionAttributeName                  = "ExpressionAttributeNames contains invalid key"
+	invalidExpressionAttributeValue                 = "ExpressionAttributeValues contains invalid key"
 )
 
 var (
@@ -41,6 +43,8 @@ func validateExpressionAttributes(exprNames map[string]string, exprValueKeys []s
 	missingValues := getMissingSubstrs(genericExpression, exprValueKeys)
 
 	if len(missingNames) > 0 {
+		sort.Strings(missingNames)
+
 		msg := unusedExpressionAttributeNamesMsg
 		if genericExpression == "" {
 			msg = expressionAttributeNamesOnlyWithExpressionsMsg
@@ -55,6 +59,12 @@ func validateExpressionAttributes(exprNames map[string]string, exprValueKeys []s
 	}
 
 	if len(missingValues) > 0 {
+		if genericExpression == "" {
+			return &smithy.GenericAPIError{Code: "ValidationException", Message: expressionAttributeValuesOnlyWithExpressionsMsg}
+		}
+
+		sort.Strings(missingValues)
+
 		return &smithy.GenericAPIError{Code: "ValidationException", Message: fmt.Sprintf("%s: keys: {%s}", unusedExpressionAttributeValuesMsg, strings.Join(missingValues, ", "))}
 	}
 

--- a/server/responses.go
+++ b/server/responses.go
@@ -63,3 +63,6 @@ type ScanOutput struct {
 type BatchWriteItemOutput struct {
 	UnprocessedItems map[string][]WriteRequest `json:"UnprocessedItems,omitempty"`
 }
+
+// TransactWriteItemsOutput mirrors DynamoDB TransactWriteItemsOutput.
+type TransactWriteItemsOutput struct{}

--- a/server/server.go
+++ b/server/server.go
@@ -112,6 +112,11 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		if err = decoder.Decode(&input); err == nil {
 			resp, err = s.client.BatchWriteItem(context.Background(), &input)
 		}
+	case "TransactWriteItems":
+		var input TransactWriteItemsInput
+		if err = decoder.Decode(&input); err == nil {
+			resp, err = s.client.TransactWriteItems(context.Background(), &input)
+		}
 	default:
 		http.Error(w, "unsupported operation", http.StatusBadRequest)
 		return
@@ -130,6 +135,46 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func writeError(w http.ResponseWriter, err error) {
+	var tce *ddbtypes.TransactionCanceledException
+
+	if errors.As(err, &tce) {
+		type cancellationReasonWire struct {
+			Code    string                     `json:"Code"`
+			Message string                     `json:"Message,omitempty"`
+			Item    map[string]*AttributeValue `json:"Item,omitempty"`
+		}
+
+		type tceBody struct {
+			Type                string                   `json:"__type"`
+			Message             string                   `json:"message"`
+			CancellationReasons []cancellationReasonWire `json:"CancellationReasons"`
+		}
+
+		wireReasons := make([]cancellationReasonWire, len(tce.CancellationReasons))
+		for i, r := range tce.CancellationReasons {
+			wireReasons[i] = cancellationReasonWire{
+				Code:    aws.ToString(r.Code),
+				Message: aws.ToString(r.Message),
+			}
+
+			if len(r.Item) > 0 {
+				wireReasons[i].Item = mapDDBAttributeMapToWire(r.Item)
+			}
+		}
+
+		body := tceBody{
+			Type:                "TransactionCanceledException",
+			Message:             aws.ToString(tce.Message),
+			CancellationReasons: wireReasons,
+		}
+
+		w.Header().Set("Content-Type", "application/x-amz-json-1.0")
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(body)
+
+		return
+	}
+
 	var ccf *ddbtypes.ConditionalCheckFailedException
 
 	if errors.As(err, &ccf) {

--- a/server/server.go
+++ b/server/server.go
@@ -135,9 +135,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func writeError(w http.ResponseWriter, err error) {
-	var tce *ddbtypes.TransactionCanceledException
-
-	if errors.As(err, &tce) {
+	if tce, ok := errors.AsType[*ddbtypes.TransactionCanceledException](err); ok {
 		type cancellationReasonWire struct {
 			Code    string                     `json:"Code"`
 			Message string                     `json:"Message,omitempty"`
@@ -175,9 +173,7 @@ func writeError(w http.ResponseWriter, err error) {
 		return
 	}
 
-	var ccf *ddbtypes.ConditionalCheckFailedException
-
-	if errors.As(err, &ccf) {
+	if ccf, ok := errors.AsType[*ddbtypes.ConditionalCheckFailedException](err); ok {
 		type ccfBody struct {
 			Type    string                     `json:"__type"`
 			Message string                     `json:"message"`

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1809,3 +1809,668 @@ func makeBasicTable(t *testing.T, cli *dynamodb.Client, table, hashKey string) {
 	})
 	require.NoError(t, err)
 }
+
+func TestServerTransactWriteItems(t *testing.T) {
+	s := NewServer()
+	ts := httptest.NewServer(s)
+
+	defer ts.Close()
+
+	cli := newTestDynamoClient(t, ts.URL)
+
+	makeBasicTable(t, cli, "pokemons", "id")
+
+	t.Run("atomicity", func(t *testing.T) {
+		t.Run("rollback on failure", func(t *testing.T) {
+			c := require.New(t)
+
+			_, err := cli.TransactWriteItems(context.Background(), &dynamodb.TransactWriteItemsInput{
+				TransactItems: []ddbtypes.TransactWriteItem{
+					{
+						Put: &ddbtypes.Put{
+							TableName: aws.String("pokemons"),
+							Item: map[string]ddbtypes.AttributeValue{
+								"id":   &ddbtypes.AttributeValueMemberS{Value: "rollback-me"},
+								"name": &ddbtypes.AttributeValueMemberS{Value: "ShouldNotExist"},
+							},
+						},
+					},
+					{
+						ConditionCheck: &ddbtypes.ConditionCheck{
+							TableName:           aws.String("pokemons"),
+							Key:                 map[string]ddbtypes.AttributeValue{"id": &ddbtypes.AttributeValueMemberS{Value: "non-existent"}},
+							ConditionExpression: aws.String("attribute_exists(id)"),
+						},
+					},
+				},
+			})
+			c.Error(err)
+
+			out, err := cli.GetItem(context.Background(), &dynamodb.GetItemInput{
+				TableName: aws.String("pokemons"),
+				Key:       map[string]ddbtypes.AttributeValue{"id": &ddbtypes.AttributeValueMemberS{Value: "rollback-me"}},
+			})
+			c.NoError(err)
+			c.Empty(out.Item)
+		})
+
+		t.Run("rollback across tables", func(t *testing.T) {
+			c := require.New(t)
+
+			makeBasicTable(t, cli, "items", "id")
+
+			_, err := cli.TransactWriteItems(context.Background(), &dynamodb.TransactWriteItemsInput{
+				TransactItems: []ddbtypes.TransactWriteItem{
+					{
+						Put: &ddbtypes.Put{
+							TableName: aws.String("items"),
+							Item: map[string]ddbtypes.AttributeValue{
+								"id": &ddbtypes.AttributeValueMemberS{Value: "should-rollback"},
+							},
+						},
+					},
+					{
+						ConditionCheck: &ddbtypes.ConditionCheck{
+							TableName:           aws.String("pokemons"),
+							Key:                 map[string]ddbtypes.AttributeValue{"id": &ddbtypes.AttributeValueMemberS{Value: "non-existent"}},
+							ConditionExpression: aws.String("attribute_exists(id)"),
+						},
+					},
+				},
+			})
+
+			var tce *ddbtypes.TransactionCanceledException
+			c.True(errors.As(err, &tce))
+
+			out, err := cli.GetItem(context.Background(), &dynamodb.GetItemInput{
+				TableName: aws.String("items"),
+				Key:       map[string]ddbtypes.AttributeValue{"id": &ddbtypes.AttributeValueMemberS{Value: "should-rollback"}},
+			})
+			c.NoError(err)
+			c.Empty(out.Item)
+		})
+	})
+
+	t.Run("validation", func(t *testing.T) {
+		t.Run("empty item rejected", func(t *testing.T) {
+			c := require.New(t)
+
+			_, err := cli.TransactWriteItems(context.Background(), &dynamodb.TransactWriteItemsInput{
+				TransactItems: []ddbtypes.TransactWriteItem{{}},
+			})
+
+			var apiErr smithy.APIError
+			c.True(errors.As(err, &apiErr))
+			c.Equal("ValidationException", apiErr.ErrorCode())
+		})
+
+		t.Run("duplicate item rejected", func(t *testing.T) {
+			c := require.New(t)
+
+			_, err := cli.TransactWriteItems(context.Background(), &dynamodb.TransactWriteItemsInput{
+				TransactItems: []ddbtypes.TransactWriteItem{
+					{
+						Put: &ddbtypes.Put{
+							TableName: aws.String("pokemons"),
+							Item:      map[string]ddbtypes.AttributeValue{"id": &ddbtypes.AttributeValueMemberS{Value: "dup"}},
+						},
+					},
+					{
+						Update: &ddbtypes.Update{
+							TableName:                 aws.String("pokemons"),
+							Key:                       map[string]ddbtypes.AttributeValue{"id": &ddbtypes.AttributeValueMemberS{Value: "dup"}},
+							UpdateExpression:          aws.String("SET #n = :n"),
+							ExpressionAttributeNames:  map[string]string{"#n": "name"},
+							ExpressionAttributeValues: map[string]ddbtypes.AttributeValue{":n": &ddbtypes.AttributeValueMemberS{Value: "Bulbasaur"}},
+						},
+					},
+				},
+			})
+
+			var apiErr smithy.APIError
+			c.True(errors.As(err, &apiErr))
+			c.Equal("ValidationException", apiErr.ErrorCode())
+		})
+	})
+
+	t.Run("error injection", func(t *testing.T) {
+		t.Run("emulated server error", func(t *testing.T) {
+			c := require.New(t)
+
+			s.EmulateFailure(FailureConditionInternalServerError)
+			defer s.EmulateFailure(FailureConditionNone)
+
+			_, err := cli.TransactWriteItems(context.Background(), &dynamodb.TransactWriteItemsInput{
+				TransactItems: []ddbtypes.TransactWriteItem{
+					{
+						Put: &ddbtypes.Put{
+							TableName: aws.String("pokemons"),
+							Item: map[string]ddbtypes.AttributeValue{
+								"id": &ddbtypes.AttributeValueMemberS{Value: "001"},
+							},
+						},
+					},
+				},
+			})
+
+			var internalErr *ddbtypes.InternalServerError
+			c.True(errors.As(err, &internalErr))
+		})
+	})
+
+	t.Run("put", func(t *testing.T) {
+		t.Run("success", func(t *testing.T) {
+			c := require.New(t)
+
+			_, err := cli.TransactWriteItems(context.Background(), &dynamodb.TransactWriteItemsInput{
+				TransactItems: []ddbtypes.TransactWriteItem{
+					{
+						Put: &ddbtypes.Put{
+							TableName: aws.String("pokemons"),
+							Item: map[string]ddbtypes.AttributeValue{
+								"id":   &ddbtypes.AttributeValueMemberS{Value: "001"},
+								"name": &ddbtypes.AttributeValueMemberS{Value: "Bulbasaur"},
+							},
+						},
+					},
+				},
+			})
+			c.NoError(err)
+
+			out, err := cli.GetItem(context.Background(), &dynamodb.GetItemInput{
+				TableName: aws.String("pokemons"),
+				Key:       map[string]ddbtypes.AttributeValue{"id": &ddbtypes.AttributeValueMemberS{Value: "001"}},
+			})
+			c.NoError(err)
+			c.Equal("Bulbasaur", out.Item["name"].(*ddbtypes.AttributeValueMemberS).Value)
+		})
+
+		t.Run("non-existent table", func(t *testing.T) {
+			c := require.New(t)
+
+			_, err := cli.TransactWriteItems(context.Background(), &dynamodb.TransactWriteItemsInput{
+				TransactItems: []ddbtypes.TransactWriteItem{
+					{
+						Put: &ddbtypes.Put{
+							TableName: aws.String("non-existent"),
+							Item:      map[string]ddbtypes.AttributeValue{"id": &ddbtypes.AttributeValueMemberS{Value: "1"}},
+						},
+					},
+				},
+			})
+
+			var notFound *ddbtypes.ResourceNotFoundException
+			c.True(errors.As(err, &notFound))
+		})
+
+		t.Run("unused expression attribute", func(t *testing.T) {
+			c := require.New(t)
+
+			_, err := cli.TransactWriteItems(context.Background(), &dynamodb.TransactWriteItemsInput{
+				TransactItems: []ddbtypes.TransactWriteItem{
+					{
+						Put: &ddbtypes.Put{
+							TableName: aws.String("pokemons"),
+							Item: map[string]ddbtypes.AttributeValue{
+								"id": &ddbtypes.AttributeValueMemberS{Value: "001"},
+							},
+							ExpressionAttributeValues: map[string]ddbtypes.AttributeValue{
+								":unused": &ddbtypes.AttributeValueMemberS{Value: "x"},
+							},
+						},
+					},
+				},
+			})
+
+			var apiErr smithy.APIError
+			c.True(errors.As(err, &apiErr))
+			c.Equal("ValidationException", apiErr.ErrorCode())
+		})
+
+		t.Run("failing condition", func(t *testing.T) {
+			c := require.New(t)
+
+			_, err := cli.PutItem(context.Background(), &dynamodb.PutItemInput{
+				TableName: aws.String("pokemons"),
+				Item: map[string]ddbtypes.AttributeValue{
+					"id":   &ddbtypes.AttributeValueMemberS{Value: "cond-put"},
+					"name": &ddbtypes.AttributeValueMemberS{Value: "Mewtwo"},
+				},
+			})
+			c.NoError(err)
+
+			_, err = cli.TransactWriteItems(context.Background(), &dynamodb.TransactWriteItemsInput{
+				TransactItems: []ddbtypes.TransactWriteItem{
+					{
+						Put: &ddbtypes.Put{
+							TableName:           aws.String("pokemons"),
+							Item:                map[string]ddbtypes.AttributeValue{"id": &ddbtypes.AttributeValueMemberS{Value: "cond-put"}},
+							ConditionExpression: aws.String("attribute_not_exists(id)"),
+						},
+					},
+				},
+			})
+
+			var tce *ddbtypes.TransactionCanceledException
+			c.True(errors.As(err, &tce))
+			c.Equal("ConditionalCheckFailed", aws.ToString(tce.CancellationReasons[0].Code))
+		})
+	})
+
+	t.Run("update", func(t *testing.T) {
+		t.Run("success", func(t *testing.T) {
+			c := require.New(t)
+
+			_, err := cli.PutItem(context.Background(), &dynamodb.PutItemInput{
+				TableName: aws.String("pokemons"),
+				Item: map[string]ddbtypes.AttributeValue{
+					"id":   &ddbtypes.AttributeValueMemberS{Value: "002"},
+					"name": &ddbtypes.AttributeValueMemberS{Value: "Ivysaur"},
+				},
+			})
+			c.NoError(err)
+
+			_, err = cli.TransactWriteItems(context.Background(), &dynamodb.TransactWriteItemsInput{
+				TransactItems: []ddbtypes.TransactWriteItem{
+					{
+						Update: &ddbtypes.Update{
+							TableName:                 aws.String("pokemons"),
+							Key:                       map[string]ddbtypes.AttributeValue{"id": &ddbtypes.AttributeValueMemberS{Value: "002"}},
+							UpdateExpression:          aws.String("SET #n = :n"),
+							ExpressionAttributeNames:  map[string]string{"#n": "name"},
+							ExpressionAttributeValues: map[string]ddbtypes.AttributeValue{":n": &ddbtypes.AttributeValueMemberS{Value: "Venusaur"}},
+						},
+					},
+				},
+			})
+			c.NoError(err)
+
+			out, err := cli.GetItem(context.Background(), &dynamodb.GetItemInput{
+				TableName: aws.String("pokemons"),
+				Key:       map[string]ddbtypes.AttributeValue{"id": &ddbtypes.AttributeValueMemberS{Value: "002"}},
+			})
+			c.NoError(err)
+			c.Equal("Venusaur", out.Item["name"].(*ddbtypes.AttributeValueMemberS).Value)
+		})
+
+		t.Run("non-existent table", func(t *testing.T) {
+			c := require.New(t)
+
+			_, err := cli.TransactWriteItems(context.Background(), &dynamodb.TransactWriteItemsInput{
+				TransactItems: []ddbtypes.TransactWriteItem{
+					{
+						Update: &ddbtypes.Update{
+							TableName:                 aws.String("non-existent"),
+							Key:                       map[string]ddbtypes.AttributeValue{"id": &ddbtypes.AttributeValueMemberS{Value: "1"}},
+							UpdateExpression:          aws.String("SET #n = :n"),
+							ExpressionAttributeNames:  map[string]string{"#n": "name"},
+							ExpressionAttributeValues: map[string]ddbtypes.AttributeValue{":n": &ddbtypes.AttributeValueMemberS{Value: "x"}},
+						},
+					},
+				},
+			})
+
+			var notFound *ddbtypes.ResourceNotFoundException
+			c.True(errors.As(err, &notFound))
+		})
+
+		t.Run("unused expression attribute", func(t *testing.T) {
+			c := require.New(t)
+
+			_, err := cli.TransactWriteItems(context.Background(), &dynamodb.TransactWriteItemsInput{
+				TransactItems: []ddbtypes.TransactWriteItem{
+					{
+						Update: &ddbtypes.Update{
+							TableName:                aws.String("pokemons"),
+							Key:                      map[string]ddbtypes.AttributeValue{"id": &ddbtypes.AttributeValueMemberS{Value: "001"}},
+							UpdateExpression:         aws.String("SET #n = :n"),
+							ExpressionAttributeNames: map[string]string{"#n": "name"},
+							ExpressionAttributeValues: map[string]ddbtypes.AttributeValue{
+								":n":      &ddbtypes.AttributeValueMemberS{Value: "Venusaur"},
+								":unused": &ddbtypes.AttributeValueMemberS{Value: "x"},
+							},
+						},
+					},
+				},
+			})
+
+			var apiErr smithy.APIError
+			c.True(errors.As(err, &apiErr))
+			c.Equal("ValidationException", apiErr.ErrorCode())
+		})
+
+		t.Run("syntax error", func(t *testing.T) {
+			c := require.New(t)
+
+			_, err := cli.PutItem(context.Background(), &dynamodb.PutItemInput{
+				TableName: aws.String("pokemons"),
+				Item: map[string]ddbtypes.AttributeValue{
+					"id":   &ddbtypes.AttributeValueMemberS{Value: "syntax-test"},
+					"name": &ddbtypes.AttributeValueMemberS{Value: "Snorlax"},
+				},
+			})
+			c.NoError(err)
+
+			_, err = cli.TransactWriteItems(context.Background(), &dynamodb.TransactWriteItemsInput{
+				TransactItems: []ddbtypes.TransactWriteItem{
+					{
+						Update: &ddbtypes.Update{
+							TableName:                 aws.String("pokemons"),
+							Key:                       map[string]ddbtypes.AttributeValue{"id": &ddbtypes.AttributeValueMemberS{Value: "syntax-test"}},
+							UpdateExpression:          aws.String("SET #n = :n SET #n = :n"),
+							ExpressionAttributeNames:  map[string]string{"#n": "name"},
+							ExpressionAttributeValues: map[string]ddbtypes.AttributeValue{":n": &ddbtypes.AttributeValueMemberS{Value: "Munchlax"}},
+						},
+					},
+				},
+			})
+
+			var apiErr smithy.APIError
+			c.True(errors.As(err, &apiErr))
+			c.Equal("ValidationException", apiErr.ErrorCode())
+		})
+
+		t.Run("failing condition", func(t *testing.T) {
+			c := require.New(t)
+
+			_, err := cli.PutItem(context.Background(), &dynamodb.PutItemInput{
+				TableName: aws.String("pokemons"),
+				Item: map[string]ddbtypes.AttributeValue{
+					"id":   &ddbtypes.AttributeValueMemberS{Value: "cond-update"},
+					"name": &ddbtypes.AttributeValueMemberS{Value: "Mew"},
+				},
+			})
+			c.NoError(err)
+
+			_, err = cli.TransactWriteItems(context.Background(), &dynamodb.TransactWriteItemsInput{
+				TransactItems: []ddbtypes.TransactWriteItem{
+					{
+						Update: &ddbtypes.Update{
+							TableName:                 aws.String("pokemons"),
+							Key:                       map[string]ddbtypes.AttributeValue{"id": &ddbtypes.AttributeValueMemberS{Value: "cond-update"}},
+							UpdateExpression:          aws.String("SET #n = :n"),
+							ConditionExpression:       aws.String("attribute_not_exists(id)"),
+							ExpressionAttributeNames:  map[string]string{"#n": "name"},
+							ExpressionAttributeValues: map[string]ddbtypes.AttributeValue{":n": &ddbtypes.AttributeValueMemberS{Value: "Mewtwo"}},
+						},
+					},
+				},
+			})
+
+			var tce *ddbtypes.TransactionCanceledException
+			c.True(errors.As(err, &tce))
+			c.Equal("ConditionalCheckFailed", aws.ToString(tce.CancellationReasons[0].Code))
+		})
+	})
+
+	t.Run("delete", func(t *testing.T) {
+		t.Run("success", func(t *testing.T) {
+			c := require.New(t)
+
+			_, err := cli.PutItem(context.Background(), &dynamodb.PutItemInput{
+				TableName: aws.String("pokemons"),
+				Item: map[string]ddbtypes.AttributeValue{
+					"id":   &ddbtypes.AttributeValueMemberS{Value: "to-delete"},
+					"name": &ddbtypes.AttributeValueMemberS{Value: "Gone"},
+				},
+			})
+			c.NoError(err)
+
+			_, err = cli.TransactWriteItems(context.Background(), &dynamodb.TransactWriteItemsInput{
+				TransactItems: []ddbtypes.TransactWriteItem{
+					{
+						Delete: &ddbtypes.Delete{
+							TableName: aws.String("pokemons"),
+							Key:       map[string]ddbtypes.AttributeValue{"id": &ddbtypes.AttributeValueMemberS{Value: "to-delete"}},
+						},
+					},
+				},
+			})
+			c.NoError(err)
+
+			out, err := cli.GetItem(context.Background(), &dynamodb.GetItemInput{
+				TableName: aws.String("pokemons"),
+				Key:       map[string]ddbtypes.AttributeValue{"id": &ddbtypes.AttributeValueMemberS{Value: "to-delete"}},
+			})
+			c.NoError(err)
+			c.Empty(out.Item)
+		})
+
+		t.Run("non-existent table", func(t *testing.T) {
+			c := require.New(t)
+
+			_, err := cli.TransactWriteItems(context.Background(), &dynamodb.TransactWriteItemsInput{
+				TransactItems: []ddbtypes.TransactWriteItem{
+					{
+						Delete: &ddbtypes.Delete{
+							TableName: aws.String("non-existent"),
+							Key:       map[string]ddbtypes.AttributeValue{"id": &ddbtypes.AttributeValueMemberS{Value: "1"}},
+						},
+					},
+				},
+			})
+
+			var notFound *ddbtypes.ResourceNotFoundException
+			c.True(errors.As(err, &notFound))
+		})
+
+		t.Run("unused expression attribute", func(t *testing.T) {
+			c := require.New(t)
+
+			_, err := cli.TransactWriteItems(context.Background(), &dynamodb.TransactWriteItemsInput{
+				TransactItems: []ddbtypes.TransactWriteItem{
+					{
+						Delete: &ddbtypes.Delete{
+							TableName:                aws.String("pokemons"),
+							Key:                      map[string]ddbtypes.AttributeValue{"id": &ddbtypes.AttributeValueMemberS{Value: "001"}},
+							ExpressionAttributeNames: map[string]string{"#unused": "name"},
+						},
+					},
+				},
+			})
+
+			var apiErr smithy.APIError
+			c.True(errors.As(err, &apiErr))
+			c.Equal("ValidationException", apiErr.ErrorCode())
+		})
+
+		t.Run("failing condition", func(t *testing.T) {
+			c := require.New(t)
+
+			_, err := cli.PutItem(context.Background(), &dynamodb.PutItemInput{
+				TableName: aws.String("pokemons"),
+				Item: map[string]ddbtypes.AttributeValue{
+					"id":   &ddbtypes.AttributeValueMemberS{Value: "cond-delete"},
+					"name": &ddbtypes.AttributeValueMemberS{Value: "Gengar"},
+				},
+			})
+			c.NoError(err)
+
+			_, err = cli.TransactWriteItems(context.Background(), &dynamodb.TransactWriteItemsInput{
+				TransactItems: []ddbtypes.TransactWriteItem{
+					{
+						Delete: &ddbtypes.Delete{
+							TableName:           aws.String("pokemons"),
+							Key:                 map[string]ddbtypes.AttributeValue{"id": &ddbtypes.AttributeValueMemberS{Value: "cond-delete"}},
+							ConditionExpression: aws.String("attribute_not_exists(id)"),
+						},
+					},
+				},
+			})
+
+			var tce *ddbtypes.TransactionCanceledException
+			c.True(errors.As(err, &tce))
+			c.Equal("ConditionalCheckFailed", aws.ToString(tce.CancellationReasons[0].Code))
+		})
+	})
+
+	t.Run("condition check", func(t *testing.T) {
+		t.Run("pass", func(t *testing.T) {
+			c := require.New(t)
+
+			_, err := cli.PutItem(context.Background(), &dynamodb.PutItemInput{
+				TableName: aws.String("pokemons"),
+				Item: map[string]ddbtypes.AttributeValue{
+					"id":   &ddbtypes.AttributeValueMemberS{Value: "025"},
+					"name": &ddbtypes.AttributeValueMemberS{Value: "Pikachu"},
+				},
+			})
+			c.NoError(err)
+
+			_, err = cli.TransactWriteItems(context.Background(), &dynamodb.TransactWriteItemsInput{
+				TransactItems: []ddbtypes.TransactWriteItem{
+					{
+						ConditionCheck: &ddbtypes.ConditionCheck{
+							TableName:           aws.String("pokemons"),
+							Key:                 map[string]ddbtypes.AttributeValue{"id": &ddbtypes.AttributeValueMemberS{Value: "025"}},
+							ConditionExpression: aws.String("attribute_exists(id)"),
+						},
+					},
+				},
+			})
+			c.NoError(err)
+		})
+
+		t.Run("fail", func(t *testing.T) {
+			c := require.New(t)
+
+			_, err := cli.TransactWriteItems(context.Background(), &dynamodb.TransactWriteItemsInput{
+				TransactItems: []ddbtypes.TransactWriteItem{
+					{
+						ConditionCheck: &ddbtypes.ConditionCheck{
+							TableName:           aws.String("pokemons"),
+							Key:                 map[string]ddbtypes.AttributeValue{"id": &ddbtypes.AttributeValueMemberS{Value: "non-existent"}},
+							ConditionExpression: aws.String("attribute_exists(id)"),
+						},
+					},
+				},
+			})
+
+			var tce *ddbtypes.TransactionCanceledException
+			c.True(errors.As(err, &tce))
+			c.Equal("ConditionalCheckFailed", aws.ToString(tce.CancellationReasons[0].Code))
+		})
+
+		t.Run("returns old item on fail", func(t *testing.T) {
+			c := require.New(t)
+
+			_, err := cli.PutItem(context.Background(), &dynamodb.PutItemInput{
+				TableName: aws.String("pokemons"),
+				Item: map[string]ddbtypes.AttributeValue{
+					"id":   &ddbtypes.AttributeValueMemberS{Value: "existing"},
+					"name": &ddbtypes.AttributeValueMemberS{Value: "Squirtle"},
+				},
+			})
+			c.NoError(err)
+
+			_, err = cli.TransactWriteItems(context.Background(), &dynamodb.TransactWriteItemsInput{
+				TransactItems: []ddbtypes.TransactWriteItem{
+					{
+						ConditionCheck: &ddbtypes.ConditionCheck{
+							TableName:                           aws.String("pokemons"),
+							Key:                                 map[string]ddbtypes.AttributeValue{"id": &ddbtypes.AttributeValueMemberS{Value: "existing"}},
+							ConditionExpression:                 aws.String("attribute_not_exists(id)"),
+							ReturnValuesOnConditionCheckFailure: ddbtypes.ReturnValuesOnConditionCheckFailureAllOld,
+						},
+					},
+				},
+			})
+
+			var tce *ddbtypes.TransactionCanceledException
+			c.True(errors.As(err, &tce))
+
+			reason := tce.CancellationReasons[0]
+			c.Equal("ConditionalCheckFailed", aws.ToString(reason.Code))
+			c.NotEmpty(reason.Item)
+			c.Equal(&ddbtypes.AttributeValueMemberS{Value: "existing"}, reason.Item["id"])
+		})
+
+		t.Run("non-existent table", func(t *testing.T) {
+			c := require.New(t)
+
+			_, err := cli.TransactWriteItems(context.Background(), &dynamodb.TransactWriteItemsInput{
+				TransactItems: []ddbtypes.TransactWriteItem{
+					{
+						ConditionCheck: &ddbtypes.ConditionCheck{
+							TableName:           aws.String("non-existent"),
+							Key:                 map[string]ddbtypes.AttributeValue{"id": &ddbtypes.AttributeValueMemberS{Value: "1"}},
+							ConditionExpression: aws.String("attribute_exists(id)"),
+						},
+					},
+				},
+			})
+
+			var notFound *ddbtypes.ResourceNotFoundException
+			c.True(errors.As(err, &notFound))
+		})
+
+		t.Run("wrong key attributes", func(t *testing.T) {
+			c := require.New(t)
+
+			_, err := cli.TransactWriteItems(context.Background(), &dynamodb.TransactWriteItemsInput{
+				TransactItems: []ddbtypes.TransactWriteItem{
+					{
+						ConditionCheck: &ddbtypes.ConditionCheck{
+							TableName:           aws.String("pokemons"),
+							Key:                 map[string]ddbtypes.AttributeValue{"wrong_attr": &ddbtypes.AttributeValueMemberS{Value: "1"}},
+							ConditionExpression: aws.String("attribute_exists(id)"),
+						},
+					},
+				},
+			})
+
+			var apiErr smithy.APIError
+			c.True(errors.As(err, &apiErr))
+			c.Equal("ValidationException", apiErr.ErrorCode())
+		})
+
+		t.Run("wrong key type", func(t *testing.T) {
+			c := require.New(t)
+
+			_, err := cli.TransactWriteItems(context.Background(), &dynamodb.TransactWriteItemsInput{
+				TransactItems: []ddbtypes.TransactWriteItem{
+					{
+						ConditionCheck: &ddbtypes.ConditionCheck{
+							TableName:           aws.String("pokemons"),
+							Key:                 map[string]ddbtypes.AttributeValue{"id": &ddbtypes.AttributeValueMemberN{Value: "1"}},
+							ConditionExpression: aws.String("attribute_exists(id)"),
+						},
+					},
+				},
+			})
+
+			var apiErr smithy.APIError
+			c.True(errors.As(err, &apiErr))
+			c.Equal("ValidationException", apiErr.ErrorCode())
+		})
+
+		t.Run("invalid expression", func(t *testing.T) {
+			c := require.New(t)
+
+			_, err := cli.PutItem(context.Background(), &dynamodb.PutItemInput{
+				TableName: aws.String("pokemons"),
+				Item: map[string]ddbtypes.AttributeValue{
+					"id":   &ddbtypes.AttributeValueMemberS{Value: "expr-test"},
+					"name": &ddbtypes.AttributeValueMemberS{Value: "Jolteon"},
+				},
+			})
+			c.NoError(err)
+
+			_, err = cli.TransactWriteItems(context.Background(), &dynamodb.TransactWriteItemsInput{
+				TransactItems: []ddbtypes.TransactWriteItem{
+					{
+						ConditionCheck: &ddbtypes.ConditionCheck{
+							TableName:           aws.String("pokemons"),
+							Key:                 map[string]ddbtypes.AttributeValue{"id": &ddbtypes.AttributeValueMemberS{Value: "expr-test"}},
+							ConditionExpression: aws.String("UNKNOWN_FUNCTION(id)"),
+						},
+					},
+				},
+			})
+
+			var apiErr smithy.APIError
+			c.True(errors.As(err, &apiErr))
+			c.Equal("ValidationException", apiErr.ErrorCode())
+		})
+	})
+}

--- a/tools/run-e2e/main.go
+++ b/tools/run-e2e/main.go
@@ -5,6 +5,7 @@ package main
 import (
 	"bufio"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -22,6 +23,7 @@ type testEvent struct {
 
 func main() {
 	pattern := "TestE2E_"
+
 	extra := os.Args[1:]
 	if len(extra) > 0 && !strings.HasPrefix(extra[0], "-") {
 		pattern = extra[0]
@@ -29,7 +31,7 @@ func main() {
 	}
 
 	args := append([]string{"test", "./e2e/...", "-json", "-run", pattern}, extra...)
-	cmd := exec.Command("go", args...)
+	cmd := exec.Command("go", args...) //nolint:gosec // variable args are required here
 	cmd.Stderr = os.Stderr
 
 	stdout, err := cmd.StdoutPipe()
@@ -57,6 +59,7 @@ func main() {
 	sc := bufio.NewScanner(stdout)
 	for sc.Scan() {
 		line := sc.Bytes()
+
 		var ev testEvent
 		if err := json.Unmarshal(line, &ev); err != nil {
 			continue
@@ -69,17 +72,20 @@ func main() {
 				if testOut[k] == nil {
 					testOut[k] = &strings.Builder{}
 				}
-				testOut[k].WriteString(ev.Output)
+
+				_, _ = testOut[k].WriteString(ev.Output)
 			} else if ev.Package != "" {
 				if pkgOut[ev.Package] == nil {
 					pkgOut[ev.Package] = &strings.Builder{}
 				}
-				pkgOut[ev.Package].WriteString(ev.Output)
+
+				_, _ = pkgOut[ev.Package].WriteString(ev.Output)
 			}
 		case "fail":
 			if ev.Test != "" {
 				nFail++
 				k := key(ev.Package, ev.Test)
+
 				out := ""
 				if b := testOut[k]; b != nil {
 					out = b.String()
@@ -95,11 +101,13 @@ func main() {
 		case "pass":
 			if ev.Test != "" {
 				nPass++
+
 				delete(testOut, key(ev.Package, ev.Test))
 			}
 		case "skip":
 			if ev.Test != "" {
 				nSkip++
+
 				delete(testOut, key(ev.Package, ev.Test))
 			}
 		}
@@ -108,6 +116,7 @@ func main() {
 	if err := sc.Err(); err != nil {
 		fmt.Fprintf(os.Stderr, "run-e2e: reading test output: %v\n", err)
 		_ = cmd.Process.Kill()
+
 		os.Exit(1)
 	}
 
@@ -120,23 +129,30 @@ func main() {
 			fmt.Fprintln(os.Stderr, "FAIL")
 			os.Exit(exitCode(waitErr))
 		}
+
 		fmt.Printf("OK (%d test cases: %d passed", totalCases, nPass)
+
 		if nSkip > 0 {
 			fmt.Printf(", %d skipped", nSkip)
 		}
+
 		fmt.Println(")")
+
 		return
 	}
 
 	seen := make(map[string]bool)
 	var nFailedUnique int
+
 	for _, f := range failedTests {
 		if seen[f.key] {
 			continue
 		}
 		seen[f.key] = true
 		nFailedUnique++
+
 		fmt.Printf("--- FAIL: %s\n%s", f.name, f.out)
+
 		if f.out != "" && !strings.HasSuffix(f.out, "\n") {
 			fmt.Println()
 		}
@@ -146,6 +162,7 @@ func main() {
 		for pkg, b := range pkgOut {
 			if b.Len() > 0 {
 				fmt.Printf("--- FAIL: %s (package)\n%s", pkg, b.String())
+
 				if !strings.HasSuffix(b.String(), "\n") {
 					fmt.Println()
 				}
@@ -155,15 +172,19 @@ func main() {
 
 	if len(failedTests) > 0 {
 		fmt.Printf("\n%d failed (%d test cases total: %d passed", nFailedUnique, totalCases, nPass)
+
 		if nSkip > 0 {
 			fmt.Printf(", %d skipped", nSkip)
 		}
+
 		fmt.Println(")")
 	} else if pkgFailed && totalCases > 0 {
 		fmt.Printf("\n0 failed (%d test cases total: %d passed", totalCases, nPass)
+
 		if nSkip > 0 {
 			fmt.Printf(", %d skipped", nSkip)
 		}
+
 		fmt.Println(")")
 	}
 
@@ -180,8 +201,11 @@ func exitCode(err error) int {
 	if err == nil {
 		return 0
 	}
-	if ee, ok := err.(*exec.ExitError); ok {
+
+	var ee *exec.ExitError
+	if errors.As(err, &ee) {
 		return ee.ExitCode()
 	}
+
 	return 1
 }


### PR DESCRIPTION
What:
- Add TransactWriteItems to the aws-v2 client, HTTP server, and E2E parity test suite

Why:
- TransactWriteItems was unimplemented; this closes the gap so callers can use minidyn as a drop-in for DynamoDB in transactional write scenarios