### PR TITLE
Add BatchGetItem to server DynamoDB JSON API

### DIFF
--- a/aws-v2/client/client.go
+++ b/aws-v2/client/client.go
@@ -632,20 +632,22 @@ func executeGetRequest(ctx context.Context, fd *Client, getInput *dynamodb.GetIt
 	return response.Item, nil
 }
 
+func isRetriableBatchWriteSubrequestError(err error) bool {
+	if _, ok := errors.AsType[*types.InternalServerError](err); ok {
+		return true
+	}
+
+	_, ok := errors.AsType[*types.ProvisionedThroughputExceededException](err)
+
+	return ok
+}
+
 func handleBatchWriteRequestError(table string, req types.WriteRequest, unprocessed map[string][]types.WriteRequest, err error) error {
 	if err == nil {
 		return nil
 	}
 
-	var oe smithy.APIError
-	if !errors.As(err, &oe) {
-		return err
-	}
-
-	var errInternalServer *types.InternalServerError
-	var errProvisionedThroughputExceededException *types.ProvisionedThroughputExceededException
-
-	if !errors.As(err, &errInternalServer) && !errors.As(err, &errProvisionedThroughputExceededException) {
+	if !isRetriableBatchWriteSubrequestError(err) {
 		return err
 	}
 

--- a/aws-v2/client/mapper.go
+++ b/aws-v2/client/mapper.go
@@ -709,9 +709,8 @@ func toString(str string) *string {
 }
 
 func mapKnownError(err error) error {
-	var intErr types.Error
-
-	if !errors.As(err, &intErr) {
+	intErr, ok := errors.AsType[types.Error](err)
+	if !ok {
 		return err
 	}
 
@@ -721,8 +720,7 @@ func mapKnownError(err error) error {
 			Message: aws.String(intErr.Message()),
 		}
 
-		var conditionalErr *types.ConditionalCheckFailedException
-		if errors.As(err, &conditionalErr) {
+		if conditionalErr, ok := errors.AsType[*types.ConditionalCheckFailedException](err); ok {
 			checkErr.Item = mapTypesToDynamoMapItem(conditionalErr.Item)
 		}
 

--- a/e2e/parity_item_test.go
+++ b/e2e/parity_item_test.go
@@ -65,37 +65,26 @@ func TestE2E_Item(t *testing.T) {
 			name: "PutAndGetBatchItem",
 			fn: func(t *testing.T, client *dynamodb.Client) any {
 				t.Helper()
-				t.Skip("skipping PutAndGetBatchItem test until we implement it")
 				ctx := context.Background()
 
 				parityCreatePokemonTable(ctx, t, client)
 
-				opt := func(o *attributevalue.EncoderOptions) {
-					o.TagKey = "json"
-				}
-
-				item, err := attributevalue.MarshalMapWithOptions(parityPokemon{
-					ID:   "001",
-					Type: "grass",
-					Name: "Bulbasaur",
-				}, opt)
-				require.NoError(t, err)
-
-				_, err = client.PutItem(ctx, &dynamodb.PutItemInput{
-					Item:      item,
+				_, err := client.PutItem(ctx, &dynamodb.PutItemInput{
+					Item: parityMarshalPokemon(t, parityPokemon{
+						ID:   "001",
+						Type: "grass",
+						Name: "Bulbasaur",
+					}),
 					TableName: aws.String(parityPokemonTable),
 				})
 				require.NoError(t, err)
 
-				item, err = attributevalue.MarshalMapWithOptions(parityPokemon{
-					ID:   "002",
-					Type: "fire",
-					Name: "Sharmander",
-				}, opt)
-				require.NoError(t, err)
-
 				_, err = client.PutItem(ctx, &dynamodb.PutItemInput{
-					Item:      item,
+					Item: parityMarshalPokemon(t, parityPokemon{
+						ID:   "002",
+						Type: "fire",
+						Name: "Sharmander",
+					}),
 					TableName: aws.String(parityPokemonTable),
 				})
 				require.NoError(t, err)
@@ -106,7 +95,6 @@ func TestE2E_Item(t *testing.T) {
 							Keys: []map[string]dynamodbtypes.AttributeValue{
 								{"id": &dynamodbtypes.AttributeValueMemberS{Value: "001"}},
 								{"id": &dynamodbtypes.AttributeValueMemberS{Value: "002"}},
-								{"t1": &dynamodbtypes.AttributeValueMemberS{Value: "003"}},
 								{"id": &dynamodbtypes.AttributeValueMemberS{Value: "004"}},
 							},
 						},
@@ -118,6 +106,29 @@ func TestE2E_Item(t *testing.T) {
 					paritySortedBatchGetIDs(out, parityPokemonTable),
 					paritySortedUnprocessedKeySignatures(out, parityPokemonTable),
 				}
+			},
+		},
+		{
+			name: "BatchGetItemValidationException",
+			fn: func(t *testing.T, client *dynamodb.Client) any {
+				t.Helper()
+				ctx := context.Background()
+
+				parityCreatePokemonTable(ctx, t, client)
+
+				_, err := client.BatchGetItem(ctx, &dynamodb.BatchGetItemInput{
+					RequestItems: map[string]dynamodbtypes.KeysAndAttributes{
+						parityPokemonTable: {
+							Keys: []map[string]dynamodbtypes.AttributeValue{
+								{"id": &dynamodbtypes.AttributeValueMemberS{Value: "001"}},
+								{"t1": &dynamodbtypes.AttributeValueMemberS{Value: "003"}},
+							},
+						},
+					},
+				})
+				require.Error(t, err)
+
+				return normalizeSDKErrorString(err.Error())
 			},
 		},
 		{

--- a/server/client.go
+++ b/server/client.go
@@ -434,7 +434,10 @@ func (c *Client) Scan(ctx context.Context, input *ScanInput) (*ScanOutput, error
 	}, nil
 }
 
-const batchWriteItemRequestsLimit = 25
+const (
+	batchWriteItemRequestsLimit = 25
+	batchGetItemRequestsLimit   = 100
+)
 
 // DynamoDB returns this message when a WriteRequest has both Put and Delete, or neither.
 var errBatchWriteRequestShape = &smithy.GenericAPIError{
@@ -480,6 +483,16 @@ func validateBatchWriteItemInput(input *BatchWriteItemInput) error {
 	return nil
 }
 
+func isRetriableBatchSubrequestError(err error) bool {
+	if _, ok := errors.AsType[*ddbtypes.InternalServerError](err); ok {
+		return true
+	}
+
+	_, ok := errors.AsType[*ddbtypes.ProvisionedThroughputExceededException](err)
+
+	return ok
+}
+
 // BatchWriteItem runs put and delete sub-requests in order. Sub-request failures that look
 // retriable (InternalServerError, ProvisionedThroughputExceededException) are appended to
 // UnprocessedItems and processing continues, matching DynamoDB batch semantics. Any other
@@ -487,9 +500,6 @@ func validateBatchWriteItemInput(input *BatchWriteItemInput) error {
 //
 // With EmulateFailure(FailureConditionInternalServerError), each sub-request fails that way,
 // so those writes appear as unprocessed until you call EmulateFailure(FailureConditionNone).
-//
-//gocyclo:ignore
-//gocognit:ignore
 func (c *Client) BatchWriteItem(ctx context.Context, input *BatchWriteItemInput) (*BatchWriteItemOutput, error) {
 	if err := validateBatchWriteItemInput(input); err != nil {
 		return nil, err
@@ -515,15 +525,9 @@ func (c *Client) BatchWriteItem(ctx context.Context, input *BatchWriteItemInput)
 			}
 
 			if err != nil {
-				var oe smithy.APIError
-				if errors.As(err, &oe) {
-					var is500 *ddbtypes.InternalServerError
-					var isThrottled *ddbtypes.ProvisionedThroughputExceededException
-
-					if errors.As(err, &is500) || errors.As(err, &isThrottled) {
-						unprocessed[tableName] = append(unprocessed[tableName], req)
-						continue
-					}
+				if isRetriableBatchSubrequestError(err) {
+					unprocessed[tableName] = append(unprocessed[tableName], req)
+					continue
 				}
 
 				return nil, err
@@ -532,6 +536,97 @@ func (c *Client) BatchWriteItem(ctx context.Context, input *BatchWriteItemInput)
 	}
 
 	return &BatchWriteItemOutput{UnprocessedItems: unprocessed}, nil
+}
+
+func validateBatchGetItemInput(input *BatchGetItemInput) error {
+	if input == nil {
+		return nil
+	}
+
+	count := 0
+
+	for _, reqs := range input.RequestItems {
+		count += len(reqs.Keys)
+	}
+
+	if count == 0 {
+		return &smithy.GenericAPIError{
+			Code:    "ValidationException",
+			Message: "1 validation error detected: Value '{}' at 'requestItems' failed to satisfy constraint: Member must have length greater than or equal to 1",
+		}
+	}
+
+	if count > batchGetItemRequestsLimit {
+		return &smithy.GenericAPIError{
+			Code:    "ValidationException",
+			Message: "Too many items requested for the BatchGetItem call",
+		}
+	}
+
+	return nil
+}
+
+// BatchGetItem retrieves multiple items across one or more tables. Validation errors
+// (invalid key schema, malformed AttributeValues, or missing tables) fail the whole batch.
+// Retriable per-key failures (InternalServerError, ProvisionedThroughputExceededException)
+// are reported via UnprocessedKeys, mirroring DynamoDB batch semantics.
+func (c *Client) BatchGetItem(ctx context.Context, input *BatchGetItemInput) (*BatchGetItemOutput, error) {
+	if err := validateBatchGetItemInput(input); err != nil {
+		return nil, err
+	}
+
+	responses := map[string][]map[string]*AttributeValue{}
+	unprocessed := map[string]KeysAndAttributes{}
+
+	for tableName, reqs := range input.RequestItems {
+		tableResponses, unprocessedKeys, err := c.batchGetItemForTable(ctx, tableName, reqs)
+		if err != nil {
+			return nil, err
+		}
+
+		responses[tableName] = tableResponses
+
+		if len(unprocessedKeys) > 0 {
+			tableUnprocessed := reqs
+			tableUnprocessed.Keys = unprocessedKeys
+			unprocessed[tableName] = tableUnprocessed
+		}
+	}
+
+	return &BatchGetItemOutput{Responses: responses, UnprocessedKeys: unprocessed}, nil
+}
+
+func (c *Client) batchGetItemForTable(ctx context.Context, tableName string, reqs KeysAndAttributes) ([]map[string]*AttributeValue, []map[string]*AttributeValue, error) {
+	if err := validateExpressionAttributes(reqs.ExpressionAttributeNames, nil, aws.ToString(reqs.ProjectionExpression)); err != nil {
+		return nil, nil, err
+	}
+
+	responses := make([]map[string]*AttributeValue, 0, len(reqs.Keys))
+	unprocessedKeys := make([]map[string]*AttributeValue, 0, len(reqs.Keys))
+
+	for _, key := range reqs.Keys {
+		item, err := c.GetItem(ctx, &GetItemInput{
+			TableName:                aws.String(tableName),
+			Key:                      key,
+			ConsistentRead:           reqs.ConsistentRead,
+			ExpressionAttributeNames: reqs.ExpressionAttributeNames,
+			ProjectionExpression:     reqs.ProjectionExpression,
+		})
+		if err != nil {
+			if isRetriableBatchSubrequestError(err) {
+				unprocessedKeys = append(unprocessedKeys, key)
+				continue
+			}
+
+			return nil, nil, err
+		}
+
+		if len(item.Item) > 0 {
+			responses = append(responses, item.Item)
+		}
+	}
+
+	return responses, unprocessedKeys, nil
 }
 
 func (c *Client) prepareTransact(items []TransactWriteItem) (map[string]core.TableSnapshot, error) {
@@ -815,8 +910,8 @@ func mapKnownError(err error) error {
 		return nil
 	}
 
-	var intErr types.Error
-	if !errors.As(err, &intErr) {
+	intErr, ok := errors.AsType[types.Error](err)
+	if !ok {
 		return err
 	}
 
@@ -826,8 +921,7 @@ func mapKnownError(err error) error {
 			Message: aws.String(intErr.Message()),
 		}
 
-		var conditionalErr *types.ConditionalCheckFailedException
-		if errors.As(err, &conditionalErr) {
+		if conditionalErr, ok := errors.AsType[*types.ConditionalCheckFailedException](err); ok {
 			checkErr.Item = mapTypesMapToDDBAttributeValue(conditionalErr.Item)
 		}
 

--- a/server/responses.go
+++ b/server/responses.go
@@ -64,5 +64,11 @@ type BatchWriteItemOutput struct {
 	UnprocessedItems map[string][]WriteRequest `json:"UnprocessedItems,omitempty"`
 }
 
+// BatchGetItemOutput mirrors DynamoDB BatchGetItemOutput.
+type BatchGetItemOutput struct {
+	Responses       map[string][]map[string]*AttributeValue `json:"Responses,omitempty"`
+	UnprocessedKeys map[string]KeysAndAttributes            `json:"UnprocessedKeys,omitempty"`
+}
+
 // TransactWriteItemsOutput mirrors DynamoDB TransactWriteItemsOutput.
 type TransactWriteItemsOutput struct{}

--- a/server/server.go
+++ b/server/server.go
@@ -112,6 +112,11 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		if err = decoder.Decode(&input); err == nil {
 			resp, err = s.client.BatchWriteItem(context.Background(), &input)
 		}
+	case "BatchGetItem":
+		var input BatchGetItemInput
+		if err = decoder.Decode(&input); err == nil {
+			resp, err = s.client.BatchGetItem(context.Background(), &input)
+		}
 	case "TransactWriteItems":
 		var input TransactWriteItemsInput
 		if err = decoder.Decode(&input); err == nil {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -513,6 +513,233 @@ func TestServerBatchWriteItemValidatesWriteRequests(t *testing.T) {
 	})
 }
 
+func TestServerBatchGetItemWithSDKv2(t *testing.T) {
+	ts := httptest.NewServer(NewServer())
+	defer ts.Close()
+	cli := newTestDynamoClient(t, ts.URL)
+
+	makeBasicTable(t, cli, "pokemons", "id")
+
+	for _, id := range []string{"1", "2", "3"} {
+		_, err := cli.PutItem(context.Background(), &dynamodb.PutItemInput{
+			TableName: aws.String("pokemons"),
+			Item: map[string]ddbtypes.AttributeValue{
+				"id":   &ddbtypes.AttributeValueMemberS{Value: id},
+				"name": &ddbtypes.AttributeValueMemberS{Value: "p-" + id},
+			},
+		})
+		require.NoError(t, err)
+	}
+
+	out, err := cli.BatchGetItem(context.Background(), &dynamodb.BatchGetItemInput{
+		RequestItems: map[string]ddbtypes.KeysAndAttributes{
+			"pokemons": {
+				Keys: []map[string]ddbtypes.AttributeValue{
+					{"id": &ddbtypes.AttributeValueMemberS{Value: "1"}},
+					{"id": &ddbtypes.AttributeValueMemberS{Value: "2"}},
+					{"id": &ddbtypes.AttributeValueMemberS{Value: "missing"}},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, out.Responses["pokemons"], 2)
+	require.Empty(t, out.UnprocessedKeys)
+}
+
+func TestServerBatchGetItemAcrossTables(t *testing.T) {
+	ts := httptest.NewServer(NewServer())
+	defer ts.Close()
+	cli := newTestDynamoClient(t, ts.URL)
+
+	makeBasicTable(t, cli, "pokemons", "id")
+	makeBasicTable(t, cli, "trainers", "id")
+
+	_, err := cli.PutItem(context.Background(), &dynamodb.PutItemInput{
+		TableName: aws.String("pokemons"),
+		Item: map[string]ddbtypes.AttributeValue{
+			"id":   &ddbtypes.AttributeValueMemberS{Value: "1"},
+			"name": &ddbtypes.AttributeValueMemberS{Value: "Bulbasaur"},
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = cli.PutItem(context.Background(), &dynamodb.PutItemInput{
+		TableName: aws.String("trainers"),
+		Item: map[string]ddbtypes.AttributeValue{
+			"id":   &ddbtypes.AttributeValueMemberS{Value: "ash"},
+			"name": &ddbtypes.AttributeValueMemberS{Value: "Ash Ketchum"},
+		},
+	})
+	require.NoError(t, err)
+
+	out, err := cli.BatchGetItem(context.Background(), &dynamodb.BatchGetItemInput{
+		RequestItems: map[string]ddbtypes.KeysAndAttributes{
+			"pokemons": {
+				Keys: []map[string]ddbtypes.AttributeValue{
+					{"id": &ddbtypes.AttributeValueMemberS{Value: "1"}},
+				},
+			},
+			"trainers": {
+				Keys: []map[string]ddbtypes.AttributeValue{
+					{"id": &ddbtypes.AttributeValueMemberS{Value: "ash"}},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.Empty(t, out.UnprocessedKeys)
+
+	require.Len(t, out.Responses, 2)
+	require.Contains(t, out.Responses, "pokemons")
+	require.Contains(t, out.Responses, "trainers")
+
+	require.Len(t, out.Responses["pokemons"], 1)
+	require.Equal(t, "1", out.Responses["pokemons"][0]["id"].(*ddbtypes.AttributeValueMemberS).Value)
+	require.Equal(t, "Bulbasaur", out.Responses["pokemons"][0]["name"].(*ddbtypes.AttributeValueMemberS).Value)
+
+	require.Len(t, out.Responses["trainers"], 1)
+	require.Equal(t, "ash", out.Responses["trainers"][0]["id"].(*ddbtypes.AttributeValueMemberS).Value)
+	require.Equal(t, "Ash Ketchum", out.Responses["trainers"][0]["name"].(*ddbtypes.AttributeValueMemberS).Value)
+}
+
+func TestServerBatchGetItemValidationException(t *testing.T) {
+	ts := httptest.NewServer(NewServer())
+	defer ts.Close()
+	cli := newTestDynamoClient(t, ts.URL)
+
+	makeBasicTable(t, cli, "pokemons", "id")
+
+	t.Run("invalid key attribute", func(t *testing.T) {
+		_, err := cli.BatchGetItem(context.Background(), &dynamodb.BatchGetItemInput{
+			RequestItems: map[string]ddbtypes.KeysAndAttributes{
+				"pokemons": {
+					Keys: []map[string]ddbtypes.AttributeValue{
+						{"wrong": &ddbtypes.AttributeValueMemberS{Value: "x"}},
+					},
+				},
+			},
+		})
+		var apiErr smithy.APIError
+		require.ErrorAs(t, err, &apiErr)
+		require.Equal(t, "ValidationException", apiErr.ErrorCode())
+	})
+
+	t.Run("empty request items", func(t *testing.T) {
+		_, err := cli.BatchGetItem(context.Background(), &dynamodb.BatchGetItemInput{
+			RequestItems: map[string]ddbtypes.KeysAndAttributes{},
+		})
+		var apiErr smithy.APIError
+		require.ErrorAs(t, err, &apiErr)
+		require.Equal(t, "ValidationException", apiErr.ErrorCode())
+		require.Equal(t, "1 validation error detected: Value '{}' at 'requestItems' failed to satisfy constraint: Member must have length greater than or equal to 1", apiErr.ErrorMessage())
+	})
+
+	t.Run("all tables have empty keys", func(t *testing.T) {
+		_, err := cli.BatchGetItem(context.Background(), &dynamodb.BatchGetItemInput{
+			RequestItems: map[string]ddbtypes.KeysAndAttributes{
+				"pokemons": {Keys: []map[string]ddbtypes.AttributeValue{}},
+			},
+		})
+		var apiErr smithy.APIError
+		require.ErrorAs(t, err, &apiErr)
+		require.Equal(t, "ValidationException", apiErr.ErrorCode())
+		require.Equal(t, "1 validation error detected: Value '{}' at 'requestItems' failed to satisfy constraint: Member must have length greater than or equal to 1", apiErr.ErrorMessage())
+	})
+
+	t.Run("too many keys", func(t *testing.T) {
+		keys := make([]map[string]ddbtypes.AttributeValue, 0, 101)
+		for range 101 {
+			keys = append(keys, map[string]ddbtypes.AttributeValue{
+				"id": &ddbtypes.AttributeValueMemberS{Value: "x"},
+			})
+		}
+
+		_, err := cli.BatchGetItem(context.Background(), &dynamodb.BatchGetItemInput{
+			RequestItems: map[string]ddbtypes.KeysAndAttributes{"pokemons": {Keys: keys}},
+		})
+		var apiErr smithy.APIError
+		require.ErrorAs(t, err, &apiErr)
+		require.Equal(t, "ValidationException", apiErr.ErrorCode())
+		require.Equal(t, "Too many items requested for the BatchGetItem call", apiErr.ErrorMessage())
+	})
+
+	t.Run("missing table", func(t *testing.T) {
+		_, err := cli.BatchGetItem(context.Background(), &dynamodb.BatchGetItemInput{
+			RequestItems: map[string]ddbtypes.KeysAndAttributes{
+				"nope": {
+					Keys: []map[string]ddbtypes.AttributeValue{
+						{"id": &ddbtypes.AttributeValueMemberS{Value: "1"}},
+					},
+				},
+			},
+		})
+		var notFound *ddbtypes.ResourceNotFoundException
+		require.ErrorAs(t, err, &notFound)
+	})
+}
+
+func TestServerBatchGetItemUnprocessedOnEmulatedInternalError(t *testing.T) {
+	s := NewServer()
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	cli := newTestDynamoClient(t, ts.URL)
+	makeBasicTable(t, cli, "pokemons", "id")
+
+	s.EmulateFailure(FailureConditionInternalServerError)
+
+	out, err := cli.BatchGetItem(context.Background(), &dynamodb.BatchGetItemInput{
+		RequestItems: map[string]ddbtypes.KeysAndAttributes{
+			"pokemons": {
+				Keys: []map[string]ddbtypes.AttributeValue{
+					{"id": &ddbtypes.AttributeValueMemberS{Value: "a"}},
+					{"id": &ddbtypes.AttributeValueMemberS{Value: "b"}},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, out.UnprocessedKeys["pokemons"].Keys, 2)
+	require.Empty(t, out.Responses["pokemons"])
+}
+
+func TestServerBatchGetItemWithProjection(t *testing.T) {
+	ts := httptest.NewServer(NewServer())
+	defer ts.Close()
+	cli := newTestDynamoClient(t, ts.URL)
+
+	makeBasicTable(t, cli, "pokemons", "id")
+
+	_, err := cli.PutItem(context.Background(), &dynamodb.PutItemInput{
+		TableName: aws.String("pokemons"),
+		Item: map[string]ddbtypes.AttributeValue{
+			"id":   &ddbtypes.AttributeValueMemberS{Value: "1"},
+			"name": &ddbtypes.AttributeValueMemberS{Value: "Bulbasaur"},
+			"lvl":  &ddbtypes.AttributeValueMemberN{Value: "5"},
+		},
+	})
+	require.NoError(t, err)
+
+	out, err := cli.BatchGetItem(context.Background(), &dynamodb.BatchGetItemInput{
+		RequestItems: map[string]ddbtypes.KeysAndAttributes{
+			"pokemons": {
+				Keys: []map[string]ddbtypes.AttributeValue{
+					{"id": &ddbtypes.AttributeValueMemberS{Value: "1"}},
+				},
+				ProjectionExpression:     aws.String("#n"),
+				ExpressionAttributeNames: map[string]string{"#n": "name"},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, out.Responses["pokemons"], 1)
+	item := out.Responses["pokemons"][0]
+	require.Equal(t, "Bulbasaur", item["name"].(*ddbtypes.AttributeValueMemberS).Value)
+	_, hasID := item["id"]
+	require.False(t, hasID)
+}
+
 func TestServerUpdateItemWithSDKv2(t *testing.T) {
 	ts := httptest.NewServer(NewServer())
 	defer ts.Close()


### PR DESCRIPTION
Why:
The HTTP server exposed single-item reads but not batch reads, so clients could not exercise BatchGetItem against minidyn or compare behavior to DynamoDB Local.

What:
- Wire BatchGetItem in ServeHTTP and implement Client.BatchGetItem with a 100-key cap and UnprocessedKeys for throttling and internal errors.
- Add BatchGetItemOutput, server unit tests, and e2e parity for batch reads.

Issue: #80