### PR TITLE
Implement DynamoDB size() for lists, maps, and sets

### DIFF
--- a/core/table_test.go
+++ b/core/table_test.go
@@ -779,7 +779,7 @@ func TestUpdate(t *testing.T) {
 
 	var checkErr *types.ConditionalCheckFailedException
 	c.True(errors.As(err, &checkErr))
-	c.Contains(checkErr.Error(), "Conditional request failed")
+	c.Contains(checkErr.Error(), "The conditional request failed")
 	c.Len(checkErr.Item, 3)
 	c.Equal("001", types.StringValue(checkErr.Item["id"].S))
 	c.Equal("grass", types.StringValue(checkErr.Item["type"].S))

--- a/core/types.go
+++ b/core/types.go
@@ -15,7 +15,7 @@ var (
 	errMissingField = errors.New("One of the required keys was not given a value") //nolint:stylecheck,staticcheck,ST1005 // consistent with AWS SDK errors
 
 	// ErrConditionalRequestFailed when the conditional write is not meet
-	ErrConditionalRequestFailed = errors.New("Conditional request failed") //nolint:stylecheck,staticcheck,ST1005 // consistent with AWS SDK errors
+	ErrConditionalRequestFailed = errors.New("The conditional request failed") //nolint:stylecheck,staticcheck,ST1005 // consistent with AWS SDK errors
 
 	// ErrInvalidAtrributeValue when the attributte value is invalid
 	ErrInvalidAtrributeValue = errors.New("Invalid attribute value type") //nolint:stylecheck,staticcheck,ST1005 // consistent with AWS SDK errors

--- a/docs/interpreter.md
+++ b/docs/interpreter.md
@@ -50,7 +50,7 @@ Used for `Match` with `ExpressionTypeConditional`, `ExpressionTypeFilter`, or `E
 | `attribute_type(path, type)` | y | Second argument is a DynamoDB type token (`S`, `N`, `L`, …). |
 | `begins_with(path, substr)` | y | Path: **S** or **B**; substr must match (string or binary). |
 | `contains(path, operand)` | y | Path: **S**, **B**, **L**, **SS**, **BS**, or **NS** (not **M**). Operand type must match `contains` rules for that container. |
-| `size(path)` | partial | Only **S** and **B** paths return a length. Real DynamoDB also defines `size` for sets and lists; that behavior is **not** implemented here. |
+| `size(path)` | y | **S** (UTF-8 byte length), **B** (byte length), **M** (number of entries), **L** (number of elements), **SS** / **NS** / **BS** (number of elements in the set). |
 
 ---
 

--- a/e2e/parity_item_test.go
+++ b/e2e/parity_item_test.go
@@ -303,6 +303,75 @@ func TestE2E_Item(t *testing.T) {
 			},
 		},
 		{
+			name: "PutItemConditionExpressionSizeListAndSet",
+			fn: func(t *testing.T, client *dynamodb.Client) any {
+				t.Helper()
+				ctx := context.Background()
+
+				parityCreatePokemonTable(ctx, t, client)
+
+				item := parityMarshalPokemon(t, parityPokemon{
+					ID:    "001",
+					Type:  "grass",
+					Name:  "Bulbasaur",
+					Moves: []string{"Tackle", "Growl"},
+					Local: []string{"Pallet Town", "Route 1"},
+				})
+
+				// Map (M), NumberSet (NS), and BinarySet (BS): exercise size() for parity with List (L) and StringSet (SS) above.
+				item["stats"] = &dynamodbtypes.AttributeValueMemberM{
+					Value: map[string]dynamodbtypes.AttributeValue{
+						"hp":  &dynamodbtypes.AttributeValueMemberN{Value: "45"},
+						"atk": &dynamodbtypes.AttributeValueMemberN{Value: "49"},
+						"def": &dynamodbtypes.AttributeValueMemberN{Value: "49"},
+					},
+				}
+				item["ivs"] = &dynamodbtypes.AttributeValueMemberNS{
+					Value: []string{"31", "20"},
+				}
+				item["tags_bin"] = &dynamodbtypes.AttributeValueMemberBS{
+					Value: [][]byte{{0x01, 0xaa}, {0x02, 0xbb}},
+				}
+
+				_, err := client.PutItem(ctx, &dynamodb.PutItemInput{
+					Item:      item,
+					TableName: aws.String(parityPokemonTable),
+				})
+				require.NoError(t, err)
+
+				_, err = client.PutItem(ctx, &dynamodb.PutItemInput{
+					Item:      item,
+					TableName: aws.String(parityPokemonTable),
+					ConditionExpression: aws.String(
+						"size(moves) = :ssSize AND size(#local) = :listSize AND size(stats) = :mapSize AND size(ivs) = :nsSize AND size(tags_bin) = :bsSize",
+					),
+					ExpressionAttributeNames: map[string]string{
+						"#local": "local",
+					},
+					ExpressionAttributeValues: map[string]dynamodbtypes.AttributeValue{
+						":ssSize":   &dynamodbtypes.AttributeValueMemberN{Value: "2"},
+						":listSize": &dynamodbtypes.AttributeValueMemberN{Value: "2"},
+						":mapSize":  &dynamodbtypes.AttributeValueMemberN{Value: "3"},
+						":nsSize":   &dynamodbtypes.AttributeValueMemberN{Value: "2"},
+						":bsSize":   &dynamodbtypes.AttributeValueMemberN{Value: "2"},
+					},
+				})
+				require.NoError(t, err)
+
+				_, err = client.PutItem(ctx, &dynamodb.PutItemInput{
+					Item:                item,
+					TableName:           aws.String(parityPokemonTable),
+					ConditionExpression: aws.String("size(moves) = :invalidSize"),
+					ExpressionAttributeValues: map[string]dynamodbtypes.AttributeValue{
+						":invalidSize": &dynamodbtypes.AttributeValueMemberN{Value: "5"},
+					},
+				})
+				require.Error(t, err)
+
+				return normalizeSDKErrorString(err.Error())
+			},
+		},
+		{
 			name: "PutItemUnusedExpressionAttributeValues",
 			fn: func(t *testing.T, client *dynamodb.Client) any {
 				t.Helper()

--- a/interpreter/language/functions.go
+++ b/interpreter/language/functions.go
@@ -139,15 +139,8 @@ func contains(args ...Object) Object {
 func objectSize(args ...Object) Object {
 	path := args[0]
 
-	switch path.Type() {
-	case ObjectTypeString:
-		str, _ := path.(*String)
-
-		return &Number{Value: float64(len(str.Value))}
-	case ObjectTypeBinary:
-		bin, _ := path.(*Binary)
-
-		return &Number{Value: float64(len(bin.Value))}
+	if sizable, ok := path.(SizableObject); ok {
+		return &Number{Value: float64(sizable.Size())}
 	}
 
 	return newError("type not supported: size %s", path.Type())

--- a/interpreter/language/functions_test.go
+++ b/interpreter/language/functions_test.go
@@ -179,14 +179,44 @@ func TestObjectSize(t *testing.T) {
 
 	size := objectSize(&str)
 	if size.Inspect() != expected {
-		t.Fatalf("size dismatch expected=%s, actual=%s", expected, size.Inspect())
+		t.Fatalf("size mismatch expected=%s, actual=%s", expected, size.Inspect())
 	}
 
 	bin := Binary{Value: []byte{'h', 'e', 'l', 'l', 'o'}}
 
 	size = objectSize(&bin)
 	if size.Inspect() != expected {
-		t.Fatalf("size dismatch expected=%s, actual=%s", expected, size.Inspect())
+		t.Fatalf("size mismatch expected=%s, actual=%s", expected, size.Inspect())
+	}
+
+	list := &List{Value: []Object{&String{Value: "a"}, &String{Value: "b"}}}
+	size = objectSize(list)
+	if size.Inspect() != "2" {
+		t.Fatalf("list size expected=2, actual=%s", size.Inspect())
+	}
+
+	m := &Map{Value: map[string]Object{"k": &String{Value: "v"}}}
+	size = objectSize(m)
+	if size.Inspect() != "1" {
+		t.Fatalf("map size expected=1, actual=%s", size.Inspect())
+	}
+
+	ss := &StringSet{Value: map[string]bool{"a": true, "b": true}}
+	size = objectSize(ss)
+	if size.Inspect() != "2" {
+		t.Fatalf("string set size expected=2, actual=%s", size.Inspect())
+	}
+
+	ns := &NumberSet{Value: map[float64]bool{1: true, 2: true}}
+	size = objectSize(ns)
+	if size.Inspect() != "2" {
+		t.Fatalf("number set size expected=2, actual=%s", size.Inspect())
+	}
+
+	bs := &BinarySet{Value: [][]byte{{1}, {2}}}
+	size = objectSize(bs)
+	if size.Inspect() != "2" {
+		t.Fatalf("binary set size expected=2, actual=%s", size.Inspect())
 	}
 
 	size = objectSize(TRUE)

--- a/interpreter/language/object.go
+++ b/interpreter/language/object.go
@@ -83,6 +83,12 @@ type ContainerObject interface {
 	CanContain(objType ObjectType) bool
 }
 
+// SizableObject is the abstraction of objects that support the size() function.
+type SizableObject interface {
+	Object
+	Size() int64
+}
+
 // AppendableObject abstraction of the objects that can add other objects
 type AppendableObject interface {
 	Object
@@ -196,6 +202,11 @@ func (b *Binary) CanContain(objType ObjectType) bool {
 	return objType == ObjectTypeBinary
 }
 
+// Size returns the number of bytes in the binary (DynamoDB size for B).
+func (b *Binary) Size() int64 {
+	return int64(len(b.Value))
+}
+
 // Null is the representation of nil values
 type Null struct {
 	IsUndefined bool
@@ -263,6 +274,11 @@ func (s *String) ToDynamoDB() types.Item {
 // CanContain whether or not the string can contain the objType
 func (s *String) CanContain(objType ObjectType) bool {
 	return objType == ObjectTypeString
+}
+
+// Size returns the length of the string in UTF-8 bytes (DynamoDB size for S).
+func (s *String) Size() int64 {
+	return int64(len(s.Value))
 }
 
 // Map is the representation of map
@@ -334,6 +350,11 @@ func (m *Map) Get(field string) Object {
 	}
 
 	return obj
+}
+
+// Size returns the number of top-level entries in the map (DynamoDB size for M).
+func (m *Map) Size() int64 {
+	return int64(len(m.Value))
 }
 
 // List is the representation of list
@@ -442,6 +463,11 @@ func (l *List) CanContain(objType ObjectType) bool {
 	return true
 }
 
+// Size returns the number of elements in the list (DynamoDB size for L).
+func (l *List) Size() int64 {
+	return int64(len(l.Value))
+}
+
 // Add if the obj adds the value to the list
 func (l *List) Add(obj Object) Object {
 	if obj.Type() == ObjectTypeList {
@@ -531,6 +557,11 @@ func (ss *StringSet) ToDynamoDB() types.Item {
 // CanContain whether or not the string set can contain the objType
 func (ss *StringSet) CanContain(objType ObjectType) bool {
 	return objType == ObjectTypeString || objType == ObjectTypeStringSet
+}
+
+// Size returns the number of elements in the set (DynamoDB size for SS).
+func (ss *StringSet) Size() int64 {
+	return int64(len(ss.Value))
 }
 
 // Add if the obj is an string it adds the value to Set
@@ -666,6 +697,11 @@ func (bs *BinarySet) CanContain(objType ObjectType) bool {
 	return objType == ObjectTypeBinary || objType == ObjectTypeBinarySet
 }
 
+// Size returns the number of elements in the set (DynamoDB size for BS).
+func (bs *BinarySet) Size() int64 {
+	return int64(len(bs.Value))
+}
+
 // Delete if the obj is an binary it removes the value from the Set
 func (bs *BinarySet) Delete(obj Object) Object {
 	switch obj.Type() {
@@ -763,6 +799,11 @@ func (ns *NumberSet) ToDynamoDB() types.Item {
 	}
 
 	return attr
+}
+
+// Size returns the number of elements in the set (DynamoDB size for NS).
+func (ns *NumberSet) Size() int64 {
+	return int64(len(ns.Value))
 }
 
 // Contains returns if the collection contains the object


### PR DESCRIPTION
Why:
Condition and filter expressions could not use size(path) on list, map, or set attributes; results diverged from DynamoDB.

What:
- Add SizableObject and Size() on String, Binary, Map, List, and sets.
- Implement objectSize via SizableObject in interpreter/language.
- Extend TestObjectSize for list, map, and SS/NS/BS.
- Document size() support in docs/interpreter.md.
- Add e2e PutItemConditionExpressionSizeListAndSet parity case.

Issue: #120