### PR TITLE
Add table and index scoped failure emulation

### DIFF
--- a/aws-v2/client/client.go
+++ b/aws-v2/client/client.go
@@ -66,6 +66,7 @@ type Client struct {
 	nativeInterpreter     *interpreter.Native
 	useNativeInterpreter  bool
 	forceFailureErr       error
+	tableFailureErrs      map[string]error
 	indexActivationDelay  time.Duration
 }
 
@@ -76,6 +77,7 @@ func NewClient() *Client {
 		mu:                sync.Mutex{},
 		nativeInterpreter: interpreter.NewNativeInterpreter(),
 		langInterpreter:   &interpreter.Language{},
+		tableFailureErrs:  map[string]error{},
 	}
 
 	return &fake
@@ -106,6 +108,48 @@ func (fd *Client) setFailureCondition(condition FailureCondition) {
 	defer fd.mu.Unlock()
 
 	fd.forceFailureErr = emulatingErrors[condition]
+}
+
+// failureKey builds the lookup key for a table-scoped failure. An empty index
+// means the failure applies to the whole table.
+func failureKey(table, index string) string {
+	return table + "\x00" + index
+}
+
+// setTableFailureCondition scopes a failure to a table, or to a specific index of
+// that table when index is not empty. FailureConditionNone clears that exact scope.
+func (fd *Client) setTableFailureCondition(table, index string, condition FailureCondition) {
+	fd.mu.Lock()
+	defer fd.mu.Unlock()
+
+	key := failureKey(table, index)
+
+	err := emulatingErrors[condition]
+	if err == nil {
+		delete(fd.tableFailureErrs, key)
+
+		return
+	}
+
+	fd.tableFailureErrs[key] = err
+}
+
+// failureErrFor resolves the emulated error for an operation targeting the given
+// table and index. A global failure overrides everything; otherwise an
+// index-scoped failure (when index is set) wins over a table-wide one. Callers
+// must hold fd.mu.
+func (fd *Client) failureErrFor(table, index string) error {
+	if fd.forceFailureErr != nil {
+		return fd.forceFailureErr
+	}
+
+	if index != "" {
+		if err := fd.tableFailureErrs[failureKey(table, index)]; err != nil {
+			return err
+		}
+	}
+
+	return fd.tableFailureErrs[failureKey(table, "")]
 }
 
 func (fd *Client) setIndexActivationDelay(delay time.Duration) {
@@ -237,8 +281,8 @@ func (fd *Client) PutItem(ctx context.Context, input *dynamodb.PutItemInput, opt
 	fd.mu.Lock()
 	defer fd.mu.Unlock()
 
-	if fd.forceFailureErr != nil {
-		return nil, fd.forceFailureErr
+	if ferr := fd.failureErrFor(aws.ToString(input.TableName), ""); ferr != nil {
+		return nil, ferr
 	}
 
 	err := validateExpressionAttributes(input.ExpressionAttributeNames, input.ExpressionAttributeValues, aws.ToString(input.ConditionExpression))
@@ -263,8 +307,8 @@ func (fd *Client) DeleteItem(ctx context.Context, input *dynamodb.DeleteItemInpu
 	fd.mu.Lock()
 	defer fd.mu.Unlock()
 
-	if fd.forceFailureErr != nil {
-		return nil, fd.forceFailureErr
+	if ferr := fd.failureErrFor(aws.ToString(input.TableName), ""); ferr != nil {
+		return nil, ferr
 	}
 
 	err := validateExpressionAttributes(input.ExpressionAttributeNames, input.ExpressionAttributeValues, aws.ToString(input.ConditionExpression))
@@ -314,8 +358,8 @@ func (fd *Client) UpdateItem(ctx context.Context, input *dynamodb.UpdateItemInpu
 	fd.mu.Lock()
 	defer fd.mu.Unlock()
 
-	if fd.forceFailureErr != nil {
-		return nil, fd.forceFailureErr
+	if ferr := fd.failureErrFor(aws.ToString(input.TableName), ""); ferr != nil {
+		return nil, ferr
 	}
 
 	err := validateExpressionAttributes(input.ExpressionAttributeNames, input.ExpressionAttributeValues, aws.ToString(input.UpdateExpression), aws.ToString(input.ConditionExpression))
@@ -351,8 +395,8 @@ func (fd *Client) GetItem(ctx context.Context, input *dynamodb.GetItemInput, opt
 	fd.mu.Lock()
 	defer fd.mu.Unlock()
 
-	if fd.forceFailureErr != nil {
-		return nil, fd.forceFailureErr
+	if ferr := fd.failureErrFor(aws.ToString(input.TableName), ""); ferr != nil {
+		return nil, ferr
 	}
 
 	err := validateExpressionAttributes(input.ExpressionAttributeNames, nil, aws.ToString(input.ProjectionExpression))
@@ -398,8 +442,8 @@ func (fd *Client) Query(ctx context.Context, input *dynamodb.QueryInput, opt ...
 	fd.mu.Lock()
 	defer fd.mu.Unlock()
 
-	if fd.forceFailureErr != nil {
-		return nil, fd.forceFailureErr
+	if ferr := fd.failureErrFor(aws.ToString(input.TableName), aws.ToString(input.IndexName)); ferr != nil {
+		return nil, ferr
 	}
 
 	err := validateExpressionAttributes(input.ExpressionAttributeNames, input.ExpressionAttributeValues, aws.ToString(input.KeyConditionExpression), aws.ToString(input.FilterExpression), aws.ToString(input.ProjectionExpression))
@@ -442,8 +486,8 @@ func (fd *Client) Scan(ctx context.Context, input *dynamodb.ScanInput, opt ...fu
 	fd.mu.Lock()
 	defer fd.mu.Unlock()
 
-	if fd.forceFailureErr != nil {
-		return nil, fd.forceFailureErr
+	if ferr := fd.failureErrFor(aws.ToString(input.TableName), aws.ToString(input.IndexName)); ferr != nil {
+		return nil, ferr
 	}
 
 	err := validateExpressionAttributes(input.ExpressionAttributeNames, input.ExpressionAttributeValues, aws.ToString(input.ProjectionExpression), aws.ToString(input.FilterExpression))
@@ -697,6 +741,10 @@ func (fd *Client) prepareTransact(items []types.TransactWriteItem) (map[string]c
 
 		if tableName == "" {
 			continue
+		}
+
+		if ferr := fd.failureErrFor(tableName, ""); ferr != nil {
+			return nil, ferr
 		}
 
 		if _, alreadySnapped := snapshots[tableName]; !alreadySnapped {

--- a/aws-v2/client/client_test.go
+++ b/aws-v2/client/client_test.go
@@ -2176,6 +2176,203 @@ func TestBatchWriteItemWithFailingDatabase(t *testing.T) {
 	c.Nil(output)
 }
 
+func TestEmulateFailureForTableScopesToTable(t *testing.T) {
+	c := require.New(t)
+	client := NewClient()
+
+	c.NoError(ensurePokemonTable(client))
+
+	const secondTable = "items"
+
+	c.NoError(AddTable(context.Background(), client, secondTable, "id", ""))
+
+	EmulateFailureForTable(client, tableName, FailureConditionInternalServerError)
+
+	var internal *dynamodbtypes.InternalServerError
+
+	err := createPokemon(client, pokemon{ID: "001", Type: "grass", Name: "Bulbasaur"})
+	c.ErrorAs(err, &internal)
+
+	_, err = client.PutItem(context.Background(), &dynamodb.PutItemInput{
+		TableName: aws.String(secondTable),
+		Item:      map[string]dynamodbtypes.AttributeValue{"id": &dynamodbtypes.AttributeValueMemberS{Value: "x"}},
+	})
+	c.NoError(err)
+
+	EmulateFailureForTable(client, tableName, FailureConditionNone)
+
+	c.NoError(createPokemon(client, pokemon{ID: "001", Type: "grass", Name: "Bulbasaur"}))
+}
+
+func TestEmulateFailureForTableIndexScoped(t *testing.T) {
+	c := require.New(t)
+	client := NewClient()
+
+	c.NoError(ensurePokemonTable(client))
+	c.NoError(ensurePokemonTypeIndex(client))
+	c.NoError(createPokemon(client, pokemon{ID: "001", Type: "grass", Name: "Bulbasaur"}))
+
+	EmulateFailureForTable(client, tableName, FailureConditionInternalServerError, "by-type")
+
+	var internal *dynamodbtypes.InternalServerError
+
+	_, err := getPokemonsByType(client, "grass")
+	c.ErrorAs(err, &internal)
+
+	// Operations that do not use the failing index are unaffected.
+	item, err := getPokemon(client, "001")
+	c.NoError(err)
+	c.Equal(&dynamodbtypes.AttributeValueMemberS{Value: "Bulbasaur"}, item["name"])
+
+	c.NoError(createPokemon(client, pokemon{ID: "002", Type: "fire", Name: "Charmander"}))
+}
+
+func TestEmulateFailureForTableBatchWriteMultiTable(t *testing.T) {
+	c := require.New(t)
+	client := NewClient()
+
+	c.NoError(ensurePokemonTable(client))
+
+	const secondTable = "items"
+
+	c.NoError(AddTable(context.Background(), client, secondTable, "id", ""))
+
+	EmulateFailureForTable(client, tableName, FailureConditionInternalServerError)
+
+	out, err := client.BatchWriteItem(context.Background(), &dynamodb.BatchWriteItemInput{
+		RequestItems: map[string][]dynamodbtypes.WriteRequest{
+			tableName: {
+				{PutRequest: &dynamodbtypes.PutRequest{Item: map[string]dynamodbtypes.AttributeValue{"id": &dynamodbtypes.AttributeValueMemberS{Value: "001"}}}},
+			},
+			secondTable: {
+				{PutRequest: &dynamodbtypes.PutRequest{Item: map[string]dynamodbtypes.AttributeValue{"id": &dynamodbtypes.AttributeValueMemberS{Value: "x"}}}},
+			},
+		},
+	})
+	c.NoError(err)
+	c.Len(out.UnprocessedItems[tableName], 1)
+	c.Empty(out.UnprocessedItems[secondTable])
+
+	got, err := client.GetItem(context.Background(), &dynamodb.GetItemInput{
+		TableName: aws.String(secondTable),
+		Key:       map[string]dynamodbtypes.AttributeValue{"id": &dynamodbtypes.AttributeValueMemberS{Value: "x"}},
+	})
+	c.NoError(err)
+	c.NotEmpty(got.Item)
+}
+
+func TestEmulateFailureForTableBatchGetMultiTable(t *testing.T) {
+	c := require.New(t)
+	client := NewClient()
+
+	c.NoError(ensurePokemonTable(client))
+
+	const secondTable = "items"
+
+	c.NoError(AddTable(context.Background(), client, secondTable, "id", ""))
+	c.NoError(createPokemon(client, pokemon{ID: "001", Type: "grass", Name: "Bulbasaur"}))
+
+	_, err := client.PutItem(context.Background(), &dynamodb.PutItemInput{
+		TableName: aws.String(secondTable),
+		Item:      map[string]dynamodbtypes.AttributeValue{"id": &dynamodbtypes.AttributeValueMemberS{Value: "x"}},
+	})
+	c.NoError(err)
+
+	EmulateFailureForTable(client, tableName, FailureConditionInternalServerError)
+
+	out, err := client.BatchGetItem(context.Background(), &dynamodb.BatchGetItemInput{
+		RequestItems: map[string]dynamodbtypes.KeysAndAttributes{
+			tableName: {Keys: []map[string]dynamodbtypes.AttributeValue{
+				{"id": &dynamodbtypes.AttributeValueMemberS{Value: "001"}},
+			}},
+			secondTable: {Keys: []map[string]dynamodbtypes.AttributeValue{
+				{"id": &dynamodbtypes.AttributeValueMemberS{Value: "x"}},
+			}},
+		},
+	})
+	c.NoError(err)
+	c.Len(out.UnprocessedKeys[tableName].Keys, 1)
+	c.Empty(out.UnprocessedKeys[secondTable].Keys)
+	c.Len(out.Responses[secondTable], 1)
+}
+
+func TestEmulateFailureForTableTransactWriteAtomic(t *testing.T) {
+	c := require.New(t)
+	client := NewClient()
+
+	c.NoError(ensurePokemonTable(client))
+
+	const secondTable = "items"
+
+	c.NoError(AddTable(context.Background(), client, secondTable, "id", ""))
+
+	EmulateFailureForTable(client, tableName, FailureConditionInternalServerError)
+
+	_, err := client.TransactWriteItems(context.Background(), &dynamodb.TransactWriteItemsInput{
+		TransactItems: []dynamodbtypes.TransactWriteItem{
+			{Put: &dynamodbtypes.Put{TableName: aws.String(secondTable), Item: map[string]dynamodbtypes.AttributeValue{"id": &dynamodbtypes.AttributeValueMemberS{Value: "x"}}}},
+			{Put: &dynamodbtypes.Put{TableName: aws.String(tableName), Item: map[string]dynamodbtypes.AttributeValue{"id": &dynamodbtypes.AttributeValueMemberS{Value: "001"}}}},
+		},
+	})
+
+	var internal *dynamodbtypes.InternalServerError
+
+	c.ErrorAs(err, &internal)
+
+	got, err := client.GetItem(context.Background(), &dynamodb.GetItemInput{
+		TableName: aws.String(secondTable),
+		Key:       map[string]dynamodbtypes.AttributeValue{"id": &dynamodbtypes.AttributeValueMemberS{Value: "x"}},
+	})
+	c.NoError(err)
+	c.Empty(got.Item)
+}
+
+func TestEmulateFailureForTableGlobalOverride(t *testing.T) {
+	c := require.New(t)
+	client := NewClient()
+
+	c.NoError(ensurePokemonTable(client))
+
+	const secondTable = "items"
+
+	c.NoError(AddTable(context.Background(), client, secondTable, "id", ""))
+
+	EmulateFailureForTable(client, tableName, FailureConditionInternalServerError)
+	EmulateFailure(client, FailureConditionInternalServerError)
+
+	var internal *dynamodbtypes.InternalServerError
+
+	_, err := client.PutItem(context.Background(), &dynamodb.PutItemInput{
+		TableName: aws.String(secondTable),
+		Item:      map[string]dynamodbtypes.AttributeValue{"id": &dynamodbtypes.AttributeValueMemberS{Value: "x"}},
+	})
+	c.ErrorAs(err, &internal)
+
+	// Clearing the global failure leaves the table-scoped failure in place.
+	EmulateFailure(client, FailureConditionNone)
+
+	_, err = client.PutItem(context.Background(), &dynamodb.PutItemInput{
+		TableName: aws.String(secondTable),
+		Item:      map[string]dynamodbtypes.AttributeValue{"id": &dynamodbtypes.AttributeValueMemberS{Value: "x"}},
+	})
+	c.NoError(err)
+
+	err = createPokemon(client, pokemon{ID: "001", Type: "grass", Name: "Bulbasaur"})
+	c.ErrorAs(err, &internal)
+}
+
+func TestEmulateFailureForTableDeprecated(t *testing.T) {
+	c := require.New(t)
+	client := NewClient()
+
+	c.NoError(ensurePokemonTable(client))
+
+	EmulateFailureForTable(client, tableName, FailureConditionDeprecated)
+
+	err := createPokemon(client, pokemon{ID: "001", Type: "grass", Name: "Bulbasaur"})
+	c.ErrorIs(err, ErrForcedFailure)
+}
+
 func TestHandleBatchWriteRequestError(t *testing.T) {
 	t.Run("nil error", func(t *testing.T) {
 		unprocessed := map[string][]dynamodbtypes.WriteRequest{}

--- a/aws-v2/client/minidyn.go
+++ b/aws-v2/client/minidyn.go
@@ -48,6 +48,25 @@ func EmulateFailure(client FakeClient, condition FailureCondition) {
 	fakeClient.setFailureCondition(condition)
 }
 
+// EmulateFailureForTable scopes failure emulation to a single table, or to a
+// specific index of that table when indexName is provided. Operations targeting
+// other tables (or, for an index-scoped failure, other access paths on the same
+// table) keep working. Passing FailureConditionNone clears the failure for that
+// exact table/index scope. The global EmulateFailure still overrides everything.
+func EmulateFailureForTable(client FakeClient, tableName string, condition FailureCondition, indexName ...string) {
+	fakeClient, ok := client.(*Client)
+	if !ok {
+		panic("EmulateFailureForTable: invalid client type")
+	}
+
+	index := ""
+	if len(indexName) > 0 {
+		index = indexName[0]
+	}
+
+	fakeClient.setTableFailureCondition(tableName, index, condition)
+}
+
 // ActiveForceFailure active force operation to fail
 func ActiveForceFailure(client FakeClient) {
 	fakeClient, ok := client.(*Client)

--- a/aws-v2/client/minidyn_test.go
+++ b/aws-v2/client/minidyn_test.go
@@ -62,6 +62,36 @@ func TestEmulateFailure(t *testing.T) {
 	EmulateFailure(client, FailureConditionInternalServerError)
 }
 
+func TestEmulateFailureForTable(t *testing.T) {
+	c := require.New(t)
+
+	c.Panics(func() {
+		cfg, err := config.LoadDefaultConfig(context.Background())
+		c.NoError(err)
+
+		client := dynamodb.NewFromConfig(cfg)
+		EmulateFailureForTable(client, tableName, FailureConditionInternalServerError)
+	})
+
+	client := NewClient()
+
+	err := ensurePokemonTable(client)
+	c.NoError(err)
+
+	EmulateFailureForTable(client, tableName, FailureConditionInternalServerError)
+
+	err = createPokemon(client, pokemon{ID: "001", Type: "grass", Name: "Bulbasaur"})
+
+	var internal *dynamodbtypes.InternalServerError
+
+	c.ErrorAs(err, &internal)
+
+	EmulateFailureForTable(client, tableName, FailureConditionNone)
+
+	err = createPokemon(client, pokemon{ID: "001", Type: "grass", Name: "Bulbasaur"})
+	c.NoError(err)
+}
+
 func TestAddIndex(t *testing.T) {
 	c := require.New(t)
 

--- a/server/client.go
+++ b/server/client.go
@@ -22,6 +22,7 @@ type Client struct {
 	nativeInterpreter    *interpreter.Native
 	useNativeInterpreter bool
 	forceFailureErr      error
+	tableFailureErrs     map[string]error
 	indexActivationDelay time.Duration
 }
 
@@ -32,11 +33,53 @@ func NewClient() *Client {
 		mu:                sync.Mutex{},
 		nativeInterpreter: interpreter.NewNativeInterpreter(),
 		langInterpreter:   &interpreter.Language{},
+		tableFailureErrs:  map[string]error{},
 	}
 }
 
 func (c *Client) setFailureCondition(err error) {
 	c.forceFailureErr = err
+}
+
+// failureKey builds the lookup key for a table-scoped failure. An empty index
+// means the failure applies to the whole table.
+func failureKey(table, index string) string {
+	return table + "\x00" + index
+}
+
+// setTableFailureCondition scopes a failure to a table, or to a specific index of
+// that table when index is not empty. A nil err clears that exact scope.
+func (c *Client) setTableFailureCondition(table, index string, err error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	key := failureKey(table, index)
+
+	if err == nil {
+		delete(c.tableFailureErrs, key)
+
+		return
+	}
+
+	c.tableFailureErrs[key] = err
+}
+
+// failureErrFor resolves the emulated error for an operation targeting the given
+// table and index. A global failure overrides everything; otherwise an
+// index-scoped failure (when index is set) wins over a table-wide one. Callers
+// must hold c.mu.
+func (c *Client) failureErrFor(table, index string) error {
+	if c.forceFailureErr != nil {
+		return c.forceFailureErr
+	}
+
+	if index != "" {
+		if err := c.tableFailureErrs[failureKey(table, index)]; err != nil {
+			return err
+		}
+	}
+
+	return c.tableFailureErrs[failureKey(table, "")]
 }
 
 func (c *Client) setIndexActivationDelay(delay time.Duration) {
@@ -192,8 +235,8 @@ func (c *Client) PutItem(ctx context.Context, input *PutItemInput) (*PutItemOutp
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	if c.forceFailureErr != nil {
-		return nil, c.forceFailureErr
+	if ferr := c.failureErrFor(aws.ToString(input.TableName), ""); ferr != nil {
+		return nil, ferr
 	}
 
 	if err := validateExpressionAttributes(
@@ -232,8 +275,8 @@ func (c *Client) DeleteItem(ctx context.Context, input *DeleteItemInput) (*Delet
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	if c.forceFailureErr != nil {
-		return nil, c.forceFailureErr
+	if ferr := c.failureErrFor(aws.ToString(input.TableName), ""); ferr != nil {
+		return nil, ferr
 	}
 
 	if err := validateExpressionAttributes(
@@ -273,8 +316,8 @@ func (c *Client) UpdateItem(ctx context.Context, input *UpdateItemInput) (*Updat
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	if c.forceFailureErr != nil {
-		return nil, c.forceFailureErr
+	if ferr := c.failureErrFor(aws.ToString(input.TableName), ""); ferr != nil {
+		return nil, ferr
 	}
 
 	if err := validateExpressionAttributes(
@@ -314,8 +357,8 @@ func (c *Client) GetItem(ctx context.Context, input *GetItemInput) (*GetItemOutp
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	if c.forceFailureErr != nil {
-		return nil, c.forceFailureErr
+	if ferr := c.failureErrFor(aws.ToString(input.TableName), ""); ferr != nil {
+		return nil, ferr
 	}
 
 	if err := validateExpressionAttributes(input.ExpressionAttributeNames, nil, aws.ToString(input.ProjectionExpression)); err != nil {
@@ -356,8 +399,8 @@ func (c *Client) Query(ctx context.Context, input *QueryInput) (*QueryOutput, er
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	if c.forceFailureErr != nil {
-		return nil, c.forceFailureErr
+	if ferr := c.failureErrFor(aws.ToString(input.TableName), aws.ToString(input.IndexName)); ferr != nil {
+		return nil, ferr
 	}
 
 	if err := validateExpressionAttributes(
@@ -408,8 +451,8 @@ func (c *Client) Scan(ctx context.Context, input *ScanInput) (*ScanOutput, error
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	if c.forceFailureErr != nil {
-		return nil, c.forceFailureErr
+	if ferr := c.failureErrFor(aws.ToString(input.TableName), aws.ToString(input.IndexName)); ferr != nil {
+		return nil, ferr
 	}
 
 	if err := validateExpressionAttributes(
@@ -666,6 +709,10 @@ func (c *Client) prepareTransact(items []TransactWriteItem) (map[string]core.Tab
 
 		if tableName == "" {
 			continue
+		}
+
+		if ferr := c.failureErrFor(tableName, ""); ferr != nil {
+			return nil, ferr
 		}
 
 		if _, alreadySnapped := snapshots[tableName]; !alreadySnapped {

--- a/server/minidyn.go
+++ b/server/minidyn.go
@@ -49,6 +49,24 @@ func (s *Server) EmulateFailure(condition FailureCondition) {
 	s.client.setFailureCondition(emulatingErrors[condition])
 }
 
+// EmulateFailureForTable scopes failure injection to a single table, or to a
+// specific index of that table when indexName is provided. Operations targeting
+// other tables (or, for an index-scoped failure, other access paths on the same
+// table) keep working. Passing FailureConditionNone clears the failure for that
+// exact table/index scope. The global EmulateFailure still overrides everything.
+func (s *Server) EmulateFailureForTable(tableName string, condition FailureCondition, indexName ...string) {
+	if s == nil || s.client == nil {
+		return
+	}
+
+	index := ""
+	if len(indexName) > 0 {
+		index = indexName[0]
+	}
+
+	s.client.setTableFailureCondition(tableName, index, emulatingErrors[condition])
+}
+
 // SetIndexActivationDelay configures how long newly created GSIs report CREATING before ACTIVE.
 func (s *Server) SetIndexActivationDelay(delay time.Duration) {
 	if s == nil || s.client == nil {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1173,6 +1173,188 @@ func TestServerEmulateFailureWithSDKv2(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestServerEmulateFailureForTable(t *testing.T) {
+	s := NewServer()
+
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	cli := newTestDynamoClient(t, ts.URL)
+
+	makeBasicTable(t, cli, "pokemons", "id")
+	makeBasicTable(t, cli, "items", "id")
+
+	s.EmulateFailureForTable("pokemons", FailureConditionInternalServerError)
+
+	var internal *ddbtypes.InternalServerError
+
+	_, err := cli.PutItem(context.Background(), &dynamodb.PutItemInput{
+		TableName: aws.String("pokemons"),
+		Item:      map[string]ddbtypes.AttributeValue{"id": &ddbtypes.AttributeValueMemberS{Value: "1"}},
+	})
+	require.ErrorAs(t, err, &internal)
+
+	_, err = cli.PutItem(context.Background(), &dynamodb.PutItemInput{
+		TableName: aws.String("items"),
+		Item:      map[string]ddbtypes.AttributeValue{"id": &ddbtypes.AttributeValueMemberS{Value: "x"}},
+	})
+	require.NoError(t, err)
+
+	s.EmulateFailureForTable("pokemons", FailureConditionNone)
+
+	_, err = cli.PutItem(context.Background(), &dynamodb.PutItemInput{
+		TableName: aws.String("pokemons"),
+		Item:      map[string]ddbtypes.AttributeValue{"id": &ddbtypes.AttributeValueMemberS{Value: "1"}},
+	})
+	require.NoError(t, err)
+}
+
+func TestServerEmulateFailureForTableIndexScoped(t *testing.T) {
+	s := NewServer()
+
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	cli := newTestDynamoClient(t, ts.URL)
+
+	makeBasicTable(t, cli, "pokemons", "id")
+	createServerTestGlobalSecondaryIndex(t, cli, "pokemons", "by-type")
+
+	_, err := cli.PutItem(context.Background(), &dynamodb.PutItemInput{
+		TableName: aws.String("pokemons"),
+		Item: map[string]ddbtypes.AttributeValue{
+			"id":   &ddbtypes.AttributeValueMemberS{Value: "1"},
+			"type": &ddbtypes.AttributeValueMemberS{Value: "grass"},
+		},
+	})
+	require.NoError(t, err)
+
+	s.EmulateFailureForTable("pokemons", FailureConditionInternalServerError, "by-type")
+
+	var internal *ddbtypes.InternalServerError
+
+	_, err = cli.Query(context.Background(), &dynamodb.QueryInput{
+		TableName:                 aws.String("pokemons"),
+		IndexName:                 aws.String("by-type"),
+		KeyConditionExpression:    aws.String("#type = :type"),
+		ExpressionAttributeNames:  map[string]string{"#type": "type"},
+		ExpressionAttributeValues: map[string]ddbtypes.AttributeValue{":type": &ddbtypes.AttributeValueMemberS{Value: "grass"}},
+	})
+	require.ErrorAs(t, err, &internal)
+
+	// GetItem does not use the index, so it must keep working.
+	out, err := cli.GetItem(context.Background(), &dynamodb.GetItemInput{
+		TableName: aws.String("pokemons"),
+		Key:       map[string]ddbtypes.AttributeValue{"id": &ddbtypes.AttributeValueMemberS{Value: "1"}},
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, out.Item)
+}
+
+func TestServerEmulateFailureForTableBatchWriteMultiTable(t *testing.T) {
+	s := NewServer()
+
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	cli := newTestDynamoClient(t, ts.URL)
+
+	makeBasicTable(t, cli, "pokemons", "id")
+	makeBasicTable(t, cli, "items", "id")
+
+	s.EmulateFailureForTable("pokemons", FailureConditionInternalServerError)
+
+	out, err := cli.BatchWriteItem(context.Background(), &dynamodb.BatchWriteItemInput{
+		RequestItems: map[string][]ddbtypes.WriteRequest{
+			"pokemons": {
+				{PutRequest: &ddbtypes.PutRequest{Item: map[string]ddbtypes.AttributeValue{"id": &ddbtypes.AttributeValueMemberS{Value: "1"}}}},
+			},
+			"items": {
+				{PutRequest: &ddbtypes.PutRequest{Item: map[string]ddbtypes.AttributeValue{"id": &ddbtypes.AttributeValueMemberS{Value: "x"}}}},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, out.UnprocessedItems["pokemons"], 1)
+	require.Empty(t, out.UnprocessedItems["items"])
+
+	got, err := cli.GetItem(context.Background(), &dynamodb.GetItemInput{
+		TableName: aws.String("items"),
+		Key:       map[string]ddbtypes.AttributeValue{"id": &ddbtypes.AttributeValueMemberS{Value: "x"}},
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, got.Item)
+}
+
+func TestServerEmulateFailureForTableTransactWriteAtomic(t *testing.T) {
+	s := NewServer()
+
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	cli := newTestDynamoClient(t, ts.URL)
+
+	makeBasicTable(t, cli, "pokemons", "id")
+	makeBasicTable(t, cli, "items", "id")
+
+	s.EmulateFailureForTable("pokemons", FailureConditionInternalServerError)
+
+	_, err := cli.TransactWriteItems(context.Background(), &dynamodb.TransactWriteItemsInput{
+		TransactItems: []ddbtypes.TransactWriteItem{
+			{Put: &ddbtypes.Put{TableName: aws.String("items"), Item: map[string]ddbtypes.AttributeValue{"id": &ddbtypes.AttributeValueMemberS{Value: "x"}}}},
+			{Put: &ddbtypes.Put{TableName: aws.String("pokemons"), Item: map[string]ddbtypes.AttributeValue{"id": &ddbtypes.AttributeValueMemberS{Value: "1"}}}},
+		},
+	})
+
+	var internal *ddbtypes.InternalServerError
+
+	require.ErrorAs(t, err, &internal)
+
+	got, err := cli.GetItem(context.Background(), &dynamodb.GetItemInput{
+		TableName: aws.String("items"),
+		Key:       map[string]ddbtypes.AttributeValue{"id": &ddbtypes.AttributeValueMemberS{Value: "x"}},
+	})
+	require.NoError(t, err)
+	require.Empty(t, got.Item)
+}
+
+func TestServerEmulateFailureForTableGlobalOverride(t *testing.T) {
+	s := NewServer()
+
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	cli := newTestDynamoClient(t, ts.URL)
+
+	makeBasicTable(t, cli, "pokemons", "id")
+	makeBasicTable(t, cli, "items", "id")
+
+	s.EmulateFailureForTable("pokemons", FailureConditionInternalServerError)
+	s.EmulateFailure(FailureConditionInternalServerError)
+
+	var internal *ddbtypes.InternalServerError
+
+	_, err := cli.PutItem(context.Background(), &dynamodb.PutItemInput{
+		TableName: aws.String("items"),
+		Item:      map[string]ddbtypes.AttributeValue{"id": &ddbtypes.AttributeValueMemberS{Value: "x"}},
+	})
+	require.ErrorAs(t, err, &internal)
+
+	s.EmulateFailure(FailureConditionNone)
+
+	_, err = cli.PutItem(context.Background(), &dynamodb.PutItemInput{
+		TableName: aws.String("items"),
+		Item:      map[string]ddbtypes.AttributeValue{"id": &ddbtypes.AttributeValueMemberS{Value: "x"}},
+	})
+	require.NoError(t, err)
+
+	_, err = cli.PutItem(context.Background(), &dynamodb.PutItemInput{
+		TableName: aws.String("pokemons"),
+		Item:      map[string]ddbtypes.AttributeValue{"id": &ddbtypes.AttributeValueMemberS{Value: "1"}},
+	})
+	require.ErrorAs(t, err, &internal)
+}
+
 func TestServerGetItemAttributeNameValidation(t *testing.T) {
 	ts := httptest.NewServer(NewServer())
 	defer ts.Close()


### PR DESCRIPTION
Why:
EmulateFailure is global: it fails every operation on every table, so a test that exercises code touching more than one table cannot assert that one table fails while another keeps working.

What:
- Add EmulateFailureForTable to the aws-v2/client and server packages, scoping failure to a table and optionally one of its indexes.
- Resolve failures per operation via failureErrFor (global overrides, then index-scoped, then table-wide); wire it into single-item, Query, and Scan.
- Make batch sub-requests on a failing table land in unprocessed results while other tables persist, and abort a transaction if any item hits that table.
- Keep the global EmulateFailure unchanged for backward compatibility.

Issue: #131