### PR TITLE
Fix case-insensitive keyword parsing in condition expressions

### DIFF
--- a/interpreter/language/evaluator_test.go
+++ b/interpreter/language/evaluator_test.go
@@ -25,6 +25,10 @@ func TestEval(t *testing.T) {
 		{":a = :a AND :b = :b", TRUE},
 		{":a = :a AND :a = :b", FALSE},
 		{":a = :a OR :a = :b", TRUE},
+		{":a = :a or :a = :b", TRUE},
+		{":a = :a and :b = :b", TRUE},
+		{"not :a = :a", FALSE},
+		{":a = :a Or :a = :b", TRUE},
 		{":x = :y", FALSE},
 		// Numbers
 		{":s = :b", FALSE},

--- a/interpreter/language/lexer_test.go
+++ b/interpreter/language/lexer_test.go
@@ -92,6 +92,25 @@ func TestNextToken(t *testing.T) {
 			{DOT, "."},
 			{IDENT, "f"},
 		},
+		`a or b`: {
+			{IDENT, "a"},
+			{OR, "or"},
+			{IDENT, "b"},
+		},
+		`a and b`: {
+			{IDENT, "a"},
+			{AND, "and"},
+			{IDENT, "b"},
+		},
+		`not a`: {
+			{NOT, "not"},
+			{IDENT, "a"},
+		},
+		`a Or b`: {
+			{IDENT, "a"},
+			{OR, "Or"},
+			{IDENT, "b"},
+		},
 	}
 
 	for input, tests := range table {

--- a/interpreter/language/parser.go
+++ b/interpreter/language/parser.go
@@ -231,7 +231,7 @@ func (p *Parser) parseExpression(precedence int) Expression {
 func (p *Parser) parsePrefixExpression() Expression {
 	expression := &PrefixExpression{
 		Token:    p.curToken,
-		Operator: p.curToken.Literal,
+		Operator: string(p.curToken.Type),
 	}
 
 	p.nextToken()
@@ -243,7 +243,7 @@ func (p *Parser) parsePrefixExpression() Expression {
 func (p *Parser) parseInfixExpression(left Expression) Expression {
 	expression := &InfixExpression{
 		Token:    p.curToken,
-		Operator: p.curToken.Literal,
+		Operator: string(p.curToken.Type),
 		Left:     left,
 	}
 

--- a/interpreter/language/token.go
+++ b/interpreter/language/token.go
@@ -1,5 +1,7 @@
 package language
 
+import "strings"
+
 // TokenType represents the type of the token
 type TokenType string
 
@@ -664,7 +666,7 @@ var (
 
 // LookupIdent checks if the ident is a keyword
 func LookupIdent(ident string) TokenType {
-	if tok, ok := keywords[ident]; ok {
+	if tok, ok := keywords[strings.ToUpper(ident)]; ok {
 		return tok
 	}
 


### PR DESCRIPTION
DynamoDB keywords (OR, AND, NOT, etc.) are case-insensitive, but minidyn only recognized uppercase variants. Lowercase keywords like "or" were tokenized as identifiers, causing errors such as "unknown operator: BOOL or BOOL".

- Normalize identifier lookup with strings.ToUpper in LookupIdent
- Use canonical token type instead of raw literal for operators in parseInfixExpression and parsePrefixExpression

Fix of issue: https://github.com/truora/minidyn/issues/128
