### PR TITLE
Return error for undeclared expression attribute names

### DIFF
--- a/core/table.go
+++ b/core/table.go
@@ -289,6 +289,29 @@ func validateSearchInputMaps(input QueryInput) error {
 	return nil
 }
 
+// validateSearchExpressionAttributeNames rejects up front any Query/Scan expression that
+// references an attribute name placeholder (#name) not declared in ExpressionAttributeNames.
+// DynamoDB validates this before scanning, so it must error even when the table is empty or
+// no item matches (when the per-item interpreter checks would never run).
+func validateSearchExpressionAttributeNames(input QueryInput) error {
+	checks := []struct {
+		label      string
+		expression string
+	}{
+		{"KeyConditionExpression", input.KeyConditionExpression},
+		{"FilterExpression", input.FilterExpression},
+		{"ProjectionExpression", input.ProjectionExpression},
+	}
+
+	for _, c := range checks {
+		if err := interpreter.ValidateExpressionAttributeNamesDeclared(c.label, c.expression, input.Aliases); err != nil {
+			return types.NewError("ValidationException", err.Error(), nil)
+		}
+	}
+
+	return nil
+}
+
 func validateUpdateItemInputKeysAndValues(input *types.UpdateItemInput) error {
 	if err := types.ValidateItemMap(input.Key); err != nil {
 		return types.NewError("ValidationException", err.Error(), nil)
@@ -415,6 +438,10 @@ func GetKeyAt(sortedKeys []string, size int64, pos int64, forward bool) string {
 // SearchData queries the table based on the input.
 func (t *Table) SearchData(input QueryInput) ([]map[string]*types.Item, map[string]*types.Item, error) { //nolint:gocognit // query loop with paging, filters, and interpreter errors
 	if err := validateSearchInputMaps(input); err != nil {
+		return nil, nil, err
+	}
+
+	if err := validateSearchExpressionAttributeNames(input); err != nil {
 		return nil, nil, err
 	}
 

--- a/core/table_test.go
+++ b/core/table_test.go
@@ -725,6 +725,49 @@ func TestSearchData_duplicateExpressionAttributeValues(t *testing.T) {
 	c.Contains(apiErr.Message(), "contains duplicates")
 }
 
+func TestSearchData_undeclaredExpressionAttributeName(t *testing.T) {
+	cases := []struct {
+		name  string
+		input QueryInput
+		label string
+	}{
+		{
+			name:  "KeyConditionExpression",
+			input: QueryInput{KeyConditionExpression: "#a = :v"},
+			label: "KeyConditionExpression",
+		},
+		{
+			name:  "FilterExpression",
+			input: QueryInput{FilterExpression: "#a = :v"},
+			label: "FilterExpression",
+		},
+		{
+			name:  "ProjectionExpression",
+			input: QueryInput{ProjectionExpression: "#a"},
+			label: "ProjectionExpression",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := require.New(t)
+
+			newTable, err := createPokemonTable()
+			c.NoError(err)
+
+			// Empty table: the per-item interpreter checks never run, so validation must
+			// happen up front to match DynamoDB.
+			_, _, err = newTable.SearchData(tc.input)
+			c.Error(err)
+
+			var apiErr types.Error
+			c.True(errors.As(err, &apiErr))
+			c.Equal("ValidationException", apiErr.Code())
+			c.Contains(apiErr.Message(), "Invalid "+tc.label+": An expression attribute name used in the document path is not defined; attribute name: #a")
+		})
+	}
+}
+
 func TestUpdate_duplicateExpressionAttributeValues(t *testing.T) {
 	c := require.New(t)
 
@@ -1140,6 +1183,9 @@ func TestMatchKey(t *testing.T) {
 	queryInput := QueryInput{
 		ExpressionAttributeValues: map[string]*types.Item{
 			":id": {S: new("001")},
+		},
+		Aliases: map[string]string{
+			"#id": "id",
 		},
 		KeyConditionExpression: "#id = :id",
 		FilterExpression:       "#id = :id",

--- a/e2e/parity_expression_names_test.go
+++ b/e2e/parity_expression_names_test.go
@@ -1,0 +1,135 @@
+package e2e
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	dynamodbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+)
+
+// errString returns a normalized error string for parity comparison, or "<nil>"
+// when no error was returned.
+func errString(err error) string {
+	if err == nil {
+		return "<nil>"
+	}
+
+	return normalizeSDKErrorString(err.Error())
+}
+
+// TestE2E_UndeclaredExpressionAttributeName verifies that referencing an expression
+// attribute name placeholder (#name) that is not declared in ExpressionAttributeNames
+// returns a ValidationException, across every expression type.
+func TestE2E_UndeclaredExpressionAttributeName(t *testing.T) {
+	tests := []struct {
+		name string
+		fn   func(t *testing.T, client *dynamodb.Client) any
+	}{
+		{
+			name: "UpdateExpression",
+			fn: func(t *testing.T, client *dynamodb.Client) any {
+				t.Helper()
+
+				ctx := context.Background()
+				parityCreatePokemonTable(ctx, t, client)
+				parityCreatePokemon(ctx, t, client, parityPokemon{ID: "u1", Type: "fire", Name: "Charmander"})
+
+				_, err := client.UpdateItem(ctx, &dynamodb.UpdateItemInput{
+					TableName: aws.String(parityPokemonTable),
+					Key: map[string]dynamodbtypes.AttributeValue{
+						"id": &dynamodbtypes.AttributeValueMemberS{Value: "u1"},
+					},
+					UpdateExpression: aws.String("SET #a = :v"),
+					ExpressionAttributeValues: map[string]dynamodbtypes.AttributeValue{
+						":v": &dynamodbtypes.AttributeValueMemberS{Value: "x"},
+					},
+				})
+
+				return errString(err)
+			},
+		},
+		{
+			name: "ConditionExpression",
+			fn: func(t *testing.T, client *dynamodb.Client) any {
+				t.Helper()
+
+				ctx := context.Background()
+				parityCreatePokemonTable(ctx, t, client)
+
+				_, err := client.PutItem(ctx, &dynamodb.PutItemInput{
+					TableName:           aws.String(parityPokemonTable),
+					Item:                parityMarshalPokemon(t, parityPokemon{ID: "c1", Type: "water", Name: "Squirtle"}),
+					ConditionExpression: aws.String("attribute_not_exists(#a)"),
+				})
+
+				return errString(err)
+			},
+		},
+		{
+			name: "FilterExpression",
+			fn: func(t *testing.T, client *dynamodb.Client) any {
+				t.Helper()
+
+				ctx := context.Background()
+				parityCreatePokemonTable(ctx, t, client)
+
+				_, err := client.Scan(ctx, &dynamodb.ScanInput{
+					TableName:        aws.String(parityPokemonTable),
+					FilterExpression: aws.String("#a = :v"),
+					ExpressionAttributeValues: map[string]dynamodbtypes.AttributeValue{
+						":v": &dynamodbtypes.AttributeValueMemberS{Value: "x"},
+					},
+				})
+
+				return errString(err)
+			},
+		},
+		{
+			name: "KeyConditionExpression",
+			fn: func(t *testing.T, client *dynamodb.Client) any {
+				t.Helper()
+
+				ctx := context.Background()
+				parityCreatePokemonTable(ctx, t, client)
+
+				_, err := client.Query(ctx, &dynamodb.QueryInput{
+					TableName:              aws.String(parityPokemonTable),
+					KeyConditionExpression: aws.String("#a = :v"),
+					ExpressionAttributeValues: map[string]dynamodbtypes.AttributeValue{
+						":v": &dynamodbtypes.AttributeValueMemberS{Value: "x"},
+					},
+				})
+
+				return errString(err)
+			},
+		},
+		{
+			name: "ProjectionExpression",
+			fn: func(t *testing.T, client *dynamodb.Client) any {
+				t.Helper()
+
+				ctx := context.Background()
+				parityCreatePokemonTable(ctx, t, client)
+				parityCreatePokemon(ctx, t, client, parityPokemon{ID: "p1", Type: "grass", Name: "Bulbasaur"})
+
+				_, err := client.GetItem(ctx, &dynamodb.GetItemInput{
+					TableName: aws.String(parityPokemonTable),
+					Key: map[string]dynamodbtypes.AttributeValue{
+						"id": &dynamodbtypes.AttributeValueMemberS{Value: "p1"},
+					},
+					ProjectionExpression: aws.String("#a"),
+				})
+
+				return errString(err)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			RunE2E(t, tt.fn)
+		})
+	}
+}

--- a/interpreter/interpreter.go
+++ b/interpreter/interpreter.go
@@ -2,7 +2,9 @@ package interpreter
 
 import (
 	"errors"
+	"fmt"
 
+	"github.com/truora/minidyn/interpreter/language"
 	"github.com/truora/minidyn/types"
 )
 
@@ -12,6 +14,38 @@ var (
 	// ErrUnsupportedFeature when an expression or attribute type in not yet supported by the interpreter
 	ErrUnsupportedFeature = errors.New("unsupported expression or attribute type")
 )
+
+// undeclaredAttributeNameError reports an expression that references an attribute name
+// placeholder (#name) not declared in ExpressionAttributeNames. Its message mirrors
+// DynamoDB's ValidationException wording; it unwraps to ErrSyntaxError so the same error
+// gating that maps expression syntax errors to ValidationException also covers this case.
+type undeclaredAttributeNameError struct {
+	expressionType string
+	name           string
+}
+
+func (e *undeclaredAttributeNameError) Error() string {
+	//nolint:stylecheck,staticcheck,ST1005 // DynamoDB ValidationException wording (parity)
+	return fmt.Sprintf(
+		"Invalid %s: An expression attribute name used in the document path is not defined; attribute name: %s",
+		e.expressionType, e.name,
+	)
+}
+
+func (e *undeclaredAttributeNameError) Unwrap() error { return ErrSyntaxError }
+
+// ValidateExpressionAttributeNamesDeclared returns an error when expression references an
+// attribute name placeholder (#name) that is absent from aliases (ExpressionAttributeNames),
+// matching DynamoDB which reports the first undeclared name. expressionType is the DynamoDB
+// expression label used in the message (e.g. "UpdateExpression", "FilterExpression").
+func ValidateExpressionAttributeNamesDeclared(expressionType, expression string, aliases map[string]string) error {
+	undeclared := language.UndeclaredExpressionAttributeNames(expression, aliases)
+	if len(undeclared) == 0 {
+		return nil
+	}
+
+	return &undeclaredAttributeNameError{expressionType: expressionType, name: undeclared[0]}
+}
 
 // ExpressionType type of the evaluated expression
 type ExpressionType string

--- a/interpreter/language.go
+++ b/interpreter/language.go
@@ -45,6 +45,10 @@ func (li *Language) Match(input MatchInput) (bool, error) {
 		return false, fmt.Errorf("%w: empty expression", ErrSyntaxError)
 	}
 
+	if err := ValidateExpressionAttributeNamesDeclared(matchExpressionLabel(input.ExpressionType), input.Expression, input.Aliases); err != nil {
+		return false, err
+	}
+
 	env := language.NewEnvironment()
 
 	aliases := map[string]string{}
@@ -83,6 +87,19 @@ func (li *Language) Match(input MatchInput) (bool, error) {
 	return result == language.TRUE, nil
 }
 
+// matchExpressionLabel maps a MatchInput expression type to its DynamoDB expression label
+// used in ValidationException messages.
+func matchExpressionLabel(t ExpressionType) string {
+	switch t {
+	case ExpressionTypeKey:
+		return "KeyConditionExpression"
+	case ExpressionTypeFilter:
+		return "FilterExpression"
+	default:
+		return "ConditionExpression"
+	}
+}
+
 // Project evaluates a projection expression and returns a new attribute map containing only the requested paths.
 func (li *Language) Project(input ProjectInput) (map[string]*types.Item, error) {
 	l := language.NewLexer(input.Expression)
@@ -91,6 +108,10 @@ func (li *Language) Project(input ProjectInput) (map[string]*types.Item, error) 
 
 	if len(p.Errors()) != 0 {
 		return nil, fmt.Errorf("Invalid ProjectionExpression: %w; %s", ErrSyntaxError, strings.Join(p.Errors(), "\n")) //nolint:stylecheck,staticcheck,ST1005 // consistent with AWS SDK errors
+	}
+
+	if err := ValidateExpressionAttributeNamesDeclared("ProjectionExpression", input.Expression, input.Aliases); err != nil {
+		return nil, err
 	}
 
 	env := language.NewEnvironment()
@@ -154,6 +175,10 @@ func (li *Language) Update(input UpdateInput) error {
 		}
 
 		return fmt.Errorf("%w: %s", errType, strings.Join(p.Errors(), "\n"))
+	}
+
+	if err := ValidateExpressionAttributeNamesDeclared("UpdateExpression", input.Expression, aliases); err != nil {
+		return err
 	}
 
 	item := map[string]*types.Item{}

--- a/interpreter/language/expression_attribute_name_validation.go
+++ b/interpreter/language/expression_attribute_name_validation.go
@@ -1,0 +1,32 @@
+package language
+
+import "strings"
+
+// UndeclaredExpressionAttributeNames scans the expression for attribute name placeholders
+// (#name) that are not declared in aliases (ExpressionAttributeNames), returning each
+// undeclared placeholder once in first-seen order. An empty expression yields no results.
+func UndeclaredExpressionAttributeNames(expression string, aliases map[string]string) []string {
+	l := NewLexer(expression)
+
+	seen := map[string]bool{}
+	undeclared := []string{}
+
+	for tok := l.NextToken(); tok.Type != EOF; tok = l.NextToken() {
+		if tok.Type != IDENT || !strings.HasPrefix(tok.Literal, "#") {
+			continue
+		}
+
+		if _, ok := aliases[tok.Literal]; ok {
+			continue
+		}
+
+		if seen[tok.Literal] {
+			continue
+		}
+
+		seen[tok.Literal] = true
+		undeclared = append(undeclared, tok.Literal)
+	}
+
+	return undeclared
+}

--- a/interpreter/language/expression_attribute_name_validation_test.go
+++ b/interpreter/language/expression_attribute_name_validation_test.go
@@ -1,0 +1,71 @@
+package language
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestUndeclaredExpressionAttributeNames(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name       string
+		expression string
+		aliases    map[string]string
+		want       []string
+	}{
+		{
+			name:       "all declared",
+			expression: "SET #a = :v",
+			aliases:    map[string]string{"#a": "attr"},
+			want:       []string{},
+		},
+		{
+			name:       "undeclared single",
+			expression: "SET #a = :v",
+			aliases:    nil,
+			want:       []string{"#a"},
+		},
+		{
+			name:       "undeclared in document path",
+			expression: "#a.#b = :v",
+			aliases:    map[string]string{"#a": "attr"},
+			want:       []string{"#b"},
+		},
+		{
+			name:       "deduplicated first-seen order",
+			expression: "#b = :x OR #a = :y OR #b = :z",
+			aliases:    nil,
+			want:       []string{"#b", "#a"},
+		},
+		{
+			name:       "no placeholders",
+			expression: "attr = :v",
+			aliases:    nil,
+			want:       []string{},
+		},
+		{
+			name:       "empty expression",
+			expression: "",
+			aliases:    nil,
+			want:       []string{},
+		},
+		{
+			name:       "value placeholders ignored",
+			expression: "#a = :v",
+			aliases:    map[string]string{"#a": "attr"},
+			want:       []string{},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := UndeclaredExpressionAttributeNames(tc.expression, tc.aliases)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("UndeclaredExpressionAttributeNames(%q) = %v, want %v", tc.expression, got, tc.want)
+			}
+		})
+	}
+}

--- a/interpreter/undeclared_attribute_name_test.go
+++ b/interpreter/undeclared_attribute_name_test.go
@@ -1,0 +1,118 @@
+package interpreter
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/truora/minidyn/types"
+)
+
+func TestUndeclaredExpressionAttributeNameErrors(t *testing.T) {
+	t.Parallel()
+
+	li := Language{}
+	item := map[string]*types.Item{
+		"id": {S: new("x")},
+	}
+
+	t.Run("UpdateExpression", func(t *testing.T) {
+		t.Parallel()
+
+		err := li.Update(UpdateInput{
+			Expression: "SET #a = :v",
+			Item:       item,
+			Attributes: map[string]*types.Item{":v": {S: new("y")}},
+		})
+		assertUndeclaredNameError(t, err, "UpdateExpression", "#a")
+	})
+
+	t.Run("ConditionExpression", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := li.Match(MatchInput{
+			Expression:     "attribute_not_exists(#a)",
+			ExpressionType: ExpressionTypeConditional,
+			Item:           item,
+		})
+		assertUndeclaredNameError(t, err, "ConditionExpression", "#a")
+	})
+
+	t.Run("FilterExpression", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := li.Match(MatchInput{
+			Expression:     "#a = :v",
+			ExpressionType: ExpressionTypeFilter,
+			Item:           item,
+			Attributes:     map[string]*types.Item{":v": {S: new("y")}},
+		})
+		assertUndeclaredNameError(t, err, "FilterExpression", "#a")
+	})
+
+	t.Run("KeyConditionExpression", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := li.Match(MatchInput{
+			Expression:     "#a = :v",
+			ExpressionType: ExpressionTypeKey,
+			Item:           item,
+			Attributes:     map[string]*types.Item{":v": {S: new("y")}},
+		})
+		assertUndeclaredNameError(t, err, "KeyConditionExpression", "#a")
+	})
+
+	t.Run("ProjectionExpression", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := li.Project(ProjectInput{
+			Expression: "#a",
+			Item:       item,
+		})
+		assertUndeclaredNameError(t, err, "ProjectionExpression", "#a")
+	})
+
+	t.Run("reports first undeclared name", func(t *testing.T) {
+		t.Parallel()
+
+		err := li.Update(UpdateInput{
+			Expression: "SET #b = :v REMOVE #c",
+			Item:       item,
+			Attributes: map[string]*types.Item{":v": {S: new("y")}},
+		})
+		assertUndeclaredNameError(t, err, "UpdateExpression", "#b")
+	})
+
+	t.Run("declared names do not error", func(t *testing.T) {
+		t.Parallel()
+
+		err := li.Update(UpdateInput{
+			Expression: "SET #a = :v",
+			Item:       item,
+			Attributes: map[string]*types.Item{":v": {S: new("y")}},
+			Aliases:    map[string]string{"#a": "attr"},
+		})
+		if err != nil {
+			t.Fatalf("unexpected error for declared name: %v", err)
+		}
+	})
+}
+
+func assertUndeclaredNameError(t *testing.T, err error, expressionType, name string) {
+	t.Helper()
+
+	if err == nil {
+		t.Fatalf("expected an error for undeclared %s name %q", expressionType, name)
+	}
+
+	want := "Invalid " + expressionType +
+		": An expression attribute name used in the document path is not defined; attribute name: " + name
+	if err.Error() != want {
+		t.Fatalf("error message mismatch\n got: %q\nwant: %q", err.Error(), want)
+	}
+
+	// Undeclared-name errors must be mapped to ValidationException by the same gating that
+	// handles expression syntax errors.
+	if !errors.Is(err, ErrSyntaxError) {
+		t.Fatalf("expected error to unwrap to ErrSyntaxError, got %v", err)
+	}
+}


### PR DESCRIPTION
## Why

DynamoDB rejects any expression that references a `#name` placeholder absent from `ExpressionAttributeNames`, returning a `ValidationException`. Minidyn silently resolved the undeclared placeholder to `UNDEFINED`, diverging from real DynamoDB across every expression type.

## What

- Add `UndeclaredExpressionAttributeNames` to scan an expression for `#name` placeholders missing from the aliases map (first-seen order).
- Reject undeclared names in `Match`, `Project`, and `Update` with a DynamoDB-parity message — `Invalid <Type>Expression: An expression attribute name used in the document path is not defined; attribute name: #a` — via a typed error that `Unwrap()`s to `ErrSyntaxError`, so the existing error→`ValidationException` mapping (incl. the TransactWriteItems update gate) handles it with no server changes.
- Validate `KeyCondition`/`Filter`/`Projection` up front in `SearchData`, so empty or unmatched tables still error like DynamoDB (the per-item interpreter checks would otherwise never run).
- Tests: E2E parity (`TestE2E_UndeclaredExpressionAttributeName`, 5 expression types), language-level, interpreter-level (full message + `ErrSyntaxError` unwrap), and core-level (`SearchData` up-front rejection). Updated `TestMatchKey` to declare its `#id` alias.

## Verification

- `go test` (non-e2e) ✓
- `go run ./tools/run-e2e` ✓ 233/233 parity cases
- `golangci-lint` 0 issues · `check_coverage.sh` exit 0 (new funcs 100% covered)

## Known gap

Transact condition expressions on Put/Delete/ConditionCheck surface undeclared names as `TransactionCanceled` rather than `ValidationException` (pre-existing transact error-mapping shape; the transact *update* path is correct). Not covered here.

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)