### PR TITLE
Add configurable GSI activation delay and IndexStatus

### DIFF
--- a/aws-v2/client/client.go
+++ b/aws-v2/client/client.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
@@ -63,6 +64,7 @@ type Client struct {
 	nativeInterpreter     *interpreter.Native
 	useNativeInterpreter  bool
 	forceFailureErr       error
+	indexActivationDelay  time.Duration
 }
 
 // NewClient initializes dynamodb client with a mock
@@ -104,6 +106,17 @@ func (fd *Client) setFailureCondition(condition FailureCondition) {
 	fd.forceFailureErr = emulatingErrors[condition]
 }
 
+func (fd *Client) setIndexActivationDelay(delay time.Duration) {
+	fd.mu.Lock()
+	defer fd.mu.Unlock()
+
+	fd.indexActivationDelay = delay
+
+	for _, table := range fd.tables {
+		table.IndexActivationDelay = delay
+	}
+}
+
 // SetInterpreter assigns a native interpreter
 func (fd *Client) SetInterpreter(i interpreter.Interpreter) {
 	native, ok := i.(*interpreter.Native)
@@ -136,6 +149,7 @@ func (fd *Client) CreateTable(ctx context.Context, input *dynamodb.CreateTableIn
 	newTable.NativeInterpreter = *fd.nativeInterpreter
 	newTable.UseNativeInterpreter = fd.useNativeInterpreter
 	newTable.LangInterpreter = *fd.langInterpreter
+	newTable.IndexActivationDelay = fd.indexActivationDelay
 
 	if err := newTable.CreatePrimaryIndex(mapDynamoToTypesCreateTableInput(input)); err != nil {
 		return nil, mapKnownError(err)

--- a/aws-v2/client/client_test.go
+++ b/aws-v2/client/client_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -531,6 +532,77 @@ func TestUpdateTable(t *testing.T) {
 
 	_, err = client.UpdateTable(context.Background(), input)
 	c.Equal("ResourceNotFoundException: Requested resource not found", err.Error())
+}
+
+func createTestGlobalSecondaryIndex(t *testing.T, client FakeClient, indexName string) {
+	t.Helper()
+
+	_, err := client.UpdateTable(context.Background(), &dynamodb.UpdateTableInput{
+		AttributeDefinitions: []dynamodbtypes.AttributeDefinition{
+			{AttributeName: aws.String("id"), AttributeType: dynamodbtypes.ScalarAttributeTypeS},
+			{AttributeName: aws.String("type"), AttributeType: dynamodbtypes.ScalarAttributeTypeS},
+		},
+		GlobalSecondaryIndexUpdates: []dynamodbtypes.GlobalSecondaryIndexUpdate{
+			{
+				Create: &dynamodbtypes.CreateGlobalSecondaryIndexAction{
+					IndexName: aws.String(indexName),
+					KeySchema: []dynamodbtypes.KeySchemaElement{
+						{AttributeName: aws.String("type"), KeyType: dynamodbtypes.KeyTypeHash},
+						{AttributeName: aws.String("id"), KeyType: dynamodbtypes.KeyTypeRange},
+					},
+					Projection: &dynamodbtypes.Projection{
+						ProjectionType: dynamodbtypes.ProjectionTypeAll,
+					},
+				},
+			},
+		},
+		TableName: aws.String(tableName),
+	})
+	require.NoError(t, err)
+}
+
+func describeGlobalSecondaryIndexStatus(t *testing.T, client FakeClient, indexName string) dynamodbtypes.IndexStatus {
+	t.Helper()
+
+	out, err := client.DescribeTable(context.Background(), &dynamodb.DescribeTableInput{
+		TableName: aws.String(tableName),
+	})
+	require.NoError(t, err)
+
+	for _, g := range out.Table.GlobalSecondaryIndexes {
+		if aws.ToString(g.IndexName) == indexName {
+			return g.IndexStatus
+		}
+	}
+
+	t.Fatalf("GSI %q not found on table %q", indexName, tableName)
+
+	return ""
+}
+
+func TestUpdateTableReportsGSIActiveByDefault(t *testing.T) {
+	c := require.New(t)
+	client := NewClient()
+
+	c.NoError(ensurePokemonTable(client))
+	createTestGlobalSecondaryIndex(t, client, "status-index")
+
+	c.Equal(dynamodbtypes.IndexStatusActive, describeGlobalSecondaryIndexStatus(t, client, "status-index"))
+}
+
+func TestSetIndexActivationDelayReportsGSIStatusTransition(t *testing.T) {
+	c := require.New(t)
+	client := NewClient()
+
+	SetIndexActivationDelay(client, 5*time.Millisecond)
+	c.NoError(ensurePokemonTable(client))
+	createTestGlobalSecondaryIndex(t, client, "delayed-index")
+
+	c.Equal(dynamodbtypes.IndexStatusCreating, describeGlobalSecondaryIndexStatus(t, client, "delayed-index"))
+
+	time.Sleep(10 * time.Millisecond)
+
+	c.Equal(dynamodbtypes.IndexStatusActive, describeGlobalSecondaryIndexStatus(t, client, "delayed-index"))
 }
 
 func TestPutAndGetItem(t *testing.T) {

--- a/aws-v2/client/minidyn.go
+++ b/aws-v2/client/minidyn.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"maps"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
@@ -123,6 +124,16 @@ func AddIndex(ctx context.Context, client FakeClient, tableName, indexName, part
 	_, err := client.UpdateTable(ctx, input)
 
 	return err
+}
+
+// SetIndexActivationDelay configures how long newly created GSIs report CREATING before ACTIVE.
+func SetIndexActivationDelay(client FakeClient, delay time.Duration) {
+	fakeClient, ok := client.(*Client)
+	if !ok {
+		panic("SetIndexActivationDelay: invalid client type")
+	}
+
+	fakeClient.setIndexActivationDelay(delay)
 }
 
 // ClearTable removes all data from a specific table

--- a/core/index.go
+++ b/core/index.go
@@ -3,6 +3,7 @@ package core
 import (
 	"maps"
 	"sort"
+	"time"
 
 	"github.com/truora/minidyn/types"
 )
@@ -22,6 +23,7 @@ type index struct {
 	projection *types.Projection
 	Table      *Table
 	refs       map[string]string
+	createdAt  time.Time
 }
 
 func newIndex(t *Table, typ indexType, ks keySchema) *index {

--- a/core/table.go
+++ b/core/table.go
@@ -5,11 +5,14 @@ import (
 	"maps"
 	"reflect"
 	"sort"
+	"time"
 
 	"github.com/truora/minidyn/interpreter"
 	"github.com/truora/minidyn/interpreter/language"
 	"github.com/truora/minidyn/types"
 )
+
+const defaultIndexActivationDelay = 0
 
 // QueryInput struct to represent a query input
 type QueryInput struct {
@@ -39,16 +42,18 @@ type Table struct {
 	UseNativeInterpreter bool
 	NativeInterpreter    interpreter.Native
 	LangInterpreter      interpreter.Language
+	IndexActivationDelay time.Duration
 }
 
 // NewTable creates a new Table
 func NewTable(name string) *Table {
 	return &Table{
-		Name:          name,
-		Indexes:       map[string]*index{},
-		AttributesDef: map[string]string{},
-		SortedKeys:    []string{},
-		Data:          map[string]map[string]*types.Item{},
+		Name:                 name,
+		Indexes:              map[string]*index{},
+		AttributesDef:        map[string]string{},
+		SortedKeys:           []string{},
+		Data:                 map[string]map[string]*types.Item{},
+		IndexActivationDelay: defaultIndexActivationDelay,
 	}
 }
 
@@ -216,6 +221,7 @@ func (t *Table) addGlobalIndex(gsiInput *types.GlobalSecondaryIndex) error {
 		return err
 	}
 
+	i.createdAt = time.Now()
 	t.Indexes[*gsiInput.IndexName] = i
 
 	return nil
@@ -974,11 +980,17 @@ func (t *Table) IndexesDescription() ([]types.GlobalSecondaryIndexDescription, [
 		switch index.typ {
 		case indexTypeGlobal:
 			{
+				status := "ACTIVE"
+				if t.IndexActivationDelay > 0 && time.Since(index.createdAt) < t.IndexActivationDelay {
+					status = "CREATING"
+				}
+
 				gsi = append(gsi, types.GlobalSecondaryIndexDescription{
-					IndexName:  &indexName,
-					ItemCount:  count,
-					KeySchema:  schema,
-					Projection: index.projection,
+					IndexName:   &indexName,
+					ItemCount:   count,
+					KeySchema:   schema,
+					Projection:  index.projection,
+					IndexStatus: &status,
 				})
 			}
 		case indexTypeLocal:

--- a/e2e/parity_helpers_test.go
+++ b/e2e/parity_helpers_test.go
@@ -181,8 +181,8 @@ func parityWaitUntilGSIActive(ctx context.Context, t *testing.T, client *dynamod
 				continue
 			}
 
-			// Minidyn DescribeTable omits IndexStatus; DynamoDB Local reports CREATING then ACTIVE.
-			if g.IndexStatus == dynamodbtypes.IndexStatusActive || g.IndexStatus == "" {
+			// Minidyn E2E server opts into a short activation delay; wait until ACTIVE.
+			if g.IndexStatus == dynamodbtypes.IndexStatusActive {
 				return
 			}
 		}

--- a/e2e/setup.go
+++ b/e2e/setup.go
@@ -28,10 +28,12 @@ const dynamoDBLocalImage = "amazon/dynamodb-local:latest"
 func setupMinidynClient(t *testing.T) *dynamodb.Client {
 	t.Helper()
 
-	srv := httptest.NewServer(server.NewServer())
-	t.Cleanup(srv.Close)
+	srv := server.NewServer()
+	srv.SetIndexActivationDelay(5 * time.Millisecond)
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
 
-	return newSDKClient(t, srv.URL)
+	return newSDKClient(t, ts.URL)
 }
 
 // setupDynamoDBLocalClient starts amazon/dynamodb-local in Docker and returns

--- a/server/client.go
+++ b/server/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"sync"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	ddbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
@@ -21,6 +22,7 @@ type Client struct {
 	nativeInterpreter    *interpreter.Native
 	useNativeInterpreter bool
 	forceFailureErr      error
+	indexActivationDelay time.Duration
 }
 
 // NewClient creates a new in-memory DynamoDB-compatible client used by the HTTP server.
@@ -35,6 +37,17 @@ func NewClient() *Client {
 
 func (c *Client) setFailureCondition(err error) {
 	c.forceFailureErr = err
+}
+
+func (c *Client) setIndexActivationDelay(delay time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.indexActivationDelay = delay
+
+	for _, table := range c.tables {
+		table.IndexActivationDelay = delay
+	}
 }
 
 // Table helpers
@@ -60,6 +73,7 @@ func (c *Client) CreateTable(ctx context.Context, input *CreateTableInput) (*Cre
 	table.NativeInterpreter = *c.nativeInterpreter
 	table.UseNativeInterpreter = c.useNativeInterpreter
 	table.LangInterpreter = *c.langInterpreter
+	table.IndexActivationDelay = c.indexActivationDelay
 
 	if err := table.CreatePrimaryIndex(&types.CreateTableInput{
 		KeySchema:             mapKeySchema(input.KeySchema),

--- a/server/mapper.go
+++ b/server/mapper.go
@@ -358,9 +358,10 @@ func mapTypesGSI(in []types.GlobalSecondaryIndexDescription) []ddbtypes.GlobalSe
 	for i, g := range in {
 		gCopy := g
 		out[i] = ddbtypes.GlobalSecondaryIndexDescription{
-			IndexName: gCopy.IndexName,
-			ItemCount: aws.Int64(gCopy.ItemCount),
-			KeySchema: mapTypesKeySchema(gCopy.KeySchema),
+			IndexName:   gCopy.IndexName,
+			ItemCount:   aws.Int64(gCopy.ItemCount),
+			KeySchema:   mapTypesKeySchema(gCopy.KeySchema),
+			IndexStatus: ddbtypes.IndexStatus(aws.ToString(gCopy.IndexStatus)),
 			Projection: &ddbtypes.Projection{
 				NonKeyAttributes: fromStringPtrs(gCopy.Projection.NonKeyAttributes),
 				ProjectionType:   ddbtypes.ProjectionType(aws.ToString(gCopy.Projection.ProjectionType)),

--- a/server/minidyn.go
+++ b/server/minidyn.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"errors"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	ddbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
@@ -46,6 +47,15 @@ func (s *Server) EmulateFailure(condition FailureCondition) {
 	}
 
 	s.client.setFailureCondition(emulatingErrors[condition])
+}
+
+// SetIndexActivationDelay configures how long newly created GSIs report CREATING before ACTIVE.
+func (s *Server) SetIndexActivationDelay(delay time.Duration) {
+	if s == nil || s.client == nil {
+		return
+	}
+
+	s.client.setIndexActivationDelay(delay)
 }
 
 // ClearTable removes all data from a table and its indexes using the in-memory client.

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1023,6 +1023,75 @@ func TestServerDescribeAndUpdateTableWithSDKv2(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func createServerTestGlobalSecondaryIndex(t *testing.T, cli *dynamodb.Client, table, indexName string) {
+	t.Helper()
+
+	_, err := cli.UpdateTable(context.Background(), &dynamodb.UpdateTableInput{
+		TableName: aws.String(table),
+		AttributeDefinitions: []ddbtypes.AttributeDefinition{
+			{AttributeName: aws.String("type"), AttributeType: ddbtypes.ScalarAttributeTypeS},
+		},
+		GlobalSecondaryIndexUpdates: []ddbtypes.GlobalSecondaryIndexUpdate{
+			{Create: &ddbtypes.CreateGlobalSecondaryIndexAction{
+				IndexName: aws.String(indexName),
+				KeySchema: []ddbtypes.KeySchemaElement{
+					{AttributeName: aws.String("type"), KeyType: ddbtypes.KeyTypeHash},
+				},
+				Projection: &ddbtypes.Projection{ProjectionType: ddbtypes.ProjectionTypeAll},
+			}},
+		},
+	})
+	require.NoError(t, err)
+}
+
+func describeServerGlobalSecondaryIndexStatus(t *testing.T, cli *dynamodb.Client, table, indexName string) ddbtypes.IndexStatus {
+	t.Helper()
+
+	out, err := cli.DescribeTable(context.Background(), &dynamodb.DescribeTableInput{
+		TableName: aws.String(table),
+	})
+	require.NoError(t, err)
+
+	for _, g := range out.Table.GlobalSecondaryIndexes {
+		if aws.ToString(g.IndexName) == indexName {
+			return g.IndexStatus
+		}
+	}
+
+	t.Fatalf("GSI %q not found on table %q", indexName, table)
+
+	return ""
+}
+
+func TestServerDescribeTableIncludesGSIStatus(t *testing.T) {
+	srv := NewServer()
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	cli := newTestDynamoClient(t, ts.URL)
+	makeBasicTable(t, cli, "pokemons", "id")
+	createServerTestGlobalSecondaryIndex(t, cli, "pokemons", "by-type")
+
+	require.Equal(t, ddbtypes.IndexStatusActive, describeServerGlobalSecondaryIndexStatus(t, cli, "pokemons", "by-type"))
+}
+
+func TestServerSetIndexActivationDelayReportsGSIStatusTransition(t *testing.T) {
+	srv := NewServer()
+	srv.SetIndexActivationDelay(5 * time.Millisecond)
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	cli := newTestDynamoClient(t, ts.URL)
+	makeBasicTable(t, cli, "pokemons", "id")
+	createServerTestGlobalSecondaryIndex(t, cli, "pokemons", "delayed-index")
+
+	require.Equal(t, ddbtypes.IndexStatusCreating, describeServerGlobalSecondaryIndexStatus(t, cli, "pokemons", "delayed-index"))
+
+	time.Sleep(10 * time.Millisecond)
+
+	require.Equal(t, ddbtypes.IndexStatusActive, describeServerGlobalSecondaryIndexStatus(t, cli, "pokemons", "delayed-index"))
+}
+
 func TestServerAddLSIWithSDKv2(t *testing.T) {
 	ts := httptest.NewServer(NewServer())
 	defer ts.Close()


### PR DESCRIPTION
Why:
DescribeTable should report CREATING then ACTIVE for new GSIs like DynamoDB Local, while keeping immediate ACTIVE as the default for tests and callers that do not opt in.

What:
- Track GSI creation time and derive IndexStatus in core descriptions.
- Expose SetIndexActivationDelay on aws-v2/client and server entry points.
- Serialize IndexStatus in the server mapper and add unit tests.
- Opt E2E Minidyn setup into a 5ms delay and drop the empty-status workaround in parityWaitUntilGSIActive.

Issue: #120