### PR TITLE
Document DynamoDB support in docs and link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,36 @@ Amazon DynamoDB testing library written in Go.
 * Run DynamoDB tests in a CI without external dependencies.
 * Identify errors caused by DynamoDB restrictions.
 
+## Installation
+
+### As a Go module dependency
+
+Requires **Go 1.26** or newer (see `go.mod`). From your project root:
+
+```bash
+go get github.com/truora/minidyn@latest
+```
+
+Pin a specific version or pseudo-version instead of `@latest` if your policy requires it. `go get` updates `go.mod` (and `go.sum`); run `go mod tidy` after you remove imports or upgrade other modules.
+
+Import the packages you use, for example:
+
+```go
+import "github.com/truora/minidyn"
+
+import miniserver "github.com/truora/minidyn/server" // optional: HTTP DynamoDB API
+```
+
+### From a clone of this repository
+
+To work on minidyn itself, clone the repo, then build or test from the root (no separate install step):
+
+```bash
+git clone https://github.com/truora/minidyn.git
+cd minidyn
+go test ./...
+```
+
 ## Usage
 
 ### In-memory client (existing)
@@ -83,52 +113,12 @@ ddb := dynamodb.NewFromConfig(cfg)
 // use ddb as usual: CreateTable, PutItem, Query, etc.
 ```
 
-Supported operations in HTTP mode include CreateTable, DescribeTable, UpdateTable, DeleteTable, PutItem, GetItem, UpdateItem, DeleteItem, Query, Scan, and BatchWriteItem.
+## Supported Operations and Features
 
-## Language interpreter
+For a detailed list of supported DynamoDB operations, types, and expressions, please refer to the documentation:
 
-This library has an interpreter implementation for the DynamoDB Expressions.
-
-### Conditional Expressions
-
-#### Types
-
-| Name      | Type     | Short | Supported? |
-| --------- | -------- | ----- | ---------- |
-| Number    | scalar   | N     | y          |
-| String    | scalar   | S     | y          |
-| Binary    | scalar   | B     | y          |
-| Bool      | scalar   | BOOL  | y          |
-| Null      | scalar   | NULL  | y          |
-| List      | document | L     | y          |
-| Map       | document | M     | y          |
-| StringSet | set      | SS    | y          |
-| NumberSet | set      | NS    | y          |
-| BinarySet | set      | BS    | y          |
-
-#### Expressions
-
-|                                              | Syntax                                                                              | Supported? |
-| -------------------------------------------- | ----------------------------------------------------------------------------------- | ---------- |
-| operand comparator operand                   | = <> < <= > and >=                                                                  | y          |
-| operand BETWEEN operand AND operand          | N,S,B                                                                               | y          |
-| operand IN ( operand (',' operand (, ...) )) |                                                                                     | y          |
-| function                                     | attribute_exists, attribute_not_exists, attribute_type, begins_with, contains, size | y          |
-| condition AND condition                      |                                                                                     | y          |
-| condition OR condition                       |                                                                                     | y          |
-| NOT condition                                |                                                                                     | y          |
-
-### Update Expressions
-
-#### Expressions
-
-|          | Syntax                       | Supported? |
-| -------- | ---------------------------- | ---------- |
-| SET      | SET action [, action] ...    | y          |
-| REMOVE   | REMOVE action [, action] ... | y          |
-| ADD      | ADD action [, action] ...    | y          |
-| DELETE   | DELETE action [, action] ... | y          |
-| function | list_append, if_not_exists   | y          |
+* [Supported Operations](docs/operations.md)
+* [Language Interpreter Support](docs/interpreter.md)
 
 ## Developer notes
 

--- a/docs/interpreter.md
+++ b/docs/interpreter.md
@@ -1,0 +1,114 @@
+# Language Interpreter Support
+
+Minidyn evaluates DynamoDB-style expressions for **ConditionExpression**, **FilterExpression**, **KeyConditionExpression**, **ProjectionExpression**, and **UpdateExpression**. Parsing and evaluation live under `interpreter/language`; the high-level API is `interpreter.Language` (`Match`, `Project`, `Update`).
+
+Placeholders work like DynamoDB:
+
+- **Expression attribute names** — identifiers prefixed with `#` (for example `#pk`). Resolve them via `ExpressionAttributeNames` / the corresponding alias maps in code.
+- **Expression attribute values** — identifiers prefixed with `:` (for example `:v1`). Resolve them via `ExpressionAttributeValues`.
+
+The grammar below is what the lexer/parser accept; **KeyConditionExpression** uses the same conditional grammar but DynamoDB only allows a restricted subset on keys (partition/sort). Minidyn relies on table/query logic for those constraints.
+
+---
+
+## Conditional expressions (Condition, Filter, Key)
+
+Used for `Match` with `ExpressionTypeConditional`, `ExpressionTypeFilter`, or `ExpressionTypeKey`.
+
+### Types
+
+| Name      | Type     | Short | Supported? |
+| --------- | -------- | ----- | ---------- |
+| Number    | scalar   | N     | y          |
+| String    | scalar   | S     | y          |
+| Binary    | scalar   | B     | y          |
+| Bool      | scalar   | BOOL  | y          |
+| Null      | scalar   | NULL  | y          |
+| List      | document | L     | y          |
+| Map       | document | M     | y          |
+| StringSet | set      | SS    | y          |
+| NumberSet | set      | NS    | y          |
+| BinarySet | set      | BS    | y          |
+
+### Syntax
+
+| Feature | Syntax | Notes |
+| ------- | ------ | ----- |
+| Comparators | `=`, `<>`, `<`, `<=`, `>`, `>=` | Ordering comparisons apply to **N**, **S**, and **B** only. |
+| BETWEEN | `operand BETWEEN low AND high` | Low/high operands: **N**, **S**, or **B**. |
+| IN | `operand IN (a, b, …)` | |
+| Logical | `AND`, `OR`, `NOT` | |
+| Parentheses | `( condition )` | Grouping |
+| Functions | See below | |
+
+### Functions (conditional context)
+
+| Function | Supported? | Notes |
+| -------- | ---------- | ----- |
+| `attribute_exists(path)` | y | |
+| `attribute_not_exists(path)` | y | |
+| `attribute_type(path, type)` | y | Second argument is a DynamoDB type token (`S`, `N`, `L`, …). |
+| `begins_with(path, substr)` | y | Path: **S** or **B**; substr must match (string or binary). |
+| `contains(path, operand)` | y | Path: **S**, **B**, **L**, **SS**, **BS**, or **NS** (not **M**). Operand type must match `contains` rules for that container. |
+| `size(path)` | partial | Only **S** and **B** paths return a length. Real DynamoDB also defines `size` for sets and lists; that behavior is **not** implemented here. |
+
+---
+
+## Projection expressions
+
+Used for `Project` (`ProjectionExpression` in DynamoDB). This is **path-only** syntax: a comma-separated list of document paths. It does **not** accept update clauses (`SET`, `REMOVE`, …) or function calls.
+
+### Supported path forms
+
+| Form | Example | Supported? |
+| ---- | ------- | ---------- |
+| Top-level name | `ProductId`, `#attr` | y |
+| Nested map segments | `a.b.c` | y |
+| List index (literal) | `items[0]` | y |
+| List index (dynamic) | `items[k]` | y if `k` is a placeholder or name that evaluates to a **number** at evaluation time |
+| Comma-separated paths | `a, b.c, items[0]` | y |
+
+Rules:
+
+- Each segment after `.` is an identifier (or `#` placeholder).
+- `[` … `]` selects a list index; map keys use `.name` rather than `[name]`.
+- If a path evaluates to a missing attribute, that path is skipped (no error); the projected map only includes paths that resolved.
+
+---
+
+## Update expressions
+
+Used for `Update` (`UpdateExpression`). Clauses are **`SET`**, **`REMOVE`**, **`ADD`**, and **`DELETE`**. You can repeat clauses (for example `SET … REMOVE …`) and list multiple actions after one keyword where the grammar allows.
+
+### Clause overview
+
+| Clause | Syntax pattern | Supported? |
+| ------ | -------------- | ---------- |
+| SET | `SET path = value [, path = value] …` | y |
+| REMOVE | `REMOVE path [, path] …` | y |
+| ADD | `ADD path value [, path value] …` | y |
+| DELETE | `DELETE path value [, path value] …` | y |
+
+### SET value features
+
+- **Arithmetic** in value position: `+` and `-` between **numbers** (including placeholders that evaluate to numbers).
+- **Nested assignment**: map keys and list indexes on the left-hand side (for example `map.k = :x`, `list[0] = :y`).
+- **Functions in updates** — only these are allowed in update value expressions:
+
+| Function | Supported? |
+| -------- | ---------- |
+| `if_not_exists(path, value)` | y |
+| `list_append(list1, list2)` | y |
+
+Other functions (`size`, `attribute_exists`, `begins_with`, `contains`, …) are **not** valid inside update values; they are rejected as “not allowed in an update expression.”
+
+### ADD / DELETE
+
+- **ADD**: numeric addition, or set union for **SS** / **NS** / **BS** (per DynamoDB rules).
+- **DELETE**: removes elements from **SS** / **NS** / **BS**.
+
+---
+
+## Native interpreter overrides
+
+If built-in evaluation is wrong or incomplete for your case, the **native interpreter** lets you register custom matchers or updaters (see the main `README.md` “Developer notes” / native interpreter section). That path bypasses the tables above for the expressions you override.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1,0 +1,57 @@
+# Supported Operations
+
+Minidyn aims to accurately mock DynamoDB behavior for local testing. However, it does not support the entire DynamoDB API. The following operations are currently supported by both the in-memory client and the HTTP server mode (unless otherwise specified):
+
+- `BatchGetItem`
+- `BatchWriteItem`
+- `CreateTable`
+- `DeleteItem`
+- `DeleteTable`
+- `DescribeTable`
+- `GetItem`
+- `PutItem`
+- `Query`
+- `Scan`
+- `TransactWriteItems`
+- `UpdateItem`
+- `UpdateTable`
+
+## Partially Supported Features
+
+- **[TransactWriteItems](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/transaction-apis.html)**: Transactions are supported, but minidyn handles rollbacks using **table-level snapshots** instead of item-level locks and snapshots like real DynamoDB. In a highly concurrent environment, this could cause full table rollbacks where real DynamoDB would only lock and rollback specific items.
+- **[Expressions](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.html)**: Condition Expressions, Update Expressions, and Projection Expressions are largely supported through the internal interpreter, but some complex nested functions or specific clauses may have edge case differences compared to real DynamoDB.
+- **[Secondary Indexes](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/SecondaryIndexes.html)**: Global Secondary Indexes (GSI) and Local Secondary Indexes (LSI) creation, querying, and scanning are supported. However, the following real DynamoDB features are **not** currently simulated:
+  - **Index Projections**: Minidyn does not currently enforce index projections (e.g., `KEYS_ONLY`, `INCLUDE`). Querying a secondary index will return the full item's attributes instead of only the projected attributes.
+  - **Eventual Consistency**: Global Secondary Indexes are updated synchronously and are always strongly consistent in minidyn. Real DynamoDB updates GSIs asynchronously (eventually consistent).
+  - **Throughput/Limits**: Minidyn does not enforce index-specific read/write capacity limits.
+- **Limits and Restrictions**: Real DynamoDB limits (such as 400KB item sizes, 1MB limits per Query/Scan, or max limits for pagination) are not enforced in minidyn. Queries and Scans will return all matching items unless explicitly limited.
+- **ReturnConsumedCapacity**: Operations in minidyn do not accurately calculate or return the consumed capacity units. The `ReturnConsumedCapacity` parameter is largely ignored, and mock/empty capacity reports are returned or omitted entirely.
+
+---
+
+# Not Supported Operations
+
+Operations related to administrative, backup, streaming, and global table features are generally not supported. Some common unsupported operations include:
+
+- **Item Operations**:
+  - `TransactGetItems`
+  - `ExecuteStatement`, `BatchExecuteStatement` (PartiQL)
+
+- **Table & Tagging Operations**:
+  - `ListTables`
+  - `DescribeEndpoints`
+  - `DescribeLimits`
+  - `DescribeTimeToLive`, `UpdateTimeToLive`
+  - `ListTagsOfResource`, `TagResource`, `UntagResource`
+
+- **Backup & Restore**:
+  - `CreateBackup`, `DeleteBackup`, `DescribeBackup`, `ListBackups`, `RestoreTableFromBackup`
+  - `DescribeContinuousBackups`, `UpdateContinuousBackups`, `RestoreTableToPointInTime`
+
+- **Global Tables**:
+  - `CreateGlobalTable`, `DescribeGlobalTable`, `UpdateGlobalTable`
+
+- **Streams**:
+  - `DescribeStream`, `GetRecords`, `GetShardIterator`
+
+If you need support for an operation not listed here, please consider contributing to the project or opening an issue on GitHub.


### PR DESCRIPTION
Why:
Keeps the README focused on usage while detailed support matrices live in dedicated files that are easier to extend and cross-reference.

What:
- Add docs/operations.md listing supported DynamoDB operations and gaps.
- Add docs/interpreter.md for condition, projection, and update grammar.
- Link README to docs instead of embedding long tables.
- Add install instructions in README

Issue: none