### PR TITLE
Fix validation over null vs non-existing attributes

### DIFF
--- a/e2e/parity_item_test.go
+++ b/e2e/parity_item_test.go
@@ -989,6 +989,123 @@ func TestE2E_Item(t *testing.T) {
 			},
 		},
 		{
+			name: "NullAttributeExistsAndTypeAndIfNotExists",
+			fn: func(t *testing.T, client *dynamodb.Client) any {
+				t.Helper()
+				ctx := context.Background()
+
+				parityCreatePokemonTable(ctx, t, client)
+
+				item := parityMarshalPokemon(t, parityPokemon{
+					ID:   "001",
+					Type: "grass",
+					Name: "Bulbasaur",
+				})
+				// Attribute that exists with NULL type — distinct from "attribute missing entirely".
+				item["evolves_into"] = &dynamodbtypes.AttributeValueMemberNULL{Value: true}
+
+				_, err := client.PutItem(ctx, &dynamodb.PutItemInput{
+					Item:      item,
+					TableName: aws.String(parityPokemonTable),
+				})
+				require.NoError(t, err)
+
+				results := []any{}
+
+				// attribute_exists on a NULL-typed attribute → satisfied (item exists with NULL value).
+				_, err = client.UpdateItem(ctx, &dynamodb.UpdateItemInput{
+					TableName: aws.String(parityPokemonTable),
+					Key: map[string]dynamodbtypes.AttributeValue{
+						"id": &dynamodbtypes.AttributeValueMemberS{Value: "001"},
+					},
+					ConditionExpression: aws.String("attribute_exists(evolves_into)"),
+					UpdateExpression:    aws.String("SET #lvl = :lvl"),
+					ExpressionAttributeNames: map[string]string{
+						"#lvl": "lvl",
+					},
+					ExpressionAttributeValues: map[string]dynamodbtypes.AttributeValue{
+						":lvl": &dynamodbtypes.AttributeValueMemberN{Value: "5"},
+					},
+				})
+				results = append(results, err == nil)
+
+				// attribute_not_exists on a NULL-typed attribute → fails (attribute is present).
+				var ccf *dynamodbtypes.ConditionalCheckFailedException
+				_, err = client.UpdateItem(ctx, &dynamodb.UpdateItemInput{
+					TableName: aws.String(parityPokemonTable),
+					Key: map[string]dynamodbtypes.AttributeValue{
+						"id": &dynamodbtypes.AttributeValueMemberS{Value: "001"},
+					},
+					ConditionExpression: aws.String("attribute_not_exists(evolves_into)"),
+					UpdateExpression:    aws.String("SET #lvl = :lvl"),
+					ExpressionAttributeNames: map[string]string{
+						"#lvl": "lvl",
+					},
+					ExpressionAttributeValues: map[string]dynamodbtypes.AttributeValue{
+						":lvl": &dynamodbtypes.AttributeValueMemberN{Value: "6"},
+					},
+				})
+				results = append(results, errors.As(err, &ccf))
+
+				// attribute_type(_, "NULL") on a NULL-typed attribute → satisfied.
+				_, err = client.UpdateItem(ctx, &dynamodb.UpdateItemInput{
+					TableName: aws.String(parityPokemonTable),
+					Key: map[string]dynamodbtypes.AttributeValue{
+						"id": &dynamodbtypes.AttributeValueMemberS{Value: "001"},
+					},
+					ConditionExpression: aws.String("attribute_type(evolves_into, :nullType)"),
+					UpdateExpression:    aws.String("SET #lvl = :lvl"),
+					ExpressionAttributeNames: map[string]string{
+						"#lvl": "lvl",
+					},
+					ExpressionAttributeValues: map[string]dynamodbtypes.AttributeValue{
+						":nullType": &dynamodbtypes.AttributeValueMemberS{Value: "NULL"},
+						":lvl":      &dynamodbtypes.AttributeValueMemberN{Value: "7"},
+					},
+				})
+				results = append(results, err == nil)
+
+				// attribute_type(missing_attr, "NULL") → fails (the attribute is absent, not NULL-typed).
+				ccf = nil
+				_, err = client.UpdateItem(ctx, &dynamodb.UpdateItemInput{
+					TableName: aws.String(parityPokemonTable),
+					Key: map[string]dynamodbtypes.AttributeValue{
+						"id": &dynamodbtypes.AttributeValueMemberS{Value: "001"},
+					},
+					ConditionExpression: aws.String("attribute_type(missing_attr, :nullType)"),
+					UpdateExpression:    aws.String("SET #lvl = :lvl"),
+					ExpressionAttributeNames: map[string]string{
+						"#lvl": "lvl",
+					},
+					ExpressionAttributeValues: map[string]dynamodbtypes.AttributeValue{
+						":nullType": &dynamodbtypes.AttributeValueMemberS{Value: "NULL"},
+						":lvl":      &dynamodbtypes.AttributeValueMemberN{Value: "8"},
+					},
+				})
+				results = append(results, errors.As(err, &ccf))
+
+				// if_not_exists on a NULL-typed attribute → preserves the existing NULL value
+				// rather than substituting the fallback string.
+				_, err = client.UpdateItem(ctx, &dynamodb.UpdateItemInput{
+					TableName: aws.String(parityPokemonTable),
+					Key: map[string]dynamodbtypes.AttributeValue{
+						"id": &dynamodbtypes.AttributeValueMemberS{Value: "001"},
+					},
+					UpdateExpression: aws.String("SET evolves_into = if_not_exists(evolves_into, :fallback)"),
+					ExpressionAttributeValues: map[string]dynamodbtypes.AttributeValue{
+						":fallback": &dynamodbtypes.AttributeValueMemberS{Value: "Ivysaur"},
+					},
+				})
+				require.NoError(t, err)
+
+				final := parityGetPokemon(ctx, t, client, "001")
+				_, stillNull := final["evolves_into"].(*dynamodbtypes.AttributeValueMemberNULL)
+				results = append(results, stillNull)
+
+				return results
+			},
+		},
+		{
 			name: "DeleteItemWithReturnValues",
 			fn: func(t *testing.T, client *dynamodb.Client) any {
 				t.Helper()

--- a/interpreter/language/evaluator_test.go
+++ b/interpreter/language/evaluator_test.go
@@ -213,7 +213,9 @@ func TestEvalFunctions(t *testing.T) {
 		{"size(:bin) = :binSize", TRUE},
 		{"attribute_exists(:n)", FALSE},
 		{"attribute_exists(h.notFound)", FALSE},
+		{"attribute_exists(:nilVal)", TRUE},
 		{"attribute_not_exists(:n)", TRUE},
+		{"attribute_not_exists(:nilVal)", FALSE},
 		{"begins_with(:s, :prefix)", TRUE},
 		{"contains(:s, :subtext)", TRUE},
 		{"contains(:list, :element)", TRUE},
@@ -221,6 +223,8 @@ func TestEvalFunctions(t *testing.T) {
 		{"contains(:binSet, :bin)", TRUE},
 		{"contains(:numSet, :num)", TRUE},
 		{"attribute_type(:s, :type)", TRUE},
+		{"attribute_type(:nilVal, :nullType)", TRUE},
+		{"attribute_type(:n, :nullType)", FALSE},
 	}
 
 	env := NewEnvironment()
@@ -229,6 +233,8 @@ func TestEvalFunctions(t *testing.T) {
 		":s":       {S: new("HELLO WORLD!")},
 		":sSize":   {N: new("12")},
 		":type":    {S: new("S")},
+		":nullType": {S: new("NULL")},
+		":nilVal":  {NULL: &boolTrue},
 		":bin":     {B: []byte{10, 10, 10}},
 		":binSize": {N: new("3")},
 		":prefix":  {S: new("HELLO")},

--- a/interpreter/language/evaluator_test.go
+++ b/interpreter/language/evaluator_test.go
@@ -230,17 +230,17 @@ func TestEvalFunctions(t *testing.T) {
 	env := NewEnvironment()
 
 	err := env.AddAttributes(map[string]*types.Item{
-		":s":       {S: new("HELLO WORLD!")},
-		":sSize":   {N: new("12")},
-		":type":    {S: new("S")},
+		":s":        {S: new("HELLO WORLD!")},
+		":sSize":    {N: new("12")},
+		":type":     {S: new("S")},
 		":nullType": {S: new("NULL")},
-		":nilVal":  {NULL: &boolTrue},
-		":bin":     {B: []byte{10, 10, 10}},
-		":binSize": {N: new("3")},
-		":prefix":  {S: new("HELLO")},
-		":subtext": {S: new("ELL")},
-		":element": {S: new("a")},
-		":num":     {N: new("1")},
+		":nilVal":   {NULL: &boolTrue},
+		":bin":      {B: []byte{10, 10, 10}},
+		":binSize":  {N: new("3")},
+		":prefix":   {S: new("HELLO")},
+		":subtext":  {S: new("ELL")},
+		":element":  {S: new("a")},
+		":num":      {N: new("1")},
 		":list": {
 			L: []*types.Item{
 				{S: new("a")},

--- a/interpreter/language/functions.go
+++ b/interpreter/language/functions.go
@@ -69,13 +69,13 @@ var functions = map[string]*Function{
 func attributeExists(args ...Object) Object {
 	path := args[0]
 
-	return nativeBoolToBooleanObject(path.Type() != ObjectTypeNull)
+	return nativeBoolToBooleanObject(!isUndefined(path))
 }
 
 func attributeNotExists(args ...Object) Object {
 	path := args[0]
 
-	return nativeBoolToBooleanObject(path.Type() == ObjectTypeNull)
+	return nativeBoolToBooleanObject(isUndefined(path))
 }
 
 func attributeType(args ...Object) Object {
@@ -86,6 +86,10 @@ func attributeType(args ...Object) Object {
 		strObj, _ := typ.(*String)
 		if !dynamodbTypes[ObjectType(strObj.Value)] {
 			return newError("invalid type %s", strObj.Value)
+		}
+
+		if isUndefined(path) {
+			return FALSE
 		}
 
 		return nativeBoolToBooleanObject(path.Type() == ObjectType(strObj.Value))
@@ -149,7 +153,7 @@ func objectSize(args ...Object) Object {
 func ifNotExists(args ...Object) Object {
 	obj := args[0]
 
-	if obj == nil || obj.Type() == ObjectTypeNull {
+	if isUndefined(obj) {
 		return args[1]
 	}
 

--- a/interpreter/language/functions_test.go
+++ b/interpreter/language/functions_test.go
@@ -66,9 +66,9 @@ func TestAttributeType(t *testing.T) {
 		typeArg  Object
 		expected Object
 	}{
-		"string_matches_S":      {&String{Value: "hello"}, &String{Value: "S"}, TRUE},
-		"string_does_not_match": {&String{Value: "hello"}, &String{Value: "N"}, FALSE},
-		"null_value_matches_NULL": {&Null{}, &String{Value: "NULL"}, TRUE},
+		"string_matches_S":            {&String{Value: "hello"}, &String{Value: "S"}, TRUE},
+		"string_does_not_match":       {&String{Value: "hello"}, &String{Value: "N"}, FALSE},
+		"null_value_matches_NULL":     {&Null{}, &String{Value: "NULL"}, TRUE},
 		"missing_does_not_match_NULL": {UNDEFINED, &String{Value: "NULL"}, FALSE},
 		"missing_does_not_match_S":    {UNDEFINED, &String{Value: "S"}, FALSE},
 	}

--- a/interpreter/language/functions_test.go
+++ b/interpreter/language/functions_test.go
@@ -23,47 +23,68 @@ func TestFunctionInspect(t *testing.T) {
 }
 
 func TestAttributeExists(t *testing.T) {
-	str := &String{Value: "hello"}
-
-	exists := attributeExists(str)
-	if exists.Type() == ObjectTypeBoolean && exists.Inspect() == "TRUE" {
-		t.Fatal("value should be true")
+	cases := map[string]struct {
+		path     Object
+		expected Object
+	}{
+		"string_attribute":  {&String{Value: "hello"}, TRUE},
+		"explicit_null":     {&Null{}, TRUE},
+		"missing_attribute": {UNDEFINED, FALSE},
+		"nil_path":          {nil, FALSE},
 	}
 
-	exists = attributeExists(str)
-	if exists.Type() == ObjectTypeBoolean && exists.Inspect() == "FALSE" {
-		t.Fatal("value should be false")
+	for name, tc := range cases {
+		got := attributeExists(tc.path)
+		if got != tc.expected {
+			t.Fatalf("%s: expected=%s got=%s", name, tc.expected.Inspect(), got.Inspect())
+		}
 	}
 }
 
 func TestAttributeNotExists(t *testing.T) {
-	str := &String{Value: "hello"}
-
-	exists := attributeNotExists(str)
-	if exists.Type() == ObjectTypeBoolean && exists.Inspect() != "false" {
-		t.Fatal("value should be false")
+	cases := map[string]struct {
+		path     Object
+		expected Object
+	}{
+		"string_attribute":  {&String{Value: "hello"}, FALSE},
+		"explicit_null":     {&Null{}, FALSE},
+		"missing_attribute": {UNDEFINED, TRUE},
+		"nil_path":          {nil, TRUE},
 	}
 
-	exists = attributeNotExists(UNDEFINED)
-	if exists.Type() == ObjectTypeBoolean && exists.Inspect() != "true" {
-		t.Fatal("value should be true")
+	for name, tc := range cases {
+		got := attributeNotExists(tc.path)
+		if got != tc.expected {
+			t.Fatalf("%s: expected=%s got=%s", name, tc.expected.Inspect(), got.Inspect())
+		}
 	}
 }
 
 func TestAttributeType(t *testing.T) {
-	str := &String{Value: "hello"}
-	expected := &String{Value: "S"}
-
-	isExpectedType := attributeType(str, expected)
-	if isExpectedType.Type() == ObjectTypeBoolean && isExpectedType.Inspect() != "true" {
-		t.Fatal("value should be true")
+	cases := map[string]struct {
+		path     Object
+		typeArg  Object
+		expected Object
+	}{
+		"string_matches_S":      {&String{Value: "hello"}, &String{Value: "S"}, TRUE},
+		"string_does_not_match": {&String{Value: "hello"}, &String{Value: "N"}, FALSE},
+		"null_value_matches_NULL": {&Null{}, &String{Value: "NULL"}, TRUE},
+		"missing_does_not_match_NULL": {UNDEFINED, &String{Value: "NULL"}, FALSE},
+		"missing_does_not_match_S":    {UNDEFINED, &String{Value: "S"}, FALSE},
 	}
 
-	expected = &String{Value: "TYPE"}
-	isExpectedType = attributeType(str, expected)
+	for name, tc := range cases {
+		got := attributeType(tc.path, tc.typeArg)
+		if got != tc.expected {
+			t.Fatalf("%s: expected=%s got=%s", name, tc.expected.Inspect(), got.Inspect())
+		}
+	}
 
-	if isExpectedType.Type() != ObjectTypeError || isExpectedType.Inspect() != "ERROR: invalid type TYPE" {
-		t.Fatalf("expect invalid type error, got=%s %s", isExpectedType.Type(), isExpectedType.Inspect())
+	invalidType := &String{Value: "TYPE"}
+	got := attributeType(&String{Value: "hello"}, invalidType)
+
+	if got.Type() != ObjectTypeError || got.Inspect() != "ERROR: invalid type TYPE" {
+		t.Fatalf("expect invalid type error, got=%s %s", got.Type(), got.Inspect())
 	}
 }
 


### PR DESCRIPTION
What: Use `isUndefined(path)` instead of comparing `path.Type()` against `ObjectTypeNull` in `attribute_exists`, `attribute_not_exists`, `attribute_type`, and `if_not_exists` (`interpreter/language/functions.go`).

Why: The previous checks conflated missing attributes with attributes that exist with a NULL data type — both produce a `*Null` object, distinguished only by the `IsUndefined` flag. Per [DynamoDB's documented semantics](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_Condition.html), an attribute that exists with NULL type should still satisfy `attribute_exists` and `attribute_type(_, "NULL")`, and `if_not_exists` should preserve it rather than substituting the fallback.

Tests:
- Rewrote `TestAttributeExists`, `TestAttributeNotExists`, `TestAttributeType` as table-driven tests covering String, explicit `*Null`, `UNDEFINED`, and `nil` paths. (The originals had inverted assertions — `"TRUE"` vs `"true"` — that never triggered.)
- Added evaluator-level cases in `TestEvalFunctions` for `attribute_exists(:nilVal)`, `attribute_not_exists(:nilVal)`, `attribute_type(:nilVal, "NULL")`, and `attribute_type(:missing, "NULL")`.

All `interpreter`, `core`, `aws-v2`, `server`, and `types` package tests pass locally. The `e2e` parity suite requires Docker/testcontainers and was not run.

### Scope note

The doc page linked from issue #79 describes the legacy [`Condition.ComparisonOperator` API](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_Condition.html) (`NULL` / `NOT_NULL` operators used in `Expected`, `QueryFilter`, `ScanFilter`, `KeyConditions`). This PR fixes the equivalent semantics for the **modern expression language** (`attribute_exists`, `attribute_not_exists`, `attribute_type`, `if_not_exists`) — which is what current AWS SDKs generate.

The legacy `ComparisonOperator` field is accepted at the SDK adapter boundary (`aws-v2/client/mapper.go`) but never evaluated by `core/table.go` — that whole legacy operator family appears unimplemented in minidyn, which is arguably tracked by #120 ("partially supported features") rather than #79. Happy to extend this PR or open a follow-up if you'd like that path covered too.

Issue: #79