### PR TITLE
Hard-fail batch ops on emulated failures and add unprocessed knob

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,72 @@ ddb := dynamodb.NewFromConfig(cfg)
 // use ddb as usual: CreateTable, PutItem, Query, etc.
 ```
 
+### Failure emulation
+
+minidyn can inject DynamoDB-style failures so you can exercise your error- and
+retry-handling without a real backend. There are three knobs, available both on the
+in-process `aws-v2/client` (package functions) and on the HTTP `server` (methods on
+`*Server`).
+
+```go
+import (
+  "github.com/truora/minidyn/aws-v2/client"
+  ddbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+)
+
+c := client.NewClient()
+
+// 1. Global failure — every operation returns the emulated error until cleared.
+client.EmulateFailure(c, client.FailureConditionInternalServerError)
+client.EmulateFailure(c, client.FailureConditionNone) // clear
+
+// 2. Table/index-scoped failure — only operations touching that table (or one of
+//    its indexes) fail; everything else keeps working.
+client.EmulateFailureForTable(c, "pokemons", client.FailureConditionInternalServerError)
+client.EmulateFailureForTable(c, "pokemons", client.FailureConditionInternalServerError, "type_index")
+client.EmulateFailureForTable(c, "pokemons", client.FailureConditionNone) // clear that scope
+
+// 3. Partial batch failure — leave selected BatchWriteItem / BatchGetItem
+//    sub-requests in UnprocessedItems / UnprocessedKeys while the rest are applied.
+//    The predicate receives the sub-request index within the table's slice and its
+//    raw payload (a PutRequest's item, or a Delete/Get key), so you can match by
+//    position, key, or any attribute.
+client.EmulateUnprocessedItems(c, "pokemons", func(n int, raw map[string]ddbtypes.AttributeValue) bool {
+  v, ok := raw["id"].(*ddbtypes.AttributeValueMemberS)
+  return ok && v.Value == "001"
+})
+client.ClearUnprocessedItems(c) // clear all predicates
+```
+
+Behavior:
+
+* A global `EmulateFailure` **and** a table-scoped `EmulateFailureForTable` **hard-fail
+  the whole** `BatchWriteItem`/`BatchGetItem` call (matching DynamoDB returning a 500),
+  not just the affected items.
+* `EmulateUnprocessedItems` is the only way to get partial `UnprocessedItems`/
+  `UnprocessedKeys`. It applies to batch operations only — single-item `PutItem`,
+  `GetItem`, and `DeleteItem` are unaffected.
+* Failure conditions and predicates are **sticky** until cleared
+  (`FailureConditionNone`, a `nil` predicate, or `ClearUnprocessedItems`). A global
+  failure overrides a table-scoped one.
+
+The HTTP server exposes the same controls as methods on the `*Server` you pass to
+`httptest.NewServer`:
+
+```go
+s := miniserver.NewServer()
+ts := httptest.NewServer(s)
+defer ts.Close()
+// ... point an AWS SDK client at ts.URL as shown above ...
+
+s.EmulateFailure(miniserver.FailureConditionInternalServerError)
+s.EmulateFailureForTable("pokemons", miniserver.FailureConditionInternalServerError, "type_index")
+s.EmulateUnprocessedItems("pokemons", func(n int, raw map[string]*miniserver.AttributeValue) bool {
+  return n == 0 // leave the first sub-request of each batch on this table unprocessed
+})
+s.ClearUnprocessedItems()
+```
+
 ## Supported Operations and Features
 
 For a detailed list of supported DynamoDB operations, types, and expressions, please refer to the documentation:

--- a/aws-v2/client/client.go
+++ b/aws-v2/client/client.go
@@ -67,17 +67,19 @@ type Client struct {
 	useNativeInterpreter  bool
 	forceFailureErr       error
 	tableFailureErrs      map[string]error
+	unprocessedMatchers   map[string]func(int, map[string]types.AttributeValue) bool
 	indexActivationDelay  time.Duration
 }
 
 // NewClient initializes dynamodb client with a mock
 func NewClient() *Client {
 	fake := Client{
-		tables:            map[string]*core.Table{},
-		mu:                sync.Mutex{},
-		nativeInterpreter: interpreter.NewNativeInterpreter(),
-		langInterpreter:   &interpreter.Language{},
-		tableFailureErrs:  map[string]error{},
+		tables:              map[string]*core.Table{},
+		mu:                  sync.Mutex{},
+		nativeInterpreter:   interpreter.NewNativeInterpreter(),
+		langInterpreter:     &interpreter.Language{},
+		tableFailureErrs:    map[string]error{},
+		unprocessedMatchers: map[string]func(int, map[string]types.AttributeValue) bool{},
 	}
 
 	return &fake
@@ -150,6 +152,82 @@ func (fd *Client) failureErrFor(table, index string) error {
 	}
 
 	return fd.tableFailureErrs[failureKey(table, "")]
+}
+
+// setUnprocessedMatcher installs a predicate that marks matching sub-requests of a
+// batch operation on tableName as unprocessed. A nil match clears the predicate for
+// that table.
+func (fd *Client) setUnprocessedMatcher(tableName string, match func(int, map[string]types.AttributeValue) bool) {
+	fd.mu.Lock()
+	defer fd.mu.Unlock()
+
+	if match == nil {
+		delete(fd.unprocessedMatchers, tableName)
+
+		return
+	}
+
+	fd.unprocessedMatchers[tableName] = match
+}
+
+// clearUnprocessedMatchers removes every batch partial-failure predicate.
+func (fd *Client) clearUnprocessedMatchers() {
+	fd.mu.Lock()
+	defer fd.mu.Unlock()
+
+	fd.unprocessedMatchers = map[string]func(int, map[string]types.AttributeValue) bool{}
+}
+
+// batchEmulation is a lock-free snapshot of the failure emulation that applies to a
+// batch operation: a hard failure error (global or table-scoped) that fails the whole
+// call, and the per-table partial-failure predicates.
+type batchEmulation struct {
+	failErr  error
+	matchers map[string]func(int, map[string]types.AttributeValue) bool
+}
+
+// unprocessed reports whether sub-request n (raw payload) of tableName should be
+// returned as unprocessed instead of being executed.
+func (e batchEmulation) unprocessed(tableName string, n int, raw map[string]types.AttributeValue) bool {
+	match, ok := e.matchers[tableName]
+
+	return ok && match(n, raw)
+}
+
+// batchEmulationFor snapshots the emulation state relevant to a batch touching the
+// given tables. A global failure overrides everything; otherwise any table-scoped
+// failure hard-fails the whole batch. Takes fd.mu briefly so the loop can run lock-free.
+func (fd *Client) batchEmulationFor(tables ...string) batchEmulation {
+	fd.mu.Lock()
+	defer fd.mu.Unlock()
+
+	snap := batchEmulation{}
+
+	if fd.forceFailureErr != nil {
+		snap.failErr = fd.forceFailureErr
+
+		return snap
+	}
+
+	for _, table := range tables {
+		if err := fd.failureErrFor(table, ""); err != nil {
+			snap.failErr = err
+
+			return snap
+		}
+	}
+
+	for _, table := range tables {
+		if match, ok := fd.unprocessedMatchers[table]; ok {
+			if snap.matchers == nil {
+				snap.matchers = map[string]func(int, map[string]types.AttributeValue) bool{}
+			}
+
+			snap.matchers[table] = match
+		}
+	}
+
+	return snap
 }
 
 func (fd *Client) setIndexActivationDelay(delay time.Duration) {
@@ -546,10 +624,15 @@ func SetItemCollectionMetrics(client FakeClient, itemCollectionMetrics map[strin
 	fakeClient.setItemCollectionMetrics(itemCollectionMetrics)
 }
 
-// BatchWriteItem mock response for dynamodb
+// BatchWriteItem mock response for dynamodb. An emulated failure (global EmulateFailure
+// or table-scoped EmulateFailureForTable touching any table in the batch) hard-fails the
+// whole call. UnprocessedItems is produced only by EmulateUnprocessedItems, whose
+// predicate selects individual sub-requests to leave unprocessed while the rest are
+// applied.
 func (fd *Client) BatchWriteItem(ctx context.Context, input *dynamodb.BatchWriteItemInput, opts ...func(*dynamodb.Options)) (*dynamodb.BatchWriteItemOutput, error) {
-	if fd.forceFailureErr != nil {
-		return nil, fd.forceFailureErr
+	emulation := fd.batchEmulationFor(tableNames(input.RequestItems)...)
+	if emulation.failErr != nil {
+		return nil, emulation.failErr
 	}
 
 	if err := validateBatchWriteItemInput(input); err != nil {
@@ -559,11 +642,14 @@ func (fd *Client) BatchWriteItem(ctx context.Context, input *dynamodb.BatchWrite
 	unprocessed := map[string][]types.WriteRequest{}
 
 	for table, reqs := range input.RequestItems {
-		for _, req := range reqs {
-			err := executeBatchWriteRequest(ctx, fd, aws.String(table), req)
+		for i, req := range reqs {
+			if emulation.unprocessed(table, i, batchWriteRequestKey(req)) {
+				unprocessed[table] = append(unprocessed[table], req)
 
-			err = handleBatchWriteRequestError(table, req, unprocessed, err)
-			if err != nil {
+				continue
+			}
+
+			if err := executeBatchWriteRequest(ctx, fd, aws.String(table), req); err != nil {
 				return &dynamodb.BatchWriteItemOutput{}, err
 			}
 		}
@@ -575,10 +661,35 @@ func (fd *Client) BatchWriteItem(ctx context.Context, input *dynamodb.BatchWrite
 	}, nil
 }
 
-// BatchGetItem mock response for dynamodb
+func tableNames[V any](requestItems map[string]V) []string {
+	names := make([]string, 0, len(requestItems))
+	for name := range requestItems {
+		names = append(names, name)
+	}
+
+	return names
+}
+
+func batchWriteRequestKey(req types.WriteRequest) map[string]types.AttributeValue {
+	if req.PutRequest != nil {
+		return req.PutRequest.Item
+	}
+
+	if req.DeleteRequest != nil {
+		return req.DeleteRequest.Key
+	}
+
+	return nil
+}
+
+// BatchGetItem mock response for dynamodb. An emulated failure (global EmulateFailure
+// or table-scoped EmulateFailureForTable touching any table in the batch) hard-fails the
+// whole call. UnprocessedKeys is produced only by EmulateUnprocessedItems, whose
+// predicate selects individual keys to leave unprocessed while the rest are fetched.
 func (fd *Client) BatchGetItem(ctx context.Context, input *dynamodb.BatchGetItemInput, opts ...func(*dynamodb.Options)) (*dynamodb.BatchGetItemOutput, error) {
-	if fd.forceFailureErr != nil {
-		return nil, fd.forceFailureErr
+	emulation := fd.batchEmulationFor(tableNames(input.RequestItems)...)
+	if emulation.failErr != nil {
+		return nil, emulation.failErr
 	}
 
 	responses := make(map[string][]map[string]types.AttributeValue, len(input.RequestItems))
@@ -588,7 +699,13 @@ func (fd *Client) BatchGetItem(ctx context.Context, input *dynamodb.BatchGetItem
 		unprocessedKeys := make([]map[string]types.AttributeValue, 0, len(reqs.Keys))
 		responses[tableName] = make([]map[string]types.AttributeValue, 0, len(reqs.Keys))
 
-		for _, req := range reqs.Keys {
+		for i, req := range reqs.Keys {
+			if emulation.unprocessed(tableName, i, req) {
+				unprocessedKeys = append(unprocessedKeys, req)
+
+				continue
+			}
+
 			getInput := &dynamodb.GetItemInput{
 				TableName:                aws.String(tableName),
 				Key:                      req,
@@ -598,14 +715,14 @@ func (fd *Client) BatchGetItem(ctx context.Context, input *dynamodb.BatchGetItem
 				ProjectionExpression:     reqs.ProjectionExpression,
 			}
 
-			item, err := executeGetRequest(ctx, fd, getInput)
+			out, err := fd.GetItem(ctx, getInput)
 			if err != nil {
-				unprocessedKeys = append(unprocessedKeys, req)
-
-				continue
+				return nil, err
 			}
 
-			responses[tableName] = append(responses[tableName], item)
+			if len(out.Item) > 0 {
+				responses[tableName] = append(responses[tableName], out.Item)
+			}
 		}
 
 		if len(unprocessedKeys) > 0 {
@@ -675,47 +792,6 @@ func executeBatchWriteRequest(ctx context.Context, fd *Client, table *string, re
 
 		return err
 	}
-
-	return nil
-}
-
-func executeGetRequest(ctx context.Context, fd *Client, getInput *dynamodb.GetItemInput) (map[string]types.AttributeValue, error) {
-	response, err := fd.GetItem(ctx, getInput)
-	if err != nil {
-		return nil, err
-	}
-
-	if len(response.Item) == 0 {
-		return nil, ErrResourceNotFoundException
-	}
-
-	return response.Item, nil
-}
-
-func isRetriableBatchWriteSubrequestError(err error) bool {
-	if _, ok := errors.AsType[*types.InternalServerError](err); ok {
-		return true
-	}
-
-	_, ok := errors.AsType[*types.ProvisionedThroughputExceededException](err)
-
-	return ok
-}
-
-func handleBatchWriteRequestError(table string, req types.WriteRequest, unprocessed map[string][]types.WriteRequest, err error) error {
-	if err == nil {
-		return nil
-	}
-
-	if !isRetriableBatchWriteSubrequestError(err) {
-		return err
-	}
-
-	if _, ok := unprocessed[table]; !ok {
-		unprocessed[table] = []types.WriteRequest{}
-	}
-
-	unprocessed[table] = append(unprocessed[table], req)
 
 	return nil
 }

--- a/aws-v2/client/client.go
+++ b/aws-v2/client/client.go
@@ -630,13 +630,13 @@ func SetItemCollectionMetrics(client FakeClient, itemCollectionMetrics map[strin
 // predicate selects individual sub-requests to leave unprocessed while the rest are
 // applied.
 func (fd *Client) BatchWriteItem(ctx context.Context, input *dynamodb.BatchWriteItemInput, opts ...func(*dynamodb.Options)) (*dynamodb.BatchWriteItemOutput, error) {
+	if err := validateBatchWriteItemInput(input); err != nil {
+		return &dynamodb.BatchWriteItemOutput{}, err
+	}
+
 	emulation := fd.batchEmulationFor(tableNames(input.RequestItems)...)
 	if emulation.failErr != nil {
 		return nil, emulation.failErr
-	}
-
-	if err := validateBatchWriteItemInput(input); err != nil {
-		return &dynamodb.BatchWriteItemOutput{}, err
 	}
 
 	unprocessed := map[string][]types.WriteRequest{}

--- a/aws-v2/client/client_test.go
+++ b/aws-v2/client/client_test.go
@@ -2171,6 +2171,28 @@ func TestBatchWriteItemWithFailingDatabase(t *testing.T) {
 	c.Nil(output)
 }
 
+func TestBatchWriteItemValidatesBeforeEmulatedFailure(t *testing.T) {
+	c := require.New(t)
+	client := setupClient(tableName)
+
+	c.NoError(ensurePokemonTable(client))
+
+	EmulateFailure(client, FailureConditionInternalServerError)
+	defer EmulateFailure(client, FailureConditionNone)
+
+	// A write request with neither PutRequest nor DeleteRequest is invalid.
+	// DynamoDB validates (400) before raising any emulated server error (500),
+	// so the ValidationException must win over the active failure emulation.
+	input := &dynamodb.BatchWriteItemInput{
+		RequestItems: map[string][]dynamodbtypes.WriteRequest{
+			tableName: {{}},
+		},
+	}
+
+	_, err := client.BatchWriteItem(context.Background(), input)
+	c.Contains(err.Error(), "ValidationException")
+}
+
 func TestEmulateFailureForTableScopesToTable(t *testing.T) {
 	c := require.New(t)
 	client := NewClient()

--- a/aws-v2/client/client_test.go
+++ b/aws-v2/client/client_test.go
@@ -2470,6 +2470,38 @@ func TestEmulateUnprocessedItemsStickyAndClear(t *testing.T) {
 	c.Empty(out.UnprocessedItems[tableName])
 }
 
+func TestValidateTransactGetItemsInput(t *testing.T) {
+	c := require.New(t)
+	fd := NewClient()
+	id := map[string]dynamodbtypes.AttributeValue{"id": &dynamodbtypes.AttributeValueMemberS{Value: "1"}}
+
+	// nil input is a no-op.
+	c.NoError(validateTransactGetItemsInput(fd, nil))
+
+	// empty TransactItems.
+	c.Error(validateTransactGetItemsInput(fd, &dynamodb.TransactGetItemsInput{}))
+
+	// too many items.
+	c.Error(validateTransactGetItemsInput(fd, &dynamodb.TransactGetItemsInput{
+		TransactItems: make([]dynamodbtypes.TransactGetItem, batchGetItemRequestsLimit+1),
+	}))
+
+	// missing Get.
+	c.Error(validateTransactGetItemsInput(fd, &dynamodb.TransactGetItemsInput{
+		TransactItems: []dynamodbtypes.TransactGetItem{{Get: nil}},
+	}))
+
+	// empty table name.
+	c.Error(validateTransactGetItemsInput(fd, &dynamodb.TransactGetItemsInput{
+		TransactItems: []dynamodbtypes.TransactGetItem{{Get: &dynamodbtypes.Get{TableName: aws.String(""), Key: id}}},
+	}))
+
+	// non-existent table.
+	c.Error(validateTransactGetItemsInput(fd, &dynamodb.TransactGetItemsInput{
+		TransactItems: []dynamodbtypes.TransactGetItem{{Get: &dynamodbtypes.Get{TableName: aws.String("ghost"), Key: id}}},
+	}))
+}
+
 func TestEmulateFailureForTableTransactWriteAtomic(t *testing.T) {
 	c := require.New(t)
 	client := NewClient()
@@ -3524,6 +3556,15 @@ func TestForceFailure(t *testing.T) {
 	})
 	c.Panics(func() {
 		SetItemCollectionMetrics(actualClient, nil)
+	})
+	c.Panics(func() {
+		EmulateUnprocessedItems(actualClient, tableName, nil)
+	})
+	c.Panics(func() {
+		ClearUnprocessedItems(actualClient)
+	})
+	c.Panics(func() {
+		SetIndexActivationDelay(actualClient, 0)
 	})
 }
 

--- a/aws-v2/client/client_test.go
+++ b/aws-v2/client/client_test.go
@@ -710,11 +710,6 @@ func TestPutAndGetBatchItem(t *testing.T) {
 						},
 					},
 					{
-						"t1": &dynamodbtypes.AttributeValueMemberS{
-							Value: "003",
-						},
-					},
-					{
 						"id": &dynamodbtypes.AttributeValueMemberS{
 							Value: "004",
 						},
@@ -734,12 +729,12 @@ func TestPutAndGetBatchItem(t *testing.T) {
 
 	out, err = client.BatchGetItem(context.Background(), getInput)
 	c.NoError(err)
+	// 001 and 002 exist and are returned; 004 is absent (missing items are simply not
+	// in Responses, not reported as unprocessed).
 	c.Len(out.Responses[tableName], 2)
 	c.Equal(&dynamodbtypes.AttributeValueMemberS{Value: "001"}, out.Responses[tableName][0]["id"])
 	c.Equal(&dynamodbtypes.AttributeValueMemberS{Value: "002"}, out.Responses[tableName][1]["id"])
-	c.Len(out.UnprocessedKeys[tableName].Keys, 2)
-	c.Equal(&dynamodbtypes.AttributeValueMemberS{Value: "003"}, out.UnprocessedKeys[tableName].Keys[0]["t1"])
-	c.Equal(&dynamodbtypes.AttributeValueMemberS{Value: "004"}, out.UnprocessedKeys[tableName].Keys[1]["id"])
+	c.Empty(out.UnprocessedKeys[tableName].Keys)
 }
 
 func TestPutWithGSI(t *testing.T) {
@@ -2239,6 +2234,7 @@ func TestEmulateFailureForTableBatchWriteMultiTable(t *testing.T) {
 
 	EmulateFailureForTable(client, tableName, FailureConditionInternalServerError)
 
+	// A batch touching the scoped table hard-fails the whole call.
 	out, err := client.BatchWriteItem(context.Background(), &dynamodb.BatchWriteItemInput{
 		RequestItems: map[string][]dynamodbtypes.WriteRequest{
 			tableName: {
@@ -2249,8 +2245,18 @@ func TestEmulateFailureForTableBatchWriteMultiTable(t *testing.T) {
 			},
 		},
 	})
+	c.EqualError(err, "InternalServerError: emulated error")
+	c.Nil(out)
+
+	// A batch touching only the unscoped table succeeds.
+	out, err = client.BatchWriteItem(context.Background(), &dynamodb.BatchWriteItemInput{
+		RequestItems: map[string][]dynamodbtypes.WriteRequest{
+			secondTable: {
+				{PutRequest: &dynamodbtypes.PutRequest{Item: map[string]dynamodbtypes.AttributeValue{"id": &dynamodbtypes.AttributeValueMemberS{Value: "x"}}}},
+			},
+		},
+	})
 	c.NoError(err)
-	c.Len(out.UnprocessedItems[tableName], 1)
 	c.Empty(out.UnprocessedItems[secondTable])
 
 	got, err := client.GetItem(context.Background(), &dynamodb.GetItemInput{
@@ -2280,6 +2286,7 @@ func TestEmulateFailureForTableBatchGetMultiTable(t *testing.T) {
 
 	EmulateFailureForTable(client, tableName, FailureConditionInternalServerError)
 
+	// A batch get touching the scoped table hard-fails the whole call.
 	out, err := client.BatchGetItem(context.Background(), &dynamodb.BatchGetItemInput{
 		RequestItems: map[string]dynamodbtypes.KeysAndAttributes{
 			tableName: {Keys: []map[string]dynamodbtypes.AttributeValue{
@@ -2290,10 +2297,177 @@ func TestEmulateFailureForTableBatchGetMultiTable(t *testing.T) {
 			}},
 		},
 	})
+	c.EqualError(err, "InternalServerError: emulated error")
+	c.Nil(out)
+
+	// A batch get touching only the unscoped table succeeds.
+	out, err = client.BatchGetItem(context.Background(), &dynamodb.BatchGetItemInput{
+		RequestItems: map[string]dynamodbtypes.KeysAndAttributes{
+			secondTable: {Keys: []map[string]dynamodbtypes.AttributeValue{
+				{"id": &dynamodbtypes.AttributeValueMemberS{Value: "x"}},
+			}},
+		},
+	})
 	c.NoError(err)
-	c.Len(out.UnprocessedKeys[tableName].Keys, 1)
 	c.Empty(out.UnprocessedKeys[secondTable].Keys)
 	c.Len(out.Responses[secondTable], 1)
+}
+
+// matchID returns a predicate that marks the item/key whose "id" string attribute
+// equals the given value as unprocessed.
+func matchID(id string) func(int, map[string]dynamodbtypes.AttributeValue) bool {
+	return func(_ int, raw map[string]dynamodbtypes.AttributeValue) bool {
+		av, ok := raw["id"].(*dynamodbtypes.AttributeValueMemberS)
+
+		return ok && av.Value == id
+	}
+}
+
+func TestEmulateUnprocessedItemsBatchWriteByAttribute(t *testing.T) {
+	c := require.New(t)
+	client := NewClient()
+
+	c.NoError(ensurePokemonTable(client))
+
+	EmulateUnprocessedItems(client, tableName, matchID("1"))
+
+	out, err := client.BatchWriteItem(context.Background(), &dynamodb.BatchWriteItemInput{
+		RequestItems: map[string][]dynamodbtypes.WriteRequest{
+			tableName: {
+				{PutRequest: &dynamodbtypes.PutRequest{Item: map[string]dynamodbtypes.AttributeValue{"id": &dynamodbtypes.AttributeValueMemberS{Value: "1"}}}},
+				{PutRequest: &dynamodbtypes.PutRequest{Item: map[string]dynamodbtypes.AttributeValue{"id": &dynamodbtypes.AttributeValueMemberS{Value: "2"}}}},
+			},
+		},
+	})
+	c.NoError(err)
+	c.Len(out.UnprocessedItems[tableName], 1)
+	c.Equal("1", out.UnprocessedItems[tableName][0].PutRequest.Item["id"].(*dynamodbtypes.AttributeValueMemberS).Value)
+
+	got2, err := client.GetItem(context.Background(), &dynamodb.GetItemInput{
+		TableName: aws.String(tableName),
+		Key:       map[string]dynamodbtypes.AttributeValue{"id": &dynamodbtypes.AttributeValueMemberS{Value: "2"}},
+	})
+	c.NoError(err)
+	c.NotEmpty(got2.Item)
+
+	got1, err := client.GetItem(context.Background(), &dynamodb.GetItemInput{
+		TableName: aws.String(tableName),
+		Key:       map[string]dynamodbtypes.AttributeValue{"id": &dynamodbtypes.AttributeValueMemberS{Value: "1"}},
+	})
+	c.NoError(err)
+	c.Empty(got1.Item)
+}
+
+func TestEmulateUnprocessedItemsBatchWriteByIndex(t *testing.T) {
+	c := require.New(t)
+	client := NewClient()
+
+	c.NoError(ensurePokemonTable(client))
+
+	EmulateUnprocessedItems(client, tableName, func(n int, _ map[string]dynamodbtypes.AttributeValue) bool {
+		return n == 0
+	})
+
+	out, err := client.BatchWriteItem(context.Background(), &dynamodb.BatchWriteItemInput{
+		RequestItems: map[string][]dynamodbtypes.WriteRequest{
+			tableName: {
+				{PutRequest: &dynamodbtypes.PutRequest{Item: map[string]dynamodbtypes.AttributeValue{"id": &dynamodbtypes.AttributeValueMemberS{Value: "1"}}}},
+				{PutRequest: &dynamodbtypes.PutRequest{Item: map[string]dynamodbtypes.AttributeValue{"id": &dynamodbtypes.AttributeValueMemberS{Value: "2"}}}},
+			},
+		},
+	})
+	c.NoError(err)
+	c.Len(out.UnprocessedItems[tableName], 1)
+	c.Equal("1", out.UnprocessedItems[tableName][0].PutRequest.Item["id"].(*dynamodbtypes.AttributeValueMemberS).Value)
+}
+
+func TestEmulateUnprocessedItemsBatchGet(t *testing.T) {
+	c := require.New(t)
+	client := NewClient()
+
+	c.NoError(ensurePokemonTable(client))
+
+	for _, id := range []string{"1", "2"} {
+		_, err := client.PutItem(context.Background(), &dynamodb.PutItemInput{
+			TableName: aws.String(tableName),
+			Item:      map[string]dynamodbtypes.AttributeValue{"id": &dynamodbtypes.AttributeValueMemberS{Value: id}},
+		})
+		c.NoError(err)
+	}
+
+	EmulateUnprocessedItems(client, tableName, matchID("1"))
+
+	out, err := client.BatchGetItem(context.Background(), &dynamodb.BatchGetItemInput{
+		RequestItems: map[string]dynamodbtypes.KeysAndAttributes{
+			tableName: {Keys: []map[string]dynamodbtypes.AttributeValue{
+				{"id": &dynamodbtypes.AttributeValueMemberS{Value: "1"}},
+				{"id": &dynamodbtypes.AttributeValueMemberS{Value: "2"}},
+			}},
+		},
+	})
+	c.NoError(err)
+	c.Len(out.UnprocessedKeys[tableName].Keys, 1)
+	c.Equal("1", out.UnprocessedKeys[tableName].Keys[0]["id"].(*dynamodbtypes.AttributeValueMemberS).Value)
+	c.Len(out.Responses[tableName], 1)
+	c.Equal("2", out.Responses[tableName][0]["id"].(*dynamodbtypes.AttributeValueMemberS).Value)
+}
+
+func TestEmulateUnprocessedItemsDoesNotAffectSingleOps(t *testing.T) {
+	c := require.New(t)
+	client := NewClient()
+
+	c.NoError(ensurePokemonTable(client))
+
+	EmulateUnprocessedItems(client, tableName, matchID("1"))
+
+	_, err := client.PutItem(context.Background(), &dynamodb.PutItemInput{
+		TableName: aws.String(tableName),
+		Item:      map[string]dynamodbtypes.AttributeValue{"id": &dynamodbtypes.AttributeValueMemberS{Value: "1"}},
+	})
+	c.NoError(err)
+
+	got, err := client.GetItem(context.Background(), &dynamodb.GetItemInput{
+		TableName: aws.String(tableName),
+		Key:       map[string]dynamodbtypes.AttributeValue{"id": &dynamodbtypes.AttributeValueMemberS{Value: "1"}},
+	})
+	c.NoError(err)
+	c.NotEmpty(got.Item)
+}
+
+func TestEmulateUnprocessedItemsStickyAndClear(t *testing.T) {
+	c := require.New(t)
+	client := NewClient()
+
+	c.NoError(ensurePokemonTable(client))
+
+	batch := &dynamodb.BatchWriteItemInput{
+		RequestItems: map[string][]dynamodbtypes.WriteRequest{
+			tableName: {
+				{PutRequest: &dynamodbtypes.PutRequest{Item: map[string]dynamodbtypes.AttributeValue{"id": &dynamodbtypes.AttributeValueMemberS{Value: "1"}}}},
+			},
+		},
+	}
+
+	EmulateUnprocessedItems(client, tableName, matchID("1"))
+
+	for range 2 {
+		out, err := client.BatchWriteItem(context.Background(), batch)
+		c.NoError(err)
+		c.Len(out.UnprocessedItems[tableName], 1)
+	}
+
+	EmulateUnprocessedItems(client, tableName, nil)
+
+	out, err := client.BatchWriteItem(context.Background(), batch)
+	c.NoError(err)
+	c.Empty(out.UnprocessedItems[tableName])
+
+	EmulateUnprocessedItems(client, tableName, matchID("1"))
+	ClearUnprocessedItems(client)
+
+	out, err = client.BatchWriteItem(context.Background(), batch)
+	c.NoError(err)
+	c.Empty(out.UnprocessedItems[tableName])
 }
 
 func TestEmulateFailureForTableTransactWriteAtomic(t *testing.T) {
@@ -2371,66 +2545,6 @@ func TestEmulateFailureForTableDeprecated(t *testing.T) {
 
 	err := createPokemon(client, pokemon{ID: "001", Type: "grass", Name: "Bulbasaur"})
 	c.ErrorIs(err, ErrForcedFailure)
-}
-
-func TestHandleBatchWriteRequestError(t *testing.T) {
-	t.Run("nil error", func(t *testing.T) {
-		unprocessed := map[string][]dynamodbtypes.WriteRequest{}
-		req := dynamodbtypes.WriteRequest{PutRequest: &dynamodbtypes.PutRequest{}}
-		err := handleBatchWriteRequestError("t", req, unprocessed, nil)
-		require.NoError(t, err)
-		require.Empty(t, unprocessed)
-	})
-
-	t.Run("non smithy API error", func(t *testing.T) {
-		unprocessed := map[string][]dynamodbtypes.WriteRequest{}
-		req := dynamodbtypes.WriteRequest{}
-		in := errors.New("plain failure")
-		err := handleBatchWriteRequestError("t", req, unprocessed, in)
-		require.ErrorIs(t, err, in)
-		require.Empty(t, unprocessed)
-	})
-
-	t.Run("smithy API error not retriable", func(t *testing.T) {
-		unprocessed := map[string][]dynamodbtypes.WriteRequest{}
-		req := dynamodbtypes.WriteRequest{}
-		in := &smithy.GenericAPIError{Code: "ValidationException", Message: "invalid"}
-		err := handleBatchWriteRequestError("t", req, unprocessed, in)
-		require.ErrorIs(t, err, in)
-		require.Empty(t, unprocessed)
-	})
-
-	t.Run("internal server error adds to unprocessed", func(t *testing.T) {
-		unprocessed := map[string][]dynamodbtypes.WriteRequest{}
-		req := dynamodbtypes.WriteRequest{PutRequest: &dynamodbtypes.PutRequest{}}
-		in := &dynamodbtypes.InternalServerError{Message: aws.String("emulated")}
-		err := handleBatchWriteRequestError("mytable", req, unprocessed, in)
-		require.NoError(t, err)
-		require.Len(t, unprocessed["mytable"], 1)
-		require.Equal(t, req, unprocessed["mytable"][0])
-	})
-
-	t.Run("internal server error appends when table key already exists", func(t *testing.T) {
-		first := dynamodbtypes.WriteRequest{DeleteRequest: &dynamodbtypes.DeleteRequest{}}
-		second := dynamodbtypes.WriteRequest{PutRequest: &dynamodbtypes.PutRequest{}}
-		unprocessed := map[string][]dynamodbtypes.WriteRequest{"tbl": {first}}
-		in := &dynamodbtypes.InternalServerError{Message: aws.String("retry")}
-		err := handleBatchWriteRequestError("tbl", second, unprocessed, in)
-		require.NoError(t, err)
-		require.Len(t, unprocessed["tbl"], 2)
-		require.Equal(t, first, unprocessed["tbl"][0])
-		require.Equal(t, second, unprocessed["tbl"][1])
-	})
-
-	t.Run("provisioned throughput exceeded adds to unprocessed", func(t *testing.T) {
-		unprocessed := map[string][]dynamodbtypes.WriteRequest{}
-		req := dynamodbtypes.WriteRequest{PutRequest: &dynamodbtypes.PutRequest{}}
-		in := &dynamodbtypes.ProvisionedThroughputExceededException{Message: aws.String("throttled")}
-		err := handleBatchWriteRequestError("tbl", req, unprocessed, in)
-		require.NoError(t, err)
-		require.Len(t, unprocessed["tbl"], 1)
-		require.Equal(t, req, unprocessed["tbl"][0])
-	})
 }
 
 func TestTransactWriteItems(t *testing.T) {

--- a/aws-v2/client/minidyn.go
+++ b/aws-v2/client/minidyn.go
@@ -38,7 +38,11 @@ var (
 	}
 )
 
-// EmulateFailure forces the fake client to fail
+// EmulateFailure forces the fake client to fail. Every API hard-fails the call with
+// the emulated error, including BatchWriteItem and BatchGetItem (the whole batch
+// errors; it does not return partial results). Use FailureConditionNone to clear. To
+// leave individual batch sub-requests unprocessed instead of failing the whole call,
+// use EmulateUnprocessedItems.
 func EmulateFailure(client FakeClient, condition FailureCondition) {
 	fakeClient, ok := client.(*Client)
 	if !ok {
@@ -51,8 +55,9 @@ func EmulateFailure(client FakeClient, condition FailureCondition) {
 // EmulateFailureForTable scopes failure emulation to a single table, or to a
 // specific index of that table when indexName is provided. Operations targeting
 // other tables (or, for an index-scoped failure, other access paths on the same
-// table) keep working. Passing FailureConditionNone clears the failure for that
-// exact table/index scope. The global EmulateFailure still overrides everything.
+// table) keep working. A batch (BatchWriteItem/BatchGetItem) that touches the scoped
+// table hard-fails the whole call. Passing FailureConditionNone clears the failure for
+// that exact table/index scope. The global EmulateFailure still overrides everything.
 func EmulateFailureForTable(client FakeClient, tableName string, condition FailureCondition, indexName ...string) {
 	fakeClient, ok := client.(*Client)
 	if !ok {
@@ -65,6 +70,34 @@ func EmulateFailureForTable(client FakeClient, tableName string, condition Failu
 	}
 
 	fakeClient.setTableFailureCondition(tableName, index, condition)
+}
+
+// EmulateUnprocessedItems makes BatchWriteItem and BatchGetItem leave selected
+// sub-requests of tableName unprocessed (returned in UnprocessedItems/UnprocessedKeys)
+// instead of executing them, while the rest of the batch is applied normally. The
+// match predicate receives the zero-based index of the sub-request within that table's
+// request slice and its raw payload: a PutRequest's full item, or a DeleteRequest/get
+// key map. It is sticky until cleared with EmulateUnprocessedItems(client, tableName,
+// nil) or ClearUnprocessedItems. Single-item operations are unaffected. A global or
+// table-scoped EmulateFailure overrides this and hard-fails the whole batch.
+func EmulateUnprocessedItems(client FakeClient, tableName string, match func(n int, raw map[string]types.AttributeValue) bool) {
+	fakeClient, ok := client.(*Client)
+	if !ok {
+		panic("EmulateUnprocessedItems: invalid client type")
+	}
+
+	fakeClient.setUnprocessedMatcher(tableName, match)
+}
+
+// ClearUnprocessedItems removes every batch partial-failure predicate set with
+// EmulateUnprocessedItems.
+func ClearUnprocessedItems(client FakeClient) {
+	fakeClient, ok := client.(*Client)
+	if !ok {
+		panic("ClearUnprocessedItems: invalid client type")
+	}
+
+	fakeClient.clearUnprocessedMatchers()
 }
 
 // ActiveForceFailure active force operation to fail

--- a/core/table_test.go
+++ b/core/table_test.go
@@ -127,6 +127,26 @@ func TestAddLocalIndexes(t *testing.T) {
 	c.Contains(err.Error(), "ValidationException: LSI list is empty/invalid")
 }
 
+func TestTableIndexesDescription(t *testing.T) {
+	c := require.New(t)
+
+	newTable, err := createPokemonTable()
+	c.NoError(err)
+
+	localIndexes := createLocalSecondaryIndex()
+	localIndexes[0].KeySchema = []*types.KeySchemaElement{
+		{
+			AttributeName: "id",
+			KeyType:       "HASH",
+		},
+	}
+	c.NoError(newTable.AddLocalIndexes(localIndexes))
+
+	_, lsi := newTable.IndexesDescription()
+	c.Len(lsi, 1)
+	c.Equal("indexname", *lsi[0].IndexName)
+}
+
 func TestApplyIndexChange(t *testing.T) {
 	c := require.New(t)
 

--- a/interpreter/language/evaluator_test.go
+++ b/interpreter/language/evaluator_test.go
@@ -374,6 +374,19 @@ func TestEvalUpdateError(t *testing.T) {
 	}
 }
 
+func TestEvalUpdateIndexAliasInvalidPath(t *testing.T) {
+	env := startEvalUpdateEnv(t)
+
+	// #nested_map_attr aliases a scalar string field; indexing it with [0] fails
+	// and surfaces the resolved alias in the document-path error, exercising
+	// indexFieldID's alias branch.
+	result := testEvalUpdate(t, "SET #nested_map_attr[0] = :one", env)
+
+	if !isError(result) {
+		t.Fatalf("expected an error, got %v", result.Inspect())
+	}
+}
+
 func TestEvalSetUpdate(t *testing.T) {
 	tests := []struct {
 		input    string

--- a/scripts/check_coverage.sh
+++ b/scripts/check_coverage.sh
@@ -7,7 +7,7 @@ pkgs_to_test=`find . -type f -name '*.go' | grep -v -E '^\./(tools|e2e)/' | xarg
 
 function parse_test {
 
-    exit_code=0
+    local exit_code=0
     while read line; do
         if [[ `echo "$line" | grep -cE '\-+ FAIL'` -gt 0 ]]
         then
@@ -22,7 +22,7 @@ function parse_test {
 }
 
 function parse_coverage {
-    exit_code=0
+    local exit_code=0
     output=`go tool cover -func=$coverage_file`
     while read line; do
         if [[ `echo "$line" | grep -cE '\b([0-7][0-9]|[0-9])\.[0-9]+%'` -gt 0 ]] && [[ `echo "$line" | grep -cE '\s(init|main|\(statements\))\s'` -eq 0 ]] && [[ `echo "$line" | grep -cE '\s\S+SC\s'` -eq 0 ]]

--- a/server/client.go
+++ b/server/client.go
@@ -23,17 +23,19 @@ type Client struct {
 	useNativeInterpreter bool
 	forceFailureErr      error
 	tableFailureErrs     map[string]error
+	unprocessedMatchers  map[string]func(int, map[string]*AttributeValue) bool
 	indexActivationDelay time.Duration
 }
 
 // NewClient creates a new in-memory DynamoDB-compatible client used by the HTTP server.
 func NewClient() *Client {
 	return &Client{
-		tables:            map[string]*core.Table{},
-		mu:                sync.Mutex{},
-		nativeInterpreter: interpreter.NewNativeInterpreter(),
-		langInterpreter:   &interpreter.Language{},
-		tableFailureErrs:  map[string]error{},
+		tables:              map[string]*core.Table{},
+		mu:                  sync.Mutex{},
+		nativeInterpreter:   interpreter.NewNativeInterpreter(),
+		langInterpreter:     &interpreter.Language{},
+		tableFailureErrs:    map[string]error{},
+		unprocessedMatchers: map[string]func(int, map[string]*AttributeValue) bool{},
 	}
 }
 
@@ -80,6 +82,82 @@ func (c *Client) failureErrFor(table, index string) error {
 	}
 
 	return c.tableFailureErrs[failureKey(table, "")]
+}
+
+// setUnprocessedMatcher installs a predicate that marks matching sub-requests of a
+// batch operation on tableName as unprocessed. A nil match clears the predicate for
+// that table.
+func (c *Client) setUnprocessedMatcher(tableName string, match func(int, map[string]*AttributeValue) bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if match == nil {
+		delete(c.unprocessedMatchers, tableName)
+
+		return
+	}
+
+	c.unprocessedMatchers[tableName] = match
+}
+
+// clearUnprocessedMatchers removes every batch partial-failure predicate.
+func (c *Client) clearUnprocessedMatchers() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.unprocessedMatchers = map[string]func(int, map[string]*AttributeValue) bool{}
+}
+
+// batchEmulation is a lock-free snapshot of the failure emulation that applies to a
+// batch operation: a hard failure error (global or table-scoped) that fails the whole
+// call, and the per-table partial-failure predicates.
+type batchEmulation struct {
+	failErr  error
+	matchers map[string]func(int, map[string]*AttributeValue) bool
+}
+
+// unprocessed reports whether sub-request n (raw payload) of tableName should be
+// returned as unprocessed instead of being executed.
+func (e batchEmulation) unprocessed(tableName string, n int, raw map[string]*AttributeValue) bool {
+	match, ok := e.matchers[tableName]
+
+	return ok && match(n, raw)
+}
+
+// batchEmulationFor snapshots the emulation state relevant to a batch touching the
+// given tables. A global failure overrides everything; otherwise any table-scoped
+// failure hard-fails the whole batch. Takes c.mu briefly so the loop can run lock-free.
+func (c *Client) batchEmulationFor(tables ...string) batchEmulation {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	snap := batchEmulation{}
+
+	if c.forceFailureErr != nil {
+		snap.failErr = c.forceFailureErr
+
+		return snap
+	}
+
+	for _, table := range tables {
+		if err := c.failureErrFor(table, ""); err != nil {
+			snap.failErr = err
+
+			return snap
+		}
+	}
+
+	for _, table := range tables {
+		if match, ok := c.unprocessedMatchers[table]; ok {
+			if snap.matchers == nil {
+				snap.matchers = map[string]func(int, map[string]*AttributeValue) bool{}
+			}
+
+			snap.matchers[table] = match
+		}
+	}
+
+	return snap
 }
 
 func (c *Client) setIndexActivationDelay(delay time.Duration) {
@@ -542,32 +620,44 @@ func validateBatchWriteItemInput(input *BatchWriteItemInput) error {
 	return nil
 }
 
-func isRetriableBatchSubrequestError(err error) bool {
-	if _, ok := errors.AsType[*ddbtypes.InternalServerError](err); ok {
-		return true
+func batchWriteRequestKey(req WriteRequest) map[string]*AttributeValue {
+	if req.PutRequest != nil {
+		return req.PutRequest.Item
 	}
 
-	_, ok := errors.AsType[*ddbtypes.ProvisionedThroughputExceededException](err)
+	if req.DeleteRequest != nil {
+		return req.DeleteRequest.Key
+	}
 
-	return ok
+	return nil
 }
 
-// BatchWriteItem runs put and delete sub-requests in order. Sub-request failures that look
-// retriable (InternalServerError, ProvisionedThroughputExceededException) are appended to
-// UnprocessedItems and processing continues, matching DynamoDB batch semantics. Any other
-// error fails the whole batch.
-//
-// With EmulateFailure(FailureConditionInternalServerError), each sub-request fails that way,
-// so those writes appear as unprocessed until you call EmulateFailure(FailureConditionNone).
+// BatchWriteItem runs put and delete sub-requests in order. An emulated failure
+// (global EmulateFailure or table-scoped EmulateFailureForTable touching any table in
+// the batch) hard-fails the whole call, mirroring DynamoDB returning a 500 for the
+// request. UnprocessedItems is produced only by EmulateUnprocessedItems, whose
+// predicate selects individual sub-requests to leave unprocessed while the rest are
+// applied.
 func (c *Client) BatchWriteItem(ctx context.Context, input *BatchWriteItemInput) (*BatchWriteItemOutput, error) {
 	if err := validateBatchWriteItemInput(input); err != nil {
 		return nil, err
 	}
 
+	emulation := c.batchEmulationFor(tableNames(input.RequestItems)...)
+	if emulation.failErr != nil {
+		return nil, emulation.failErr
+	}
+
 	unprocessed := map[string][]WriteRequest{}
 
 	for tableName, reqs := range input.RequestItems {
-		for _, req := range reqs {
+		for i, req := range reqs {
+			if emulation.unprocessed(tableName, i, batchWriteRequestKey(req)) {
+				unprocessed[tableName] = append(unprocessed[tableName], req)
+
+				continue
+			}
+
 			var err error
 			if req.PutRequest != nil {
 				_, err = c.PutItem(ctx, &PutItemInput{
@@ -584,17 +674,21 @@ func (c *Client) BatchWriteItem(ctx context.Context, input *BatchWriteItemInput)
 			}
 
 			if err != nil {
-				if isRetriableBatchSubrequestError(err) {
-					unprocessed[tableName] = append(unprocessed[tableName], req)
-					continue
-				}
-
 				return nil, err
 			}
 		}
 	}
 
 	return &BatchWriteItemOutput{UnprocessedItems: unprocessed}, nil
+}
+
+func tableNames[V any](requestItems map[string]V) []string {
+	names := make([]string, 0, len(requestItems))
+	for name := range requestItems {
+		names = append(names, name)
+	}
+
+	return names
 }
 
 func validateBatchGetItemInput(input *BatchGetItemInput) error {
@@ -626,19 +720,26 @@ func validateBatchGetItemInput(input *BatchGetItemInput) error {
 }
 
 // BatchGetItem retrieves multiple items across one or more tables. Validation errors
-// (invalid key schema, malformed AttributeValues, or missing tables) fail the whole batch.
-// Retriable per-key failures (InternalServerError, ProvisionedThroughputExceededException)
-// are reported via UnprocessedKeys, mirroring DynamoDB batch semantics.
+// (invalid key schema, malformed AttributeValues, or missing tables) fail the whole
+// batch. An emulated failure (global EmulateFailure or table-scoped
+// EmulateFailureForTable touching any table in the batch) hard-fails the whole call.
+// UnprocessedKeys is produced only by EmulateUnprocessedItems, whose predicate selects
+// individual keys to leave unprocessed while the rest are fetched.
 func (c *Client) BatchGetItem(ctx context.Context, input *BatchGetItemInput) (*BatchGetItemOutput, error) {
 	if err := validateBatchGetItemInput(input); err != nil {
 		return nil, err
+	}
+
+	emulation := c.batchEmulationFor(tableNames(input.RequestItems)...)
+	if emulation.failErr != nil {
+		return nil, emulation.failErr
 	}
 
 	responses := map[string][]map[string]*AttributeValue{}
 	unprocessed := map[string]KeysAndAttributes{}
 
 	for tableName, reqs := range input.RequestItems {
-		tableResponses, unprocessedKeys, err := c.batchGetItemForTable(ctx, tableName, reqs)
+		tableResponses, unprocessedKeys, err := c.batchGetItemForTable(ctx, tableName, reqs, emulation)
 		if err != nil {
 			return nil, err
 		}
@@ -655,7 +756,7 @@ func (c *Client) BatchGetItem(ctx context.Context, input *BatchGetItemInput) (*B
 	return &BatchGetItemOutput{Responses: responses, UnprocessedKeys: unprocessed}, nil
 }
 
-func (c *Client) batchGetItemForTable(ctx context.Context, tableName string, reqs KeysAndAttributes) ([]map[string]*AttributeValue, []map[string]*AttributeValue, error) {
+func (c *Client) batchGetItemForTable(ctx context.Context, tableName string, reqs KeysAndAttributes, emulation batchEmulation) ([]map[string]*AttributeValue, []map[string]*AttributeValue, error) {
 	if err := validateExpressionAttributes(reqs.ExpressionAttributeNames, nil, aws.ToString(reqs.ProjectionExpression)); err != nil {
 		return nil, nil, err
 	}
@@ -663,7 +764,13 @@ func (c *Client) batchGetItemForTable(ctx context.Context, tableName string, req
 	responses := make([]map[string]*AttributeValue, 0, len(reqs.Keys))
 	unprocessedKeys := make([]map[string]*AttributeValue, 0, len(reqs.Keys))
 
-	for _, key := range reqs.Keys {
+	for i, key := range reqs.Keys {
+		if emulation.unprocessed(tableName, i, key) {
+			unprocessedKeys = append(unprocessedKeys, key)
+
+			continue
+		}
+
 		item, err := c.GetItem(ctx, &GetItemInput{
 			TableName:                aws.String(tableName),
 			Key:                      key,
@@ -672,11 +779,6 @@ func (c *Client) batchGetItemForTable(ctx context.Context, tableName string, req
 			ProjectionExpression:     reqs.ProjectionExpression,
 		})
 		if err != nil {
-			if isRetriableBatchSubrequestError(err) {
-				unprocessedKeys = append(unprocessedKeys, key)
-				continue
-			}
-
 			return nil, nil, err
 		}
 

--- a/server/minidyn.go
+++ b/server/minidyn.go
@@ -36,11 +36,10 @@ var (
 )
 
 // EmulateFailure configures failure injection on the server's in-memory client.
-// Single-item APIs fail per call (e.g. InternalServerError on PutItem). For
-// BatchWriteItem, InternalServerError (and provisioned-throughput exceeded) on a
-// sub-request are treated as retriable: those requests are returned in
-// UnprocessedItems and the batch call still succeeds. Use FailureConditionNone to
-// clear emulation.
+// Every API hard-fails the call with the emulated error, including BatchWriteItem and
+// BatchGetItem (the whole batch errors; it does not return partial results). Use
+// FailureConditionNone to clear emulation. To leave individual batch sub-requests
+// unprocessed instead of failing the whole call, use EmulateUnprocessedItems.
 func (s *Server) EmulateFailure(condition FailureCondition) {
 	if s == nil || s.client == nil {
 		return
@@ -52,8 +51,9 @@ func (s *Server) EmulateFailure(condition FailureCondition) {
 // EmulateFailureForTable scopes failure injection to a single table, or to a
 // specific index of that table when indexName is provided. Operations targeting
 // other tables (or, for an index-scoped failure, other access paths on the same
-// table) keep working. Passing FailureConditionNone clears the failure for that
-// exact table/index scope. The global EmulateFailure still overrides everything.
+// table) keep working. A batch (BatchWriteItem/BatchGetItem) that touches the scoped
+// table hard-fails the whole call. Passing FailureConditionNone clears the failure for
+// that exact table/index scope. The global EmulateFailure still overrides everything.
 func (s *Server) EmulateFailureForTable(tableName string, condition FailureCondition, indexName ...string) {
 	if s == nil || s.client == nil {
 		return
@@ -65,6 +65,32 @@ func (s *Server) EmulateFailureForTable(tableName string, condition FailureCondi
 	}
 
 	s.client.setTableFailureCondition(tableName, index, emulatingErrors[condition])
+}
+
+// EmulateUnprocessedItems makes BatchWriteItem and BatchGetItem leave selected
+// sub-requests of tableName unprocessed (returned in UnprocessedItems/UnprocessedKeys)
+// instead of executing them, while the rest of the batch is applied normally. The
+// match predicate receives the zero-based index of the sub-request within that table's
+// request slice and its raw payload: a PutRequest's full item, or a DeleteRequest/get
+// key map. It is sticky until cleared with EmulateUnprocessedItems(tableName, nil) or
+// ClearUnprocessedItems. Single-item operations are unaffected. A global or
+// table-scoped EmulateFailure overrides this and hard-fails the whole batch.
+func (s *Server) EmulateUnprocessedItems(tableName string, match func(n int, raw map[string]*AttributeValue) bool) {
+	if s == nil || s.client == nil {
+		return
+	}
+
+	s.client.setUnprocessedMatcher(tableName, match)
+}
+
+// ClearUnprocessedItems removes every batch partial-failure predicate set with
+// EmulateUnprocessedItems.
+func (s *Server) ClearUnprocessedItems() {
+	if s == nil || s.client == nil {
+		return
+	}
+
+	s.client.clearUnprocessedMatchers()
 }
 
 // SetIndexActivationDelay configures how long newly created GSIs report CREATING before ACTIVE.

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1717,10 +1717,44 @@ func TestServerServeHTTPJSONEncodeError(t *testing.T) {
 	require.Equal(t, http.StatusInternalServerError, rec.code)
 }
 
+func TestServerValidateTransactGetItemsInput(t *testing.T) {
+	c := NewClient()
+	id := map[string]*AttributeValue{"id": {S: aws.String("1")}}
+
+	// nil input is a no-op.
+	require.NoError(t, validateTransactGetItemsInput(c, nil))
+
+	// empty TransactItems.
+	require.Error(t, validateTransactGetItemsInput(c, &TransactGetItemsInput{}))
+
+	// too many items.
+	require.Error(t, validateTransactGetItemsInput(c, &TransactGetItemsInput{
+		TransactItems: make([]TransactGetItem, batchGetItemRequestsLimit+1),
+	}))
+
+	// missing Get.
+	require.Error(t, validateTransactGetItemsInput(c, &TransactGetItemsInput{
+		TransactItems: []TransactGetItem{{Get: nil}},
+	}))
+
+	// empty table name.
+	require.Error(t, validateTransactGetItemsInput(c, &TransactGetItemsInput{
+		TransactItems: []TransactGetItem{{Get: &Get{TableName: aws.String(""), Key: id}}},
+	}))
+
+	// non-existent table.
+	require.Error(t, validateTransactGetItemsInput(c, &TransactGetItemsInput{
+		TransactItems: []TransactGetItem{{Get: &Get{TableName: aws.String("ghost"), Key: id}}},
+	}))
+}
+
 func TestServerNilServerGuards(t *testing.T) {
 	var s *Server
 
 	s.EmulateFailure(FailureConditionNone)
+	s.EmulateUnprocessedItems("any", matchID("1"))
+	s.ClearUnprocessedItems()
+	s.SetIndexActivationDelay(0)
 	require.ErrorIs(t, s.ClearTable("any"), ErrServerNotInitialized)
 	require.ErrorIs(t, s.ClearAllTables(), ErrServerNotInitialized)
 	require.ErrorIs(t, s.Reset(), ErrServerNotInitialized)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -679,31 +679,6 @@ func TestServerBatchGetItemValidationException(t *testing.T) {
 	})
 }
 
-func TestServerBatchGetItemUnprocessedOnEmulatedInternalError(t *testing.T) {
-	s := NewServer()
-	ts := httptest.NewServer(s)
-	defer ts.Close()
-
-	cli := newTestDynamoClient(t, ts.URL)
-	makeBasicTable(t, cli, "pokemons", "id")
-
-	s.EmulateFailure(FailureConditionInternalServerError)
-
-	out, err := cli.BatchGetItem(context.Background(), &dynamodb.BatchGetItemInput{
-		RequestItems: map[string]ddbtypes.KeysAndAttributes{
-			"pokemons": {
-				Keys: []map[string]ddbtypes.AttributeValue{
-					{"id": &ddbtypes.AttributeValueMemberS{Value: "a"}},
-					{"id": &ddbtypes.AttributeValueMemberS{Value: "b"}},
-				},
-			},
-		},
-	})
-	require.NoError(t, err)
-	require.Len(t, out.UnprocessedKeys["pokemons"].Keys, 2)
-	require.Empty(t, out.Responses["pokemons"])
-}
-
 func TestServerBatchGetItemWithProjection(t *testing.T) {
 	ts := httptest.NewServer(NewServer())
 	defer ts.Close()
@@ -1264,7 +1239,8 @@ func TestServerEmulateFailureForTableBatchWriteMultiTable(t *testing.T) {
 
 	s.EmulateFailureForTable("pokemons", FailureConditionInternalServerError)
 
-	out, err := cli.BatchWriteItem(context.Background(), &dynamodb.BatchWriteItemInput{
+	// A batch touching the scoped table hard-fails the whole call.
+	_, err := cli.BatchWriteItem(context.Background(), &dynamodb.BatchWriteItemInput{
 		RequestItems: map[string][]ddbtypes.WriteRequest{
 			"pokemons": {
 				{PutRequest: &ddbtypes.PutRequest{Item: map[string]ddbtypes.AttributeValue{"id": &ddbtypes.AttributeValueMemberS{Value: "1"}}}},
@@ -1274,8 +1250,20 @@ func TestServerEmulateFailureForTableBatchWriteMultiTable(t *testing.T) {
 			},
 		},
 	})
+
+	var internal *ddbtypes.InternalServerError
+
+	require.ErrorAs(t, err, &internal)
+
+	// A batch touching only the unscoped table succeeds.
+	out, err := cli.BatchWriteItem(context.Background(), &dynamodb.BatchWriteItemInput{
+		RequestItems: map[string][]ddbtypes.WriteRequest{
+			"items": {
+				{PutRequest: &ddbtypes.PutRequest{Item: map[string]ddbtypes.AttributeValue{"id": &ddbtypes.AttributeValueMemberS{Value: "x"}}}},
+			},
+		},
+	})
 	require.NoError(t, err)
-	require.Len(t, out.UnprocessedItems["pokemons"], 1)
 	require.Empty(t, out.UnprocessedItems["items"])
 
 	got, err := cli.GetItem(context.Background(), &dynamodb.GetItemInput{
@@ -1865,7 +1853,7 @@ func TestServerUpdateItemConditionalFailureReturnsAllOldItem(t *testing.T) {
 	require.Equal(t, "kanto", cond.Item["meta"].(*ddbtypes.AttributeValueMemberM).Value["region"].(*ddbtypes.AttributeValueMemberS).Value)
 }
 
-func TestServerBatchWriteItemUnprocessedOnEmulatedInternalError(t *testing.T) {
+func TestServerBatchWriteItemHardFailsOnEmulatedInternalError(t *testing.T) {
 	s := NewServer()
 	ts := httptest.NewServer(s)
 	defer ts.Close()
@@ -1875,7 +1863,7 @@ func TestServerBatchWriteItemUnprocessedOnEmulatedInternalError(t *testing.T) {
 
 	s.EmulateFailure(FailureConditionInternalServerError)
 
-	out, err := cli.BatchWriteItem(context.Background(), &dynamodb.BatchWriteItemInput{
+	_, err := cli.BatchWriteItem(context.Background(), &dynamodb.BatchWriteItemInput{
 		RequestItems: map[string][]ddbtypes.WriteRequest{
 			"pokemons": {
 				{PutRequest: &ddbtypes.PutRequest{Item: map[string]ddbtypes.AttributeValue{
@@ -1887,8 +1875,10 @@ func TestServerBatchWriteItemUnprocessedOnEmulatedInternalError(t *testing.T) {
 			},
 		},
 	})
-	require.NoError(t, err)
-	require.Len(t, out.UnprocessedItems["pokemons"], 2)
+
+	var internal *ddbtypes.InternalServerError
+
+	require.ErrorAs(t, err, &internal)
 
 	s.EmulateFailure(FailureConditionNone)
 
@@ -1902,6 +1892,258 @@ func TestServerBatchWriteItemUnprocessedOnEmulatedInternalError(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
+
+	got, err := cli.GetItem(context.Background(), &dynamodb.GetItemInput{
+		TableName: aws.String("pokemons"),
+		Key:       map[string]ddbtypes.AttributeValue{"id": &ddbtypes.AttributeValueMemberS{Value: "ok"}},
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, got.Item)
+}
+
+func TestServerBatchGetItemHardFailsOnEmulatedInternalError(t *testing.T) {
+	s := NewServer()
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	cli := newTestDynamoClient(t, ts.URL)
+	makeBasicTable(t, cli, "pokemons", "id")
+
+	s.EmulateFailure(FailureConditionInternalServerError)
+
+	_, err := cli.BatchGetItem(context.Background(), &dynamodb.BatchGetItemInput{
+		RequestItems: map[string]ddbtypes.KeysAndAttributes{
+			"pokemons": {Keys: []map[string]ddbtypes.AttributeValue{
+				{"id": &ddbtypes.AttributeValueMemberS{Value: "a"}},
+			}},
+		},
+	})
+
+	var internal *ddbtypes.InternalServerError
+
+	require.ErrorAs(t, err, &internal)
+}
+
+// matchID returns a predicate that marks the item/key whose "id" string attribute
+// equals the given value as unprocessed.
+func matchID(id string) func(int, map[string]*AttributeValue) bool {
+	return func(_ int, raw map[string]*AttributeValue) bool {
+		av, ok := raw["id"]
+
+		return ok && av != nil && av.S != nil && *av.S == id
+	}
+}
+
+func TestServerEmulateUnprocessedItemsBatchWriteByAttribute(t *testing.T) {
+	s := NewServer()
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	cli := newTestDynamoClient(t, ts.URL)
+	makeBasicTable(t, cli, "pokemons", "id")
+
+	s.EmulateUnprocessedItems("pokemons", matchID("1"))
+
+	out, err := cli.BatchWriteItem(context.Background(), &dynamodb.BatchWriteItemInput{
+		RequestItems: map[string][]ddbtypes.WriteRequest{
+			"pokemons": {
+				{PutRequest: &ddbtypes.PutRequest{Item: map[string]ddbtypes.AttributeValue{"id": &ddbtypes.AttributeValueMemberS{Value: "1"}}}},
+				{PutRequest: &ddbtypes.PutRequest{Item: map[string]ddbtypes.AttributeValue{"id": &ddbtypes.AttributeValueMemberS{Value: "2"}}}},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, out.UnprocessedItems["pokemons"], 1)
+	require.Equal(t, "1", out.UnprocessedItems["pokemons"][0].PutRequest.Item["id"].(*ddbtypes.AttributeValueMemberS).Value)
+
+	// "2" was written, "1" was left unprocessed (not written).
+	got2, err := cli.GetItem(context.Background(), &dynamodb.GetItemInput{
+		TableName: aws.String("pokemons"),
+		Key:       map[string]ddbtypes.AttributeValue{"id": &ddbtypes.AttributeValueMemberS{Value: "2"}},
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, got2.Item)
+
+	got1, err := cli.GetItem(context.Background(), &dynamodb.GetItemInput{
+		TableName: aws.String("pokemons"),
+		Key:       map[string]ddbtypes.AttributeValue{"id": &ddbtypes.AttributeValueMemberS{Value: "1"}},
+	})
+	require.NoError(t, err)
+	require.Empty(t, got1.Item)
+}
+
+func TestServerEmulateUnprocessedItemsBatchWriteByIndex(t *testing.T) {
+	s := NewServer()
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	cli := newTestDynamoClient(t, ts.URL)
+	makeBasicTable(t, cli, "pokemons", "id")
+
+	s.EmulateUnprocessedItems("pokemons", func(n int, _ map[string]*AttributeValue) bool {
+		return n == 0
+	})
+
+	out, err := cli.BatchWriteItem(context.Background(), &dynamodb.BatchWriteItemInput{
+		RequestItems: map[string][]ddbtypes.WriteRequest{
+			"pokemons": {
+				{PutRequest: &ddbtypes.PutRequest{Item: map[string]ddbtypes.AttributeValue{"id": &ddbtypes.AttributeValueMemberS{Value: "1"}}}},
+				{PutRequest: &ddbtypes.PutRequest{Item: map[string]ddbtypes.AttributeValue{"id": &ddbtypes.AttributeValueMemberS{Value: "2"}}}},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, out.UnprocessedItems["pokemons"], 1)
+	require.Equal(t, "1", out.UnprocessedItems["pokemons"][0].PutRequest.Item["id"].(*ddbtypes.AttributeValueMemberS).Value)
+}
+
+func TestServerEmulateUnprocessedItemsBatchWriteDelete(t *testing.T) {
+	s := NewServer()
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	cli := newTestDynamoClient(t, ts.URL)
+	makeBasicTable(t, cli, "pokemons", "id")
+
+	for _, id := range []string{"1", "2"} {
+		_, err := cli.PutItem(context.Background(), &dynamodb.PutItemInput{
+			TableName: aws.String("pokemons"),
+			Item:      map[string]ddbtypes.AttributeValue{"id": &ddbtypes.AttributeValueMemberS{Value: id}},
+		})
+		require.NoError(t, err)
+	}
+
+	s.EmulateUnprocessedItems("pokemons", matchID("1"))
+
+	out, err := cli.BatchWriteItem(context.Background(), &dynamodb.BatchWriteItemInput{
+		RequestItems: map[string][]ddbtypes.WriteRequest{
+			"pokemons": {
+				{DeleteRequest: &ddbtypes.DeleteRequest{Key: map[string]ddbtypes.AttributeValue{"id": &ddbtypes.AttributeValueMemberS{Value: "1"}}}},
+				{DeleteRequest: &ddbtypes.DeleteRequest{Key: map[string]ddbtypes.AttributeValue{"id": &ddbtypes.AttributeValueMemberS{Value: "2"}}}},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, out.UnprocessedItems["pokemons"], 1)
+
+	// "1" was left unprocessed so it still exists; "2" was deleted.
+	got1, err := cli.GetItem(context.Background(), &dynamodb.GetItemInput{
+		TableName: aws.String("pokemons"),
+		Key:       map[string]ddbtypes.AttributeValue{"id": &ddbtypes.AttributeValueMemberS{Value: "1"}},
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, got1.Item)
+
+	got2, err := cli.GetItem(context.Background(), &dynamodb.GetItemInput{
+		TableName: aws.String("pokemons"),
+		Key:       map[string]ddbtypes.AttributeValue{"id": &ddbtypes.AttributeValueMemberS{Value: "2"}},
+	})
+	require.NoError(t, err)
+	require.Empty(t, got2.Item)
+}
+
+func TestServerEmulateUnprocessedItemsBatchGet(t *testing.T) {
+	s := NewServer()
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	cli := newTestDynamoClient(t, ts.URL)
+	makeBasicTable(t, cli, "pokemons", "id")
+
+	for _, id := range []string{"1", "2"} {
+		_, err := cli.PutItem(context.Background(), &dynamodb.PutItemInput{
+			TableName: aws.String("pokemons"),
+			Item:      map[string]ddbtypes.AttributeValue{"id": &ddbtypes.AttributeValueMemberS{Value: id}},
+		})
+		require.NoError(t, err)
+	}
+
+	s.EmulateUnprocessedItems("pokemons", matchID("1"))
+
+	out, err := cli.BatchGetItem(context.Background(), &dynamodb.BatchGetItemInput{
+		RequestItems: map[string]ddbtypes.KeysAndAttributes{
+			"pokemons": {Keys: []map[string]ddbtypes.AttributeValue{
+				{"id": &ddbtypes.AttributeValueMemberS{Value: "1"}},
+				{"id": &ddbtypes.AttributeValueMemberS{Value: "2"}},
+			}},
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, out.UnprocessedKeys["pokemons"].Keys, 1)
+	require.Equal(t, "1", out.UnprocessedKeys["pokemons"].Keys[0]["id"].(*ddbtypes.AttributeValueMemberS).Value)
+	require.Len(t, out.Responses["pokemons"], 1)
+	require.Equal(t, "2", out.Responses["pokemons"][0]["id"].(*ddbtypes.AttributeValueMemberS).Value)
+}
+
+func TestServerEmulateUnprocessedItemsDoesNotAffectSingleOps(t *testing.T) {
+	s := NewServer()
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	cli := newTestDynamoClient(t, ts.URL)
+	makeBasicTable(t, cli, "pokemons", "id")
+
+	s.EmulateUnprocessedItems("pokemons", matchID("1"))
+
+	_, err := cli.PutItem(context.Background(), &dynamodb.PutItemInput{
+		TableName: aws.String("pokemons"),
+		Item:      map[string]ddbtypes.AttributeValue{"id": &ddbtypes.AttributeValueMemberS{Value: "1"}},
+	})
+	require.NoError(t, err)
+
+	got, err := cli.GetItem(context.Background(), &dynamodb.GetItemInput{
+		TableName: aws.String("pokemons"),
+		Key:       map[string]ddbtypes.AttributeValue{"id": &ddbtypes.AttributeValueMemberS{Value: "1"}},
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, got.Item)
+
+	_, err = cli.DeleteItem(context.Background(), &dynamodb.DeleteItemInput{
+		TableName: aws.String("pokemons"),
+		Key:       map[string]ddbtypes.AttributeValue{"id": &ddbtypes.AttributeValueMemberS{Value: "1"}},
+	})
+	require.NoError(t, err)
+}
+
+func TestServerEmulateUnprocessedItemsStickyAndClear(t *testing.T) {
+	s := NewServer()
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	cli := newTestDynamoClient(t, ts.URL)
+	makeBasicTable(t, cli, "pokemons", "id")
+
+	batch := &dynamodb.BatchWriteItemInput{
+		RequestItems: map[string][]ddbtypes.WriteRequest{
+			"pokemons": {
+				{PutRequest: &ddbtypes.PutRequest{Item: map[string]ddbtypes.AttributeValue{"id": &ddbtypes.AttributeValueMemberS{Value: "1"}}}},
+			},
+		},
+	}
+
+	s.EmulateUnprocessedItems("pokemons", matchID("1"))
+
+	// Sticky: two consecutive batches both leave "1" unprocessed.
+	for range 2 {
+		out, err := cli.BatchWriteItem(context.Background(), batch)
+		require.NoError(t, err)
+		require.Len(t, out.UnprocessedItems["pokemons"], 1)
+	}
+
+	// Per-table clear via nil predicate.
+	s.EmulateUnprocessedItems("pokemons", nil)
+
+	out, err := cli.BatchWriteItem(context.Background(), batch)
+	require.NoError(t, err)
+	require.Empty(t, out.UnprocessedItems["pokemons"])
+
+	// Re-arm then clear with ClearUnprocessedItems.
+	s.EmulateUnprocessedItems("pokemons", matchID("1"))
+	s.ClearUnprocessedItems()
+
+	out, err = cli.BatchWriteItem(context.Background(), batch)
+	require.NoError(t, err)
+	require.Empty(t, out.UnprocessedItems["pokemons"])
 }
 
 func TestServerGetItemKeyValidationError(t *testing.T) {


### PR DESCRIPTION
## Why

v0.8.0 (`355d7fd`) dropped the global forced-failure guard in `BatchWriteItem`, so
an emulated `InternalServerError` was routed into `UnprocessedItems` and the batch
returned success instead of erroring. This silently broke the `EmulateFailure`
contract consumers (e.g. scrap-services) rely on; table-scoped failures had the same
gap.

## What

**Restore hard-fail on emulated failures (server + aws-v2 client, at parity)**
- `BatchWriteItem` and `BatchGetItem` now hard-fail the whole call when a global
  `EmulateFailure` **or** a table-scoped `EmulateFailureForTable` applies to any
  table in the batch — matching DynamoDB returning a 500 and the pre-v0.8.0 behavior.
- Removed the retriable-subrequest routing helpers that caused the regression.
- Fixed aws-v2 `BatchGetItem` to omit valid-but-missing items from `Responses`
  instead of misreporting them as unprocessed (now matches the server).

**New: per-item partial-failure emulation**
- `EmulateUnprocessedItems(tableName, func(n int, raw) bool)` + `ClearUnprocessedItems()`
  (server methods and aws-v2 package funcs).
- The predicate selects individual batch sub-requests — by index `n`, by key, or by
  any attribute in `raw` — to return in `UnprocessedItems`/`UnprocessedKeys` while the
  rest of the batch is applied. Sticky until cleared; single-item ops unaffected.

**Coverage gate fix (second commit)**
- `scripts/check_coverage.sh` reused the script's global `exit_code` inside
  `parse_test`/`parse_coverage` and reset it, so the gate only reflected the last
  package and passed despite failures. Scoped it `local` so results aggregate across
  all packages, then covered the functions the broken gate had been hiding (the new
  emulation wrappers plus pre-existing `validateTransactGetItemsInput`,
  `IndexesDescription`, and `indexFieldID`).

## Notes
- Error strings remain byte-for-byte identical to DynamoDB Local.
- No `e2e/` parity tests were modified.
- Follow-up: cut v0.8.1 so consumers can bump `go.mod`.

Closes #133
