### PR TITLE
Align UpdateItem validation errors with DynamoDB Local

### DIFF
--- a/e2e/parity_item_test.go
+++ b/e2e/parity_item_test.go
@@ -1106,6 +1106,281 @@ func TestE2E_Item(t *testing.T) {
 			},
 		},
 		{
+			name: "UpdateSetNestedMissingParent",
+			fn: func(t *testing.T, client *dynamodb.Client) any {
+				t.Helper()
+				ctx := context.Background()
+
+				parityCreatePokemonTable(ctx, t, client)
+				parityCreatePokemon(ctx, t, client, parityPokemon{ID: "001", Type: "grass", Name: "Bulbasaur"})
+
+				_, err := client.UpdateItem(ctx, &dynamodb.UpdateItemInput{
+					TableName: aws.String(parityPokemonTable),
+					Key: map[string]dynamodbtypes.AttributeValue{
+						"id": &dynamodbtypes.AttributeValueMemberS{Value: "001"},
+					},
+					UpdateExpression: aws.String("SET notFound.bar = :one"),
+					ExpressionAttributeValues: map[string]dynamodbtypes.AttributeValue{
+						":one": &dynamodbtypes.AttributeValueMemberN{Value: "1"},
+					},
+				})
+				require.Error(t, err)
+
+				return normalizeSDKErrorString(err.Error())
+			},
+		},
+		{
+			name: "UpdateSetNestedScalarParent",
+			fn: func(t *testing.T, client *dynamodb.Client) any {
+				t.Helper()
+				ctx := context.Background()
+
+				parityCreatePokemonTable(ctx, t, client)
+				parityCreatePokemon(ctx, t, client, parityPokemon{ID: "001", Type: "grass", Name: "Bulbasaur"})
+
+				_, err := client.UpdateItem(ctx, &dynamodb.UpdateItemInput{
+					TableName: aws.String(parityPokemonTable),
+					Key: map[string]dynamodbtypes.AttributeValue{
+						"id": &dynamodbtypes.AttributeValueMemberS{Value: "001"},
+					},
+					UpdateExpression:         aws.String("SET #n.bar = :one"),
+					ExpressionAttributeNames: map[string]string{"#n": "name"},
+					ExpressionAttributeValues: map[string]dynamodbtypes.AttributeValue{
+						":one": &dynamodbtypes.AttributeValueMemberN{Value: "1"},
+					},
+				})
+				require.Error(t, err)
+
+				return normalizeSDKErrorString(err.Error())
+			},
+		},
+		{
+			name: "UpdateSetNestedListMissingParent",
+			fn: func(t *testing.T, client *dynamodb.Client) any {
+				t.Helper()
+				ctx := context.Background()
+
+				parityCreatePokemonTable(ctx, t, client)
+				parityCreatePokemon(ctx, t, client, parityPokemon{ID: "001", Type: "grass", Name: "Bulbasaur"})
+
+				_, err := client.UpdateItem(ctx, &dynamodb.UpdateItemInput{
+					TableName: aws.String(parityPokemonTable),
+					Key: map[string]dynamodbtypes.AttributeValue{
+						"id": &dynamodbtypes.AttributeValueMemberS{Value: "001"},
+					},
+					UpdateExpression: aws.String("SET notFound[0] = :one"),
+					ExpressionAttributeValues: map[string]dynamodbtypes.AttributeValue{
+						":one": &dynamodbtypes.AttributeValueMemberN{Value: "1"},
+					},
+				})
+				require.Error(t, err)
+
+				return normalizeSDKErrorString(err.Error())
+			},
+		},
+		{
+			name: "UpdateSetNestedListScalarParent",
+			fn: func(t *testing.T, client *dynamodb.Client) any {
+				t.Helper()
+				ctx := context.Background()
+
+				parityCreatePokemonTable(ctx, t, client)
+				parityCreatePokemon(ctx, t, client, parityPokemon{ID: "001", Type: "grass", Name: "Bulbasaur"})
+
+				_, err := client.UpdateItem(ctx, &dynamodb.UpdateItemInput{
+					TableName: aws.String(parityPokemonTable),
+					Key: map[string]dynamodbtypes.AttributeValue{
+						"id": &dynamodbtypes.AttributeValueMemberS{Value: "001"},
+					},
+					UpdateExpression:         aws.String("SET #n[0] = :one"),
+					ExpressionAttributeNames: map[string]string{"#n": "name"},
+					ExpressionAttributeValues: map[string]dynamodbtypes.AttributeValue{
+						":one": &dynamodbtypes.AttributeValueMemberN{Value: "1"},
+					},
+				})
+				require.Error(t, err)
+
+				return normalizeSDKErrorString(err.Error())
+			},
+		},
+		{
+			name: "UpdateSetDeepIntermediateMissing",
+			fn: func(t *testing.T, client *dynamodb.Client) any {
+				t.Helper()
+				ctx := context.Background()
+
+				parityCreatePokemonTable(ctx, t, client)
+				parityCreatePokemon(ctx, t, client, parityPokemon{ID: "001", Type: "grass", Name: "Bulbasaur"})
+
+				_, err := client.PutItem(ctx, &dynamodb.PutItemInput{
+					TableName: aws.String(parityPokemonTable),
+					Item: map[string]dynamodbtypes.AttributeValue{
+						"id":   &dynamodbtypes.AttributeValueMemberS{Value: "001"},
+						"type": &dynamodbtypes.AttributeValueMemberS{Value: "grass"},
+						"name": &dynamodbtypes.AttributeValueMemberS{Value: "Bulbasaur"},
+						"info": &dynamodbtypes.AttributeValueMemberM{Value: map[string]dynamodbtypes.AttributeValue{}},
+					},
+				})
+				require.NoError(t, err)
+
+				_, err = client.UpdateItem(ctx, &dynamodb.UpdateItemInput{
+					TableName: aws.String(parityPokemonTable),
+					Key: map[string]dynamodbtypes.AttributeValue{
+						"id": &dynamodbtypes.AttributeValueMemberS{Value: "001"},
+					},
+					UpdateExpression: aws.String("SET info.a.b = :one"),
+					ExpressionAttributeValues: map[string]dynamodbtypes.AttributeValue{
+						":one": &dynamodbtypes.AttributeValueMemberN{Value: "1"},
+					},
+				})
+				require.Error(t, err)
+
+				return normalizeSDKErrorString(err.Error())
+			},
+		},
+		{
+			name: "UpdateSetMixedListMapDeepMissing",
+			fn: func(t *testing.T, client *dynamodb.Client) any {
+				t.Helper()
+				ctx := context.Background()
+
+				parityCreatePokemonTable(ctx, t, client)
+				parityCreatePokemon(ctx, t, client, parityPokemon{ID: "001", Type: "grass", Name: "Bulbasaur"})
+
+				_, err := client.PutItem(ctx, &dynamodb.PutItemInput{
+					TableName: aws.String(parityPokemonTable),
+					Item: map[string]dynamodbtypes.AttributeValue{
+						"id":   &dynamodbtypes.AttributeValueMemberS{Value: "001"},
+						"type": &dynamodbtypes.AttributeValueMemberS{Value: "grass"},
+						"name": &dynamodbtypes.AttributeValueMemberS{Value: "Bulbasaur"},
+						"entry_list": &dynamodbtypes.AttributeValueMemberL{Value: []dynamodbtypes.AttributeValue{
+							&dynamodbtypes.AttributeValueMemberM{Value: map[string]dynamodbtypes.AttributeValue{}},
+						}},
+					},
+				})
+				require.NoError(t, err)
+
+				_, err = client.UpdateItem(ctx, &dynamodb.UpdateItemInput{
+					TableName: aws.String(parityPokemonTable),
+					Key: map[string]dynamodbtypes.AttributeValue{
+						"id": &dynamodbtypes.AttributeValueMemberS{Value: "001"},
+					},
+					UpdateExpression:         aws.String("SET #lst[0].a.b = :one"),
+					ExpressionAttributeNames: map[string]string{"#lst": "entry_list"},
+					ExpressionAttributeValues: map[string]dynamodbtypes.AttributeValue{
+						":one": &dynamodbtypes.AttributeValueMemberN{Value: "1"},
+					},
+				})
+				require.Error(t, err)
+
+				return normalizeSDKErrorString(err.Error())
+			},
+		},
+		{
+			name: "UpdateSetMixedMapListOnScalar",
+			fn: func(t *testing.T, client *dynamodb.Client) any {
+				t.Helper()
+				ctx := context.Background()
+
+				parityCreatePokemonTable(ctx, t, client)
+				parityCreatePokemon(ctx, t, client, parityPokemon{ID: "001", Type: "grass", Name: "Bulbasaur"})
+
+				_, err := client.PutItem(ctx, &dynamodb.PutItemInput{
+					TableName: aws.String(parityPokemonTable),
+					Item: map[string]dynamodbtypes.AttributeValue{
+						"id":   &dynamodbtypes.AttributeValueMemberS{Value: "001"},
+						"type": &dynamodbtypes.AttributeValueMemberS{Value: "grass"},
+						"name": &dynamodbtypes.AttributeValueMemberS{Value: "Bulbasaur"},
+						"wrapper": &dynamodbtypes.AttributeValueMemberM{Value: map[string]dynamodbtypes.AttributeValue{
+							"label": &dynamodbtypes.AttributeValueMemberS{Value: "text"},
+						}},
+					},
+				})
+				require.NoError(t, err)
+
+				_, err = client.UpdateItem(ctx, &dynamodb.UpdateItemInput{
+					TableName: aws.String(parityPokemonTable),
+					Key: map[string]dynamodbtypes.AttributeValue{
+						"id": &dynamodbtypes.AttributeValueMemberS{Value: "001"},
+					},
+					UpdateExpression:         aws.String("SET #wrap.label[0] = :one"),
+					ExpressionAttributeNames: map[string]string{"#wrap": "wrapper"},
+					ExpressionAttributeValues: map[string]dynamodbtypes.AttributeValue{
+						":one": &dynamodbtypes.AttributeValueMemberN{Value: "1"},
+					},
+				})
+				require.Error(t, err)
+
+				return normalizeSDKErrorString(err.Error())
+			},
+		},
+		{
+			name: "UpdateAddWrongOperandType",
+			fn: func(t *testing.T, client *dynamodb.Client) any {
+				t.Helper()
+				ctx := context.Background()
+
+				parityCreatePokemonTable(ctx, t, client)
+				parityCreatePokemon(ctx, t, client, parityPokemon{ID: "001", Type: "grass", Name: "Bulbasaur"})
+
+				_, err := client.UpdateItem(ctx, &dynamodb.UpdateItemInput{
+					TableName: aws.String(parityPokemonTable),
+					Key: map[string]dynamodbtypes.AttributeValue{
+						"id": &dynamodbtypes.AttributeValueMemberS{Value: "001"},
+					},
+					UpdateExpression:         aws.String("ADD #n :one"),
+					ExpressionAttributeNames: map[string]string{"#n": "name"},
+					ExpressionAttributeValues: map[string]dynamodbtypes.AttributeValue{
+						":one": &dynamodbtypes.AttributeValueMemberN{Value: "1"},
+					},
+				})
+				require.Error(t, err)
+
+				return normalizeSDKErrorString(err.Error())
+			},
+		},
+		{
+			name: "UpdateSetNestedIntoExistingMap",
+			fn: func(t *testing.T, client *dynamodb.Client) any {
+				t.Helper()
+				ctx := context.Background()
+
+				parityCreatePokemonTable(ctx, t, client)
+				parityCreatePokemon(ctx, t, client, parityPokemon{ID: "001", Type: "grass", Name: "Bulbasaur"})
+
+				_, err := client.PutItem(ctx, &dynamodb.PutItemInput{
+					TableName: aws.String(parityPokemonTable),
+					Item: map[string]dynamodbtypes.AttributeValue{
+						"id":   &dynamodbtypes.AttributeValueMemberS{Value: "001"},
+						"type": &dynamodbtypes.AttributeValueMemberS{Value: "grass"},
+						"name": &dynamodbtypes.AttributeValueMemberS{Value: "Bulbasaur"},
+						"info": &dynamodbtypes.AttributeValueMemberM{Value: map[string]dynamodbtypes.AttributeValue{
+							"x": &dynamodbtypes.AttributeValueMemberN{Value: "1"},
+						}},
+					},
+				})
+				require.NoError(t, err)
+
+				_, err = client.UpdateItem(ctx, &dynamodb.UpdateItemInput{
+					TableName: aws.String(parityPokemonTable),
+					Key: map[string]dynamodbtypes.AttributeValue{
+						"id": &dynamodbtypes.AttributeValueMemberS{Value: "001"},
+					},
+					UpdateExpression: aws.String("SET info.y = :one"),
+					ExpressionAttributeValues: map[string]dynamodbtypes.AttributeValue{
+						":one": &dynamodbtypes.AttributeValueMemberN{Value: "2"},
+					},
+				})
+				require.NoError(t, err)
+
+				item := parityGetPokemon(ctx, t, client, "001")
+				info, ok := item["info"].(*dynamodbtypes.AttributeValueMemberM)
+				require.True(t, ok)
+
+				return info.Value
+			},
+		},
+		{
 			name: "DeleteItemWithReturnValues",
 			fn: func(t *testing.T, client *dynamodb.Client) any {
 				t.Helper()

--- a/interpreter/language.go
+++ b/interpreter/language.go
@@ -1,6 +1,7 @@
 package interpreter
 
 import (
+	"errors"
 	"fmt"
 	"maps"
 	"strings"
@@ -181,7 +182,11 @@ func (li *Language) Update(input UpdateInput) error {
 	result := language.EvalUpdate(update, env)
 
 	if result.Type() == language.ObjectTypeError {
-		return fmt.Errorf("%w: %s", ErrSyntaxError, result.Inspect())
+		if errObj, ok := result.(*language.Error); ok {
+			return errors.New(errObj.Message)
+		}
+
+		return errors.New(result.Inspect())
 	}
 
 	env.Apply(input.Item, aliases, attributes)

--- a/interpreter/language/evaluator.go
+++ b/interpreter/language/evaluator.go
@@ -57,8 +57,17 @@ func EvalUpdate(n Node, env *Environment) Object {
 	return newError("unsupported expression: %s", n.String())
 }
 
+const invalidDocumentPathMessage = "The document path provided in the update expression is invalid for update"
+
 func newError(format string, a ...any) *Error {
 	return &Error{Message: fmt.Sprintf(format, a...)}
+}
+
+func newInvalidDocumentPathError(fieldID, path string) *Error {
+	return newError(
+		"%s; field id: %s; path: %s",
+		invalidDocumentPathMessage, fieldID, path,
+	)
 }
 
 func isError(obj Object) bool {
@@ -411,7 +420,7 @@ func evalIdentifier(node *Identifier, env *Environment, toplevel bool) Object {
 }
 
 func evalIndex(node *IndexExpression, env *Environment) Object {
-	positions, o, errObj := evalIndexPositions(node, env)
+	positions, o, errObj := evalIndexPositions(node, env, false)
 	if isError(errObj) {
 		return errObj
 	}
@@ -431,9 +440,49 @@ func evalIndex(node *IndexExpression, env *Environment) Object {
 }
 
 type indexAccessor struct {
-	kind     ObjectType
-	val      any
-	operator Token
+	kind       ObjectType
+	val        any
+	operator   Token
+	fieldID    string
+	pathSuffix string
+}
+
+func indexFieldID(id *Identifier, env *Environment) string {
+	if alias, ok := env.Aliases[id.Value]; ok {
+		return alias
+	}
+
+	return id.Value
+}
+
+func (i indexAccessor) indexName() string {
+	switch i.kind {
+	case ObjectTypeMap:
+		if s, ok := i.val.(string); ok {
+			return s
+		}
+	case ObjectTypeList:
+		if n, ok := i.val.(int64); ok {
+			return strconv.FormatInt(n, 10)
+		}
+	}
+
+	return ""
+}
+
+// documentPathSuffix formats index segments after the root attribute (root-first,
+// dot-separated). positions are innermost-first from evalIndexPositions.
+func documentPathSuffix(positions []indexAccessor) string {
+	if len(positions) == 0 {
+		return ""
+	}
+
+	parts := make([]string, len(positions))
+	for i, pos := range positions {
+		parts[len(positions)-1-i] = pos.indexName()
+	}
+
+	return strings.Join(parts, ".")
 }
 
 func (i indexAccessor) Get(container Object) Object {
@@ -486,13 +535,32 @@ func (i indexAccessor) Set(container, val Object) Object {
 		return UNDEFINED
 	}
 
-	return newError("index assignation for %q type is not supported", container.Type())
+	return newInvalidDocumentPathError(i.fieldID, i.pathSuffix)
 }
 
-func handleIndexIdentifier(n Expression, env *Environment, positions []indexAccessor) ([]indexAccessor, Object, Object) {
+func handleIndexIdentifier(n Expression, env *Environment, positions []indexAccessor, assign bool) ([]indexAccessor, Object, Object) {
 	obj, errObj := evalIndexObj(n, env)
 	if isError(errObj) {
+		if assign {
+			fieldID := ""
+			if id, ok := n.(*Identifier); ok {
+				fieldID = indexFieldID(id, env)
+			}
+
+			return nil, nil, newInvalidDocumentPathError(fieldID, documentPathSuffix(positions))
+		}
+
 		return nil, nil, errObj
+	}
+
+	if id, ok := n.(*Identifier); ok {
+		fieldID := indexFieldID(id, env)
+		suffix := documentPathSuffix(positions)
+
+		for j := range positions {
+			positions[j].fieldID = fieldID
+			positions[j].pathSuffix = suffix
+		}
 	}
 
 	return positions, obj, nil
@@ -518,14 +586,14 @@ func (i indexAccessor) Remove(container Object) Object {
 	return newError("index removal for %q type is not supported", container.Type())
 }
 
-func evalIndexPositions(n Expression, env *Environment) ([]indexAccessor, Object, Object) {
+func evalIndexPositions(n Expression, env *Environment, assign bool) ([]indexAccessor, Object, Object) {
 	positions := []indexAccessor{}
 	exp := n
 
 	for {
 		switch node := exp.(type) {
 		case *Identifier:
-			return handleIndexIdentifier(exp, env, positions)
+			return handleIndexIdentifier(exp, env, positions, assign)
 		case *IndexExpression:
 			identifier, ok := node.Index.(*Identifier)
 			if !ok {
@@ -882,7 +950,7 @@ func evalActionAdd(node *ActionExpression, env *Environment) Object {
 
 		addObj, ok := obj.(AppendableObject)
 		if !ok {
-			return newError("an operand in the update expression has an incorrect data type")
+			return newError("An operand in the update expression has an incorrect data type")
 		}
 
 		return addObj.Add(val)
@@ -912,7 +980,7 @@ func evalActionDelete(node *ActionExpression, env *Environment) Object {
 
 		addObj, ok := obj.(DetachableObject)
 		if !ok {
-			return newError("an operand in the update expression has an incorrect data type")
+			return newError("An operand in the update expression has an incorrect data type")
 		}
 
 		return addObj.Delete(val)
@@ -937,7 +1005,7 @@ func evalActionRemove(node *ActionExpression, env *Environment) Object {
 
 	indexField, ok := node.Left.(*IndexExpression)
 	if ok {
-		positions, o, errObj := evalIndexPositions(indexField, env)
+		positions, o, errObj := evalIndexPositions(indexField, env, false)
 		if isError(errObj) {
 			return errObj
 		}
@@ -1002,7 +1070,7 @@ func evalInfixUpdate(node *InfixExpression, env *Environment) Object {
 }
 
 func evalAssignIndex(n Expression, i []int, val Object, env *Environment) Object {
-	positions, o, errObj := evalIndexPositions(n, env)
+	positions, o, errObj := evalIndexPositions(n, env, true)
 	if isError(errObj) {
 		return errObj
 	}

--- a/interpreter/language/evaluator_test.go
+++ b/interpreter/language/evaluator_test.go
@@ -948,19 +948,39 @@ func TestUpdateEvalSyntaxError(t *testing.T) {
 		},
 		{
 			"SET h.bar = :one",
-			"index assignation for \"NULL\" type is not supported",
+			"The document path provided in the update expression is invalid for update; field id: h; path: bar",
 		},
 		{
 			"SET notFound.bar = :one",
-			"index assignation for \"NULL\" type is not supported",
+			"The document path provided in the update expression is invalid for update; field id: notFound; path: bar",
+		},
+		{
+			"SET :val.bar = :one",
+			"The document path provided in the update expression is invalid for update; field id: :val; path: bar",
+		},
+		{
+			"SET notFound[0] = :one",
+			"The document path provided in the update expression is invalid for update; field id: notFound; path: 0",
+		},
+		{
+			"SET info.a.b = :one",
+			"The document path provided in the update expression is invalid for update; field id: info; path: a.b",
+		},
+		{
+			"SET entry_list[0].a.b = :one",
+			"The document path provided in the update expression is invalid for update; field id: entry_list; path: 0.a.b",
+		},
+		{
+			"SET wrapper.label[0] = :one",
+			"The document path provided in the update expression is invalid for update; field id: wrapper; path: label.0",
 		},
 		{
 			"ADD :voidVal :one",
-			"an operand in the update expression has an incorrect data type",
+			"An operand in the update expression has an incorrect data type",
 		},
 		{
 			"SET :x[1] = :one",
-			"index operator not supported for \"BOOL\"",
+			"The document path provided in the update expression is invalid for update; field id: :x; path: 1",
 		},
 		{
 			"SET :list[:x] = :val",
@@ -976,7 +996,7 @@ func TestUpdateEvalSyntaxError(t *testing.T) {
 		},
 		{
 			"DELETE :x :list",
-			"an operand in the update expression has an incorrect data type",
+			"An operand in the update expression has an incorrect data type",
 		},
 		{
 			"DELETE :list sizze(:x)",
@@ -995,6 +1015,13 @@ func TestUpdateEvalSyntaxError(t *testing.T) {
 				"a": {BOOL: &boolTrue},
 			},
 		},
+		"info": {M: map[string]*types.Item{}},
+		"entry_list": {L: []*types.Item{
+			{M: map[string]*types.Item{}},
+		}},
+		"wrapper": {M: map[string]*types.Item{
+			"label": {S: new("text")},
+		}},
 		":voidVal": {
 			NULL: &boolTrue,
 		},

--- a/interpreter/language_test.go
+++ b/interpreter/language_test.go
@@ -135,11 +135,12 @@ func TestLanguageMatch_keyConditionSyntaxErrorPrefix(t *testing.T) {
 }
 
 type updateTestCase struct {
-	name        string
-	input       UpdateInput
-	output      map[string]*types.Item
-	expectedErr error
-	pending     bool
+	name           string
+	input          UpdateInput
+	output         map[string]*types.Item
+	expectedErr    error
+	expectedErrMsg string
+	pending        bool
 }
 
 func updateTestCaseVerify(tc updateTestCase, t *testing.T) {
@@ -150,6 +151,14 @@ func updateTestCaseVerify(tc updateTestCase, t *testing.T) {
 	interpeter := Language{}
 
 	err := interpeter.Update(tc.input)
+	if tc.expectedErrMsg != "" {
+		if err == nil || err.Error() != tc.expectedErrMsg {
+			t.Errorf("%q failed with unexpected error; expected=%q, got=%v", tc.input.Expression, tc.expectedErrMsg, err)
+		}
+
+		return
+	}
+
 	if tc.expectedErr != nil {
 		if !errors.Is(err, tc.expectedErr) {
 			t.Errorf("%q failed with unexpected error; expected=%v, got=%v", tc.input.Expression, tc.expectedErr, err)
@@ -194,7 +203,7 @@ func TestLanguageUpdate(t *testing.T) {
 			},
 		},
 		{
-			name: "syntax error",
+			name: "runtime validation error",
 			input: UpdateInput{
 				TableName:  "test",
 				Expression: "SET",
@@ -209,7 +218,7 @@ func TestLanguageUpdate(t *testing.T) {
 					},
 				},
 			},
-			expectedErr: ErrSyntaxError,
+			expectedErrMsg: "SET expression must have at least one action",
 		},
 		{
 			name: "typo",


### PR DESCRIPTION
Why:
UpdateItem runtime failures were wrapped as Syntax error: ERROR: and used minidyn-specific nested-path text, so parity against DynamoDB Local failed for invalid SET paths and operand type mismatches.

What:
- Return bare EvalUpdate errors as ValidationException (parser errors unchanged).
- Map invalid nested SET paths to DynamoDB's invalid document path message; add field id and dot-separated path diagnostics after ';'.
- Scope document-path errors to assignment; keep read/condition messages.
- Capitalize the ADD/DELETE incorrect-operand validation message.
- Add unit and e2e parity coverage for nested SET and operand errors.

Issue: #120