### PR TITLE
Support ReturnConsumedCapacity in all reporting operations

### DIFF
--- a/aws-v2/client/capacity.go
+++ b/aws-v2/client/capacity.go
@@ -1,0 +1,95 @@
+package client
+
+import (
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/truora/minidyn/capacity"
+)
+
+// toSDKConsumed maps a capacity.Consumed into the AWS SDK ConsumedCapacity shape.
+// It returns nil for a nil input (ReturnConsumedCapacity=NONE/unset), so callers can
+// assign the result directly and leave the field omitted.
+func toSDKConsumed(c *capacity.Consumed) *types.ConsumedCapacity {
+	if c == nil {
+		return nil
+	}
+
+	cc := &types.ConsumedCapacity{
+		TableName:     aws.String(c.TableName),
+		CapacityUnits: aws.Float64(c.CapacityUnits),
+	}
+
+	if c.ReadCapacityUnits != 0 {
+		cc.ReadCapacityUnits = aws.Float64(c.ReadCapacityUnits)
+	}
+
+	if c.WriteCapacityUnits != 0 {
+		cc.WriteCapacityUnits = aws.Float64(c.WriteCapacityUnits)
+	}
+
+	if c.Breakdown {
+		applySDKBreakdown(cc, c)
+	}
+
+	return cc
+}
+
+func applySDKBreakdown(cc *types.ConsumedCapacity, c *capacity.Consumed) {
+	entry := types.Capacity{CapacityUnits: aws.Float64(c.CapacityUnits)}
+
+	if c.ReadCapacityUnits != 0 {
+		entry.ReadCapacityUnits = aws.Float64(c.ReadCapacityUnits)
+	}
+
+	if c.WriteCapacityUnits != 0 {
+		entry.WriteCapacityUnits = aws.Float64(c.WriteCapacityUnits)
+	}
+
+	switch {
+	case c.IndexName != "" && c.IndexKind == "GSI":
+		cc.GlobalSecondaryIndexes = map[string]types.Capacity{c.IndexName: entry}
+	case c.IndexName != "" && c.IndexKind == "LSI":
+		cc.LocalSecondaryIndexes = map[string]types.Capacity{c.IndexName: entry}
+	default:
+		cc.Table = &entry
+	}
+}
+
+// consumedMode resolves the request's ReturnConsumedCapacity enum into a capacity.Mode.
+func consumedMode(s string) capacity.Mode {
+	return capacity.ParseMode(s)
+}
+
+// sdkConsumedSlice assembles the per-table ConsumedCapacity slice used by batch and
+// transactional operations from already-aggregated units. Tables with zero units are
+// omitted; nil is returned when nothing is reported (NONE/unset or empty).
+func sdkConsumedSlice(mode capacity.Mode, unitsByTable map[string]float64, isRead bool) []types.ConsumedCapacity {
+	if mode == capacity.ModeNone || len(unitsByTable) == 0 {
+		return nil
+	}
+
+	out := make([]types.ConsumedCapacity, 0, len(unitsByTable))
+
+	for table, units := range unitsByTable {
+		if units == 0 {
+			continue
+		}
+
+		var c *capacity.Consumed
+		if isRead {
+			c = capacity.ForReadUnits(mode, table, units)
+		} else {
+			c = capacity.ForWriteUnits(mode, table, units)
+		}
+
+		if cc := toSDKConsumed(c); cc != nil {
+			out = append(out, *cc)
+		}
+	}
+
+	if len(out) == 0 {
+		return nil
+	}
+
+	return out
+}

--- a/aws-v2/client/client.go
+++ b/aws-v2/client/client.go
@@ -15,6 +15,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 	"github.com/aws/smithy-go"
+	"github.com/truora/minidyn/capacity"
 	"github.com/truora/minidyn/core"
 	"github.com/truora/minidyn/interpreter"
 	mtypes "github.com/truora/minidyn/types"
@@ -373,11 +374,27 @@ func (fd *Client) PutItem(ctx context.Context, input *dynamodb.PutItemInput, opt
 		return nil, mapKnownError(err)
 	}
 
-	item, err := table.Put(mapDynamoToTypesPutItemInput(input))
+	putInput := mapDynamoToTypesPutItemInput(input)
+
+	newSize := capacity.Size(putInput.Item)
+
+	oldSize := 0
+	if key, kerr := table.KeySchema.GetKey(table.AttributesDef, putInput.Item); kerr == nil {
+		oldSize = capacity.Size(table.Data[key])
+	}
+
+	item, err := table.Put(putInput)
+	if err != nil {
+		return &dynamodb.PutItemOutput{Attributes: mapTypesToDynamoMapItem(item)}, mapKnownError(err)
+	}
 
 	return &dynamodb.PutItemOutput{
 		Attributes: mapTypesToDynamoMapItem(item),
-	}, mapKnownError(err)
+		ConsumedCapacity: toSDKConsumed(capacity.ForWrite(
+			consumedMode(string(input.ReturnConsumedCapacity)),
+			aws.ToString(input.TableName), max(oldSize, newSize),
+		)),
+	}, nil
 }
 
 // DeleteItem mock response for dynamodb
@@ -417,18 +434,31 @@ func (fd *Client) DeleteItem(ctx context.Context, input *dynamodb.DeleteItemInpu
 		}
 	}
 
-	item, err := table.Delete(mapDynamoToTypesDeleteItemInput(input))
+	deleteInput := mapDynamoToTypesDeleteItemInput(input)
+
+	item, err := table.Delete(deleteInput)
 	if err != nil {
 		return nil, mapKnownError(err)
 	}
 
+	sizeSource := item
+	if len(sizeSource) == 0 {
+		sizeSource = deleteInput.Key
+	}
+
+	consumed := toSDKConsumed(capacity.ForWrite(
+		consumedMode(string(input.ReturnConsumedCapacity)),
+		aws.ToString(input.TableName), capacity.Size(sizeSource),
+	))
+
 	if string(input.ReturnValues) == "ALL_OLD" {
 		return &dynamodb.DeleteItemOutput{
-			Attributes: mapTypesToDynamoMapItem(item),
+			Attributes:       mapTypesToDynamoMapItem(item),
+			ConsumedCapacity: consumed,
 		}, nil
 	}
 
-	return &dynamodb.DeleteItemOutput{}, nil
+	return &dynamodb.DeleteItemOutput{ConsumedCapacity: consumed}, nil
 }
 
 // UpdateItem mock response for dynamodb
@@ -450,7 +480,16 @@ func (fd *Client) UpdateItem(ctx context.Context, input *dynamodb.UpdateItemInpu
 		return nil, mapKnownError(err)
 	}
 
-	item, err := table.Update(mapDynamoToTypesUpdateItemInput(input))
+	updateInput := mapDynamoToTypesUpdateItemInput(input)
+
+	updateKey, keyErr := table.KeySchema.GetKey(table.AttributesDef, updateInput.Key)
+
+	beforeSize := 0
+	if keyErr == nil {
+		beforeSize = capacity.Size(table.Data[updateKey])
+	}
+
+	item, err := table.Update(updateInput)
 	if err != nil {
 		if errors.Is(err, interpreter.ErrSyntaxError) {
 			return nil, &smithy.GenericAPIError{Code: "ValidationException", Message: err.Error()}
@@ -459,7 +498,17 @@ func (fd *Client) UpdateItem(ctx context.Context, input *dynamodb.UpdateItemInpu
 		return nil, mapKnownError(err)
 	}
 
-	output := &dynamodb.UpdateItemOutput{}
+	afterSize := beforeSize
+	if keyErr == nil {
+		afterSize = capacity.Size(table.Data[updateKey])
+	}
+
+	output := &dynamodb.UpdateItemOutput{
+		ConsumedCapacity: toSDKConsumed(capacity.ForWrite(
+			consumedMode(string(input.ReturnConsumedCapacity)),
+			aws.ToString(input.TableName), max(beforeSize, afterSize),
+		)),
+	}
 
 	if item != nil {
 		output.Attributes = mapTypesToDynamoMapItem(item)
@@ -512,6 +561,17 @@ func (fd *Client) GetItem(ctx context.Context, input *dynamodb.GetItemInput, opt
 		Item: copyItem(item),
 	}
 
+	sizeSource := stored
+	if len(sizeSource) == 0 {
+		sizeSource = keyMap
+	}
+
+	output.ConsumedCapacity = toSDKConsumed(capacity.ForRead(
+		consumedMode(string(input.ReturnConsumedCapacity)),
+		aws.ToString(input.TableName), "", "",
+		capacity.Size(sizeSource), aws.ToBool(input.ConsistentRead),
+	))
+
 	return output, nil
 }
 
@@ -555,6 +615,12 @@ func (fd *Client) Query(ctx context.Context, input *dynamodb.QueryInput, opt ...
 		Count:            int32(count),
 		LastEvaluatedKey: mapTypesToDynamoMapItem(lastKey),
 	}
+
+	output.ConsumedCapacity = toSDKConsumed(capacity.ForRead(
+		consumedMode(string(input.ReturnConsumedCapacity)),
+		aws.ToString(input.TableName), indexName, table.IndexKind(indexName),
+		capacity.SumSize(items), aws.ToBool(input.ConsistentRead),
+	))
 
 	return output, nil
 }
@@ -606,6 +672,12 @@ func (fd *Client) Scan(ctx context.Context, input *dynamodb.ScanInput, opt ...fu
 		LastEvaluatedKey: mapTypesToDynamoMapItem(lastKey),
 	}
 
+	output.ConsumedCapacity = toSDKConsumed(capacity.ForRead(
+		consumedMode(string(input.ReturnConsumedCapacity)),
+		aws.ToString(input.TableName), indexName, table.IndexKind(indexName),
+		capacity.SumSize(items), aws.ToBool(input.ConsistentRead),
+	))
+
 	return output, nil
 }
 
@@ -640,6 +712,7 @@ func (fd *Client) BatchWriteItem(ctx context.Context, input *dynamodb.BatchWrite
 	}
 
 	unprocessed := map[string][]types.WriteRequest{}
+	unitsByTable := map[string]float64{}
 
 	for table, reqs := range input.RequestItems {
 		for i, req := range reqs {
@@ -652,13 +725,30 @@ func (fd *Client) BatchWriteItem(ctx context.Context, input *dynamodb.BatchWrite
 			if err := executeBatchWriteRequest(ctx, fd, aws.String(table), req); err != nil {
 				return &dynamodb.BatchWriteItemOutput{}, err
 			}
+
+			unitsByTable[table] += capacity.WriteUnits(capacity.Size(batchWriteRequestItem(req)))
 		}
 	}
 
 	return &dynamodb.BatchWriteItemOutput{
 		UnprocessedItems:      unprocessed,
 		ItemCollectionMetrics: fd.itemCollectionMetrics,
+		ConsumedCapacity:      sdkConsumedSlice(consumedMode(string(input.ReturnConsumedCapacity)), unitsByTable, false),
 	}, nil
+}
+
+// batchWriteRequestItem returns the item used to size a write request: the put item, or
+// the delete key when sizing a delete.
+func batchWriteRequestItem(req types.WriteRequest) map[string]*mtypes.Item {
+	if req.PutRequest != nil {
+		return mapDynamoToTypesMapItem(req.PutRequest.Item)
+	}
+
+	if req.DeleteRequest != nil {
+		return mapDynamoToTypesMapItem(req.DeleteRequest.Key)
+	}
+
+	return nil
 }
 
 func tableNames[V any](requestItems map[string]V) []string {
@@ -694,10 +784,13 @@ func (fd *Client) BatchGetItem(ctx context.Context, input *dynamodb.BatchGetItem
 
 	responses := make(map[string][]map[string]types.AttributeValue, len(input.RequestItems))
 	unprocessed := make(map[string]types.KeysAndAttributes, len(input.RequestItems))
+	unitsByTable := map[string]float64{}
 
 	for tableName, reqs := range input.RequestItems {
 		unprocessedKeys := make([]map[string]types.AttributeValue, 0, len(reqs.Keys))
 		responses[tableName] = make([]map[string]types.AttributeValue, 0, len(reqs.Keys))
+
+		consistent := aws.ToBool(reqs.ConsistentRead)
 
 		for i, req := range reqs.Keys {
 			if emulation.unprocessed(tableName, i, req) {
@@ -720,6 +813,8 @@ func (fd *Client) BatchGetItem(ctx context.Context, input *dynamodb.BatchGetItem
 				return nil, err
 			}
 
+			unitsByTable[tableName] += capacity.ReadUnits(capacity.Size(mapDynamoToTypesMapItem(out.Item)), consistent)
+
 			if len(out.Item) > 0 {
 				responses[tableName] = append(responses[tableName], out.Item)
 			}
@@ -736,8 +831,9 @@ func (fd *Client) BatchGetItem(ctx context.Context, input *dynamodb.BatchGetItem
 	}
 
 	return &dynamodb.BatchGetItemOutput{
-		Responses:       responses,
-		UnprocessedKeys: unprocessed,
+		Responses:        responses,
+		UnprocessedKeys:  unprocessed,
+		ConsumedCapacity: sdkConsumedSlice(consumedMode(string(input.ReturnConsumedCapacity)), unitsByTable, true),
 	}, nil
 }
 
@@ -885,7 +981,60 @@ func (fd *Client) TransactWriteItems(ctx context.Context, input *dynamodb.Transa
 		}
 	}
 
-	return &dynamodb.TransactWriteItemsOutput{}, nil
+	mode := consumedMode(string(input.ReturnConsumedCapacity))
+	unitsByTable := map[string]float64{}
+
+	for _, item := range input.TransactItems {
+		tableName, size := fd.transactWriteSize(item)
+		if tableName == "" {
+			continue
+		}
+
+		unitsByTable[tableName] += 2 * capacity.WriteUnits(size)
+	}
+
+	return &dynamodb.TransactWriteItemsOutput{
+		ConsumedCapacity: sdkConsumedSlice(mode, unitsByTable, false),
+	}, nil
+}
+
+// transactWriteSize returns the table name and byte size used to bill a transact write item.
+// Update sizes the stored item after the update; Delete/ConditionCheck size the key.
+func (fd *Client) transactWriteSize(item types.TransactWriteItem) (string, int) {
+	switch {
+	case item.Put != nil:
+		return aws.ToString(item.Put.TableName), capacity.Size(mapDynamoToTypesMapItem(item.Put.Item))
+	case item.Update != nil:
+		return aws.ToString(item.Update.TableName), fd.itemSizeByKey(aws.ToString(item.Update.TableName), item.Update.Key)
+	case item.Delete != nil:
+		return aws.ToString(item.Delete.TableName), capacity.Size(mapDynamoToTypesMapItem(item.Delete.Key))
+	case item.ConditionCheck != nil:
+		return aws.ToString(item.ConditionCheck.TableName), capacity.Size(mapDynamoToTypesMapItem(item.ConditionCheck.Key))
+	default:
+		return "", 0
+	}
+}
+
+// itemSizeByKey returns the byte size of the stored item for a key, falling back to the
+// key's own size when the table or item is not found.
+func (fd *Client) itemSizeByKey(tableName string, key map[string]types.AttributeValue) int {
+	keyMap := mapDynamoToTypesMapItem(key)
+
+	table, err := fd.getTable(tableName)
+	if err != nil {
+		return capacity.Size(keyMap)
+	}
+
+	k, err := table.KeySchema.GetKey(table.AttributesDef, keyMap)
+	if err != nil {
+		return capacity.Size(keyMap)
+	}
+
+	if stored := table.Data[k]; len(stored) > 0 {
+		return capacity.Size(stored)
+	}
+
+	return capacity.Size(keyMap)
 }
 
 func validateTransactGetItemsInput(fd *Client, input *dynamodb.TransactGetItemsInput) error {
@@ -973,6 +1122,8 @@ func (fd *Client) TransactGetItems(ctx context.Context, input *dynamodb.Transact
 	}
 
 	responses := make([]types.ItemResponse, 0, len(input.TransactItems))
+	mode := consumedMode(string(input.ReturnConsumedCapacity))
+	unitsByTable := map[string]float64{}
 
 	for _, item := range input.TransactItems {
 		get := item.Get
@@ -988,9 +1139,14 @@ func (fd *Client) TransactGetItems(ctx context.Context, input *dynamodb.Transact
 		}
 
 		responses = append(responses, types.ItemResponse{Item: out.Item})
+
+		unitsByTable[aws.ToString(get.TableName)] += 2 * capacity.ReadUnits(capacity.Size(mapDynamoToTypesMapItem(out.Item)), true)
 	}
 
-	return &dynamodb.TransactGetItemsOutput{Responses: responses}, nil
+	return &dynamodb.TransactGetItemsOutput{
+		Responses:        responses,
+		ConsumedCapacity: sdkConsumedSlice(mode, unitsByTable, true),
+	}, nil
 }
 
 func (fd *Client) runTransactItem(i, n int, item types.TransactWriteItem) error {

--- a/aws-v2/client/consumed_capacity_test.go
+++ b/aws-v2/client/consumed_capacity_test.go
@@ -1,0 +1,332 @@
+package client
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	dynamodbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/stretchr/testify/require"
+	"github.com/truora/minidyn/capacity"
+)
+
+func setupCapacityClient(t *testing.T) *Client {
+	t.Helper()
+
+	client := NewClient()
+	require.NoError(t, ensurePokemonTable(client))
+	require.NoError(t, createPokemon(client, pokemon{ID: "001", Type: "grass", Name: "Bulbasaur"}))
+
+	return client
+}
+
+func keyID(id string) map[string]dynamodbtypes.AttributeValue {
+	return map[string]dynamodbtypes.AttributeValue{
+		"id": &dynamodbtypes.AttributeValueMemberS{Value: id},
+	}
+}
+
+func TestToSDKConsumedBreakdowns(t *testing.T) {
+	c := require.New(t)
+
+	c.Nil(toSDKConsumed(nil))
+
+	gsi := toSDKConsumed(&capacity.Consumed{TableName: "t", CapacityUnits: 1, ReadCapacityUnits: 1, Breakdown: true, IndexName: "i", IndexKind: "GSI"})
+	c.Contains(gsi.GlobalSecondaryIndexes, "i")
+	c.Nil(gsi.Table)
+
+	lsi := toSDKConsumed(&capacity.Consumed{TableName: "t", CapacityUnits: 1, WriteCapacityUnits: 1, Breakdown: true, IndexName: "i", IndexKind: "LSI"})
+	c.Contains(lsi.LocalSecondaryIndexes, "i")
+
+	tbl := toSDKConsumed(&capacity.Consumed{TableName: "t", CapacityUnits: 1, ReadCapacityUnits: 1, Breakdown: true})
+	c.NotNil(tbl.Table)
+}
+
+func TestSDKConsumedSlice(t *testing.T) {
+	c := require.New(t)
+
+	c.Nil(sdkConsumedSlice(capacity.ModeNone, map[string]float64{"t": 1}, true))
+	c.Nil(sdkConsumedSlice(capacity.ModeTotal, map[string]float64{}, true))
+	c.Nil(sdkConsumedSlice(capacity.ModeTotal, map[string]float64{"t": 0}, true)) // zero-unit table skipped
+
+	out := sdkConsumedSlice(capacity.ModeTotal, map[string]float64{"t": 2}, false)
+	c.Len(out, 1)
+	c.Equal(2.0, aws.ToFloat64(out[0].WriteCapacityUnits))
+}
+
+func TestItemSizeByKey(t *testing.T) {
+	c := require.New(t)
+	client := setupCapacityClient(t)
+
+	c.Greater(client.itemSizeByKey(tableName, keyID("001")), 0)                                     // stored item
+	c.Greater(client.itemSizeByKey(tableName, keyID("absent")), 0)                                  // missing item -> key size
+	c.Greater(client.itemSizeByKey("no-such-table", keyID("001")), 0)                               // missing table -> key size
+	c.GreaterOrEqual(client.itemSizeByKey(tableName, map[string]dynamodbtypes.AttributeValue{}), 0) // bad key -> key size
+}
+
+func TestTransactWriteItemsConsumedCapacityUpdate(t *testing.T) {
+	c := require.New(t)
+	client := setupCapacityClient(t)
+
+	out, err := client.TransactWriteItems(context.Background(), &dynamodb.TransactWriteItemsInput{
+		ReturnConsumedCapacity: dynamodbtypes.ReturnConsumedCapacityTotal,
+		TransactItems: []dynamodbtypes.TransactWriteItem{
+			{Update: &dynamodbtypes.Update{
+				TableName:                aws.String(tableName),
+				Key:                      keyID("001"),
+				UpdateExpression:         aws.String("SET #t = :t"),
+				ExpressionAttributeNames: map[string]string{"#t": "type"},
+				ExpressionAttributeValues: map[string]dynamodbtypes.AttributeValue{
+					":t": &dynamodbtypes.AttributeValueMemberS{Value: "ice"},
+				},
+			}},
+		},
+	})
+	c.NoError(err)
+	c.Len(out.ConsumedCapacity, 1)
+	c.Greater(aws.ToFloat64(out.ConsumedCapacity[0].WriteCapacityUnits), 0.0)
+}
+
+func TestGetItemConsumedCapacity(t *testing.T) {
+	c := require.New(t)
+	client := setupCapacityClient(t)
+	ctx := context.Background()
+
+	out, err := client.GetItem(ctx, &dynamodb.GetItemInput{
+		TableName:              aws.String(tableName),
+		Key:                    keyID("001"),
+		ConsistentRead:         aws.Bool(true),
+		ReturnConsumedCapacity: dynamodbtypes.ReturnConsumedCapacityTotal,
+	})
+	c.NoError(err)
+	c.NotNil(out.ConsumedCapacity)
+	c.Equal(tableName, aws.ToString(out.ConsumedCapacity.TableName))
+	c.Greater(aws.ToFloat64(out.ConsumedCapacity.CapacityUnits), 0.0)
+	c.Equal(aws.ToFloat64(out.ConsumedCapacity.CapacityUnits), aws.ToFloat64(out.ConsumedCapacity.ReadCapacityUnits))
+	c.Nil(out.ConsumedCapacity.Table) // TOTAL has no breakdown
+
+	// Eventually consistent read costs half of a strongly consistent one.
+	eventual, err := client.GetItem(ctx, &dynamodb.GetItemInput{
+		TableName:              aws.String(tableName),
+		Key:                    keyID("001"),
+		ReturnConsumedCapacity: dynamodbtypes.ReturnConsumedCapacityTotal,
+	})
+	c.NoError(err)
+	c.Equal(aws.ToFloat64(out.ConsumedCapacity.CapacityUnits)/2, aws.ToFloat64(eventual.ConsumedCapacity.CapacityUnits))
+}
+
+func TestGetItemConsumedCapacityOmittedWhenNone(t *testing.T) {
+	c := require.New(t)
+	client := setupCapacityClient(t)
+
+	out, err := client.GetItem(context.Background(), &dynamodb.GetItemInput{
+		TableName: aws.String(tableName),
+		Key:       keyID("001"),
+	})
+	c.NoError(err)
+	c.Nil(out.ConsumedCapacity)
+}
+
+func TestGetItemConsumedCapacityMissingItem(t *testing.T) {
+	c := require.New(t)
+	client := setupCapacityClient(t)
+
+	out, err := client.GetItem(context.Background(), &dynamodb.GetItemInput{
+		TableName:              aws.String(tableName),
+		Key:                    keyID("does-not-exist"),
+		ConsistentRead:         aws.Bool(true),
+		ReturnConsumedCapacity: dynamodbtypes.ReturnConsumedCapacityTotal,
+	})
+	c.NoError(err)
+	c.NotNil(out.ConsumedCapacity)
+	c.Equal(1.0, aws.ToFloat64(out.ConsumedCapacity.CapacityUnits)) // min 1 read unit
+}
+
+func TestPutItemConsumedCapacity(t *testing.T) {
+	c := require.New(t)
+	client := setupCapacityClient(t)
+
+	out, err := client.PutItem(context.Background(), &dynamodb.PutItemInput{
+		TableName: aws.String(tableName),
+		Item: map[string]dynamodbtypes.AttributeValue{
+			"id":   &dynamodbtypes.AttributeValueMemberS{Value: "010"},
+			"name": &dynamodbtypes.AttributeValueMemberS{Value: "Caterpie"},
+		},
+		ReturnConsumedCapacity: dynamodbtypes.ReturnConsumedCapacityTotal,
+	})
+	c.NoError(err)
+	c.NotNil(out.ConsumedCapacity)
+	c.Greater(aws.ToFloat64(out.ConsumedCapacity.CapacityUnits), 0.0)
+	c.Equal(aws.ToFloat64(out.ConsumedCapacity.CapacityUnits), aws.ToFloat64(out.ConsumedCapacity.WriteCapacityUnits))
+	c.Nil(out.ConsumedCapacity.ReadCapacityUnits)
+}
+
+func TestUpdateItemConsumedCapacity(t *testing.T) {
+	c := require.New(t)
+	client := setupCapacityClient(t)
+
+	out, err := client.UpdateItem(context.Background(), &dynamodb.UpdateItemInput{
+		TableName:                aws.String(tableName),
+		Key:                      keyID("001"),
+		UpdateExpression:         aws.String("SET #t = :t"),
+		ExpressionAttributeNames: map[string]string{"#t": "type"},
+		ExpressionAttributeValues: map[string]dynamodbtypes.AttributeValue{
+			":t": &dynamodbtypes.AttributeValueMemberS{Value: "poison"},
+		},
+		ReturnConsumedCapacity: dynamodbtypes.ReturnConsumedCapacityTotal,
+	})
+	c.NoError(err)
+	c.NotNil(out.ConsumedCapacity)
+	c.Greater(aws.ToFloat64(out.ConsumedCapacity.WriteCapacityUnits), 0.0)
+}
+
+func TestDeleteItemConsumedCapacity(t *testing.T) {
+	c := require.New(t)
+	client := setupCapacityClient(t)
+
+	out, err := client.DeleteItem(context.Background(), &dynamodb.DeleteItemInput{
+		TableName:              aws.String(tableName),
+		Key:                    keyID("001"),
+		ReturnConsumedCapacity: dynamodbtypes.ReturnConsumedCapacityTotal,
+	})
+	c.NoError(err)
+	c.NotNil(out.ConsumedCapacity)
+	c.Greater(aws.ToFloat64(out.ConsumedCapacity.WriteCapacityUnits), 0.0)
+}
+
+func TestQueryConsumedCapacity(t *testing.T) {
+	c := require.New(t)
+	client := setupCapacityClient(t)
+
+	out, err := client.Query(context.Background(), &dynamodb.QueryInput{
+		TableName:                aws.String(tableName),
+		KeyConditionExpression:   aws.String("#id = :id"),
+		ExpressionAttributeNames: map[string]string{"#id": "id"},
+		ExpressionAttributeValues: map[string]dynamodbtypes.AttributeValue{
+			":id": &dynamodbtypes.AttributeValueMemberS{Value: "001"},
+		},
+		ReturnConsumedCapacity: dynamodbtypes.ReturnConsumedCapacityTotal,
+	})
+	c.NoError(err)
+	c.NotNil(out.ConsumedCapacity)
+	c.Greater(aws.ToFloat64(out.ConsumedCapacity.ReadCapacityUnits), 0.0)
+}
+
+func TestQueryIndexConsumedCapacityIndexes(t *testing.T) {
+	c := require.New(t)
+	client := setupCapacityClient(t)
+	c.NoError(ensurePokemonTypeIndex(client))
+	c.NoError(createPokemon(client, pokemon{ID: "004", Type: "fire", Name: "Charmander"}))
+
+	out, err := client.Query(context.Background(), &dynamodb.QueryInput{
+		TableName:                aws.String(tableName),
+		IndexName:                aws.String("by-type"),
+		KeyConditionExpression:   aws.String("#t = :t"),
+		ExpressionAttributeNames: map[string]string{"#t": "type"},
+		ExpressionAttributeValues: map[string]dynamodbtypes.AttributeValue{
+			":t": &dynamodbtypes.AttributeValueMemberS{Value: "fire"},
+		},
+		ReturnConsumedCapacity: dynamodbtypes.ReturnConsumedCapacityIndexes,
+	})
+	c.NoError(err)
+	c.NotNil(out.ConsumedCapacity)
+	c.Contains(out.ConsumedCapacity.GlobalSecondaryIndexes, "by-type")
+	c.Nil(out.ConsumedCapacity.Table) // index read attributes capacity to the index
+}
+
+func TestScanConsumedCapacity(t *testing.T) {
+	c := require.New(t)
+	client := setupCapacityClient(t)
+
+	out, err := client.Scan(context.Background(), &dynamodb.ScanInput{
+		TableName:              aws.String(tableName),
+		ReturnConsumedCapacity: dynamodbtypes.ReturnConsumedCapacityTotal,
+	})
+	c.NoError(err)
+	c.NotNil(out.ConsumedCapacity)
+	c.Greater(aws.ToFloat64(out.ConsumedCapacity.ReadCapacityUnits), 0.0)
+}
+
+func TestBatchGetItemConsumedCapacity(t *testing.T) {
+	c := require.New(t)
+	client := setupCapacityClient(t)
+
+	out, err := client.BatchGetItem(context.Background(), &dynamodb.BatchGetItemInput{
+		ReturnConsumedCapacity: dynamodbtypes.ReturnConsumedCapacityTotal,
+		RequestItems: map[string]dynamodbtypes.KeysAndAttributes{
+			tableName: {Keys: []map[string]dynamodbtypes.AttributeValue{keyID("001")}},
+		},
+	})
+	c.NoError(err)
+	c.Len(out.ConsumedCapacity, 1)
+	c.Equal(tableName, aws.ToString(out.ConsumedCapacity[0].TableName))
+	c.Greater(aws.ToFloat64(out.ConsumedCapacity[0].CapacityUnits), 0.0)
+}
+
+func TestBatchWriteItemConsumedCapacity(t *testing.T) {
+	c := require.New(t)
+	client := setupCapacityClient(t)
+
+	out, err := client.BatchWriteItem(context.Background(), &dynamodb.BatchWriteItemInput{
+		ReturnConsumedCapacity: dynamodbtypes.ReturnConsumedCapacityTotal,
+		RequestItems: map[string][]dynamodbtypes.WriteRequest{
+			tableName: {
+				{PutRequest: &dynamodbtypes.PutRequest{Item: map[string]dynamodbtypes.AttributeValue{
+					"id": &dynamodbtypes.AttributeValueMemberS{Value: "020"},
+				}}},
+			},
+		},
+	})
+	c.NoError(err)
+	c.Len(out.ConsumedCapacity, 1)
+	c.Greater(aws.ToFloat64(out.ConsumedCapacity[0].WriteCapacityUnits), 0.0)
+}
+
+func TestTransactGetItemsConsumedCapacity(t *testing.T) {
+	c := require.New(t)
+	client := setupCapacityClient(t)
+
+	out, err := client.TransactGetItems(context.Background(), &dynamodb.TransactGetItemsInput{
+		ReturnConsumedCapacity: dynamodbtypes.ReturnConsumedCapacityTotal,
+		TransactItems: []dynamodbtypes.TransactGetItem{
+			{Get: &dynamodbtypes.Get{TableName: aws.String(tableName), Key: keyID("001")}},
+		},
+	})
+	c.NoError(err)
+	c.Len(out.ConsumedCapacity, 1)
+	c.Greater(aws.ToFloat64(out.ConsumedCapacity[0].CapacityUnits), 0.0)
+}
+
+func TestTransactWriteItemsConsumedCapacityDoublesWrite(t *testing.T) {
+	c := require.New(t)
+	client := setupCapacityClient(t)
+
+	item := map[string]dynamodbtypes.AttributeValue{
+		"id":   &dynamodbtypes.AttributeValueMemberS{Value: "030"},
+		"name": &dynamodbtypes.AttributeValueMemberS{Value: "Pidgey"},
+	}
+
+	batch, err := client.BatchWriteItem(context.Background(), &dynamodb.BatchWriteItemInput{
+		ReturnConsumedCapacity: dynamodbtypes.ReturnConsumedCapacityTotal,
+		RequestItems: map[string][]dynamodbtypes.WriteRequest{
+			tableName: {{PutRequest: &dynamodbtypes.PutRequest{Item: item}}},
+		},
+	})
+	c.NoError(err)
+	c.Len(batch.ConsumedCapacity, 1)
+
+	txn, err := client.TransactWriteItems(context.Background(), &dynamodb.TransactWriteItemsInput{
+		ReturnConsumedCapacity: dynamodbtypes.ReturnConsumedCapacityTotal,
+		TransactItems: []dynamodbtypes.TransactWriteItem{
+			{Put: &dynamodbtypes.Put{TableName: aws.String(tableName), Item: item}},
+		},
+	})
+	c.NoError(err)
+	c.Len(txn.ConsumedCapacity, 1)
+
+	c.Equal(
+		2*aws.ToFloat64(batch.ConsumedCapacity[0].CapacityUnits),
+		aws.ToFloat64(txn.ConsumedCapacity[0].CapacityUnits),
+	)
+}

--- a/calculate-size/attribute_value.go
+++ b/calculate-size/attribute_value.go
@@ -1,0 +1,203 @@
+package docsize
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+)
+
+// sizeAttributeValue sizes one DynamoDB AttributeValue object (exactly one of S, N, M, L, ...).
+// This matches AWS item accounting and https://zaccharles.github.io/dynamodb-calculator/ (not dynamodb-size-js Map-wrapping).
+func sizeAttributeValue(attr map[string]any) (int, error) { //nolint:gocognit,gocyclo // single switch over every AttributeValue type
+	if len(attr) != 1 {
+		return 0, fmt.Errorf("attribute value must have exactly one type key, got %d keys", len(attr))
+	}
+
+	for k, v := range attr {
+		switch k {
+		case "S":
+			s, ok := v.(string)
+			if !ok {
+				return 0, fmt.Errorf("value for S must be string, got %T", v)
+			}
+
+			return calculateString(s), nil
+		case "N":
+			ns, err := coerceNumberString(v)
+			if err != nil {
+				return 0, err
+			}
+
+			return dynamoNumberSizeBytes(ns), nil
+		case "B":
+			s, ok := v.(string)
+			if !ok {
+				return 0, fmt.Errorf("value for B must be base64 string, got %T", v)
+			}
+
+			raw, err := base64.StdEncoding.DecodeString(s)
+			if err != nil {
+				return 0, fmt.Errorf("decoding B as base64: %w", err)
+			}
+
+			return len(raw), nil
+		case "BOOL":
+			switch v.(type) {
+			case bool, string:
+				return calculateBoolean(), nil
+			default:
+				return 0, fmt.Errorf("BOOL value must be bool or string, got %T", v)
+			}
+		case "NULL":
+			switch v.(type) {
+			case bool, string:
+				return calculateNull(), nil
+			default:
+				return 0, fmt.Errorf("NULL value must be bool or string, got %T", v)
+			}
+		case "SS":
+			arr, err := coerceStringSlice(v)
+			if err != nil {
+				return 0, err
+			}
+
+			sum := 0
+
+			for _, s := range arr {
+				sum += calculateString(s)
+			}
+
+			return sum, nil
+		case "NS":
+			arr, ok := v.([]any)
+			if !ok {
+				return 0, fmt.Errorf("NS value must be array, got %T", v)
+			}
+
+			sum := 0
+
+			for i, el := range arr {
+				ns, err := coerceNumberString(el)
+				if err != nil {
+					return 0, fmt.Errorf("NS[%d]: %w", i, err)
+				}
+
+				sum += dynamoNumberSizeBytes(ns)
+			}
+
+			return sum, nil
+		case "BS":
+			arr, ok := v.([]any)
+			if !ok {
+				return 0, fmt.Errorf("BS value must be array, got %T", v)
+			}
+
+			sum := 0
+
+			for i, el := range arr {
+				s, ok := el.(string)
+				if !ok {
+					return 0, fmt.Errorf("BS[%d] must be base64 string, got %T", i, el)
+				}
+
+				raw, err := base64.StdEncoding.DecodeString(s)
+				if err != nil {
+					return 0, fmt.Errorf("BS[%d] base64: %w", i, err)
+				}
+
+				sum += len(raw)
+			}
+
+			return sum, nil
+		case "M":
+			m, ok := v.(map[string]any)
+			if !ok {
+				return 0, fmt.Errorf("value for M must be object, got %T", v)
+			}
+
+			return sizeDynamoMapValue(m)
+		case "L":
+			arr, ok := v.([]any)
+			if !ok {
+				return 0, fmt.Errorf("value for L must be array, got %T", v)
+			}
+
+			return sizeDynamoListValue(arr)
+		default:
+			return 0, fmt.Errorf("unknown attribute type key %q", k)
+		}
+	}
+
+	return 0, fmt.Errorf("empty attribute value")
+}
+
+func sizeDynamoMapValue(m map[string]any) (int, error) {
+	size := compositeItemOverhead
+
+	for key, val := range m {
+		av, ok := val.(map[string]any)
+		if !ok {
+			return 0, fmt.Errorf("map key %q: expected AttributeValue object, got %T", key, val)
+		}
+
+		inner, err := sizeAttributeValue(av)
+		if err != nil {
+			return 0, fmt.Errorf("map key %q: %w", key, err)
+		}
+
+		size += calculateString(key) + inner + nestedItemOverhead
+	}
+
+	return size, nil
+}
+
+func sizeDynamoListValue(items []any) (int, error) {
+	size := compositeItemOverhead
+
+	for i, el := range items {
+		av, ok := el.(map[string]any)
+		if !ok {
+			return 0, fmt.Errorf("list index %d: expected AttributeValue object, got %T", i, el)
+		}
+
+		inner, err := sizeAttributeValue(av)
+		if err != nil {
+			return 0, fmt.Errorf("list index %d: %w", i, err)
+		}
+
+		size += inner + nestedItemOverhead
+	}
+
+	return size, nil
+}
+
+func coerceNumberString(v any) (string, error) {
+	switch x := v.(type) {
+	case string:
+		return x, nil
+	case json.Number:
+		return string(x), nil
+	default:
+		return "", fmt.Errorf("value for N must be string or number, got %T", v)
+	}
+}
+
+func coerceStringSlice(v any) ([]string, error) {
+	arr, ok := v.([]any)
+	if !ok {
+		return nil, fmt.Errorf("SS value must be array, got %T", v)
+	}
+
+	out := make([]string, len(arr))
+
+	for i, el := range arr {
+		s, ok := el.(string)
+		if !ok {
+			return nil, fmt.Errorf("SS[%d] must be string, got %T", i, el)
+		}
+
+		out[i] = s
+	}
+
+	return out, nil
+}

--- a/calculate-size/coverage_test.go
+++ b/calculate-size/coverage_test.go
@@ -1,0 +1,142 @@
+package docsize
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestCalculateDocumentSize_DocumentSetNumbers(t *testing.T) {
+	// Number set with mixed Go numeric kinds exercises toFloat64 + trimFloatJSON:
+	//   1.5        -> "1.5" -> 3
+	//   int64(22)  -> "22"  -> 2
+	//   float32(2) -> "2"   -> 2
+	//   json.Number("7")    -> 2
+	// sum = 9, plus name "n" (1) = 10
+	doc := map[string]any{
+		"n": DocumentSet{Type: "Number", Values: []any{1.5, int64(22), float32(2), json.Number("7")}},
+	}
+
+	got, err := CalculateDocumentSize(doc)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got != 10 {
+		t.Fatalf("got=%d want 10", got)
+	}
+}
+
+func TestCalculateDocumentSize_DocumentSetBinary(t *testing.T) {
+	// Binary set with a raw []byte (3 bytes) and a base64 string ("AAEC" -> 3 bytes)
+	// sum = 6, plus name "b" (1) = 7
+	doc := map[string]any{
+		"b": DocumentSet{Type: "Binary", Values: []any{[]byte{1, 2, 3}, "AAEC"}},
+	}
+
+	got, err := CalculateDocumentSize(doc)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got != 7 {
+		t.Fatalf("got=%d want 7", got)
+	}
+}
+
+func TestCalculateDocumentSize_DocumentSetUnknownType(t *testing.T) {
+	// Unknown set type contributes 0; only the name "x" (1) is counted.
+	doc := map[string]any{
+		"x": DocumentSet{Type: "Mystery", Values: []any{"a"}},
+	}
+
+	got, err := CalculateDocumentSize(doc)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got != 1 {
+		t.Fatalf("got=%d want 1", got)
+	}
+}
+
+func TestCalculateDocumentSize_NumberJSONNumber(t *testing.T) {
+	// N value provided as json.Number exercises coerceNumberString's json.Number path.
+	// "12" -> 2, plus name "n" (1) = 3
+	doc := map[string]any{"n": map[string]any{"N": json.Number("12")}}
+
+	got, err := CalculateDocumentSize(doc)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got != 3 {
+		t.Fatalf("got=%d want 3", got)
+	}
+}
+
+func TestCalculateDocumentSize_NumberSetJSONNumber(t *testing.T) {
+	// NS with json.Number elements exercises coerceNumberString in the NS branch.
+	doc := map[string]any{"ns": map[string]any{"NS": []any{json.Number("1"), json.Number("100")}}}
+
+	if _, err := CalculateDocumentSize(doc); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestCalculateDocumentSize_NumberErrors(t *testing.T) {
+	// N with a non-string/non-json.Number value is rejected by coerceNumberString.
+	if _, err := CalculateDocumentSize(map[string]any{"n": map[string]any{"N": 123}}); err == nil {
+		t.Errorf("expected error for numeric N value")
+	}
+
+	// NS with a bad element is rejected.
+	if _, err := CalculateDocumentSize(map[string]any{"ns": map[string]any{"NS": []any{true}}}); err == nil {
+		t.Errorf("expected error for bad NS element")
+	}
+}
+
+func TestTrimHelpers(t *testing.T) {
+	if got := trimRightChar("100", '0'); got != "1" {
+		t.Errorf("trimRightChar(\"100\", '0') = %q, want %q", got, "1")
+	}
+
+	if got := trimRightChar("abc", '0'); got != "abc" {
+		t.Errorf("trimRightChar(\"abc\", '0') = %q, want %q", got, "abc")
+	}
+
+	if got := trimTrailingZerosFloat("1.500"); got != "1.5" {
+		t.Errorf("trimTrailingZerosFloat(\"1.500\") = %q, want %q", got, "1.5")
+	}
+
+	if got := trimTrailingZerosFloat("42"); got != "42" {
+		t.Errorf("trimTrailingZerosFloat(\"42\") = %q, want %q", got, "42")
+	}
+}
+
+func TestCalculateBinaryDecoded(t *testing.T) {
+	if got := calculateBinaryDecoded([]byte{1, 2, 3}); got != 3 {
+		t.Errorf("calculateBinaryDecoded([]byte) = %d, want 3", got)
+	}
+
+	if got := calculateBinaryDecoded("AAEC"); got != 3 {
+		t.Errorf("calculateBinaryDecoded(base64) = %d, want 3", got)
+	}
+
+	if got := calculateBinaryDecoded("!!not base64!!"); got != 0 {
+		t.Errorf("calculateBinaryDecoded(invalid base64) = %d, want 0", got)
+	}
+
+	if got := calculateBinaryDecoded(123); got != 0 {
+		t.Errorf("calculateBinaryDecoded(int) = %d, want 0", got)
+	}
+}
+
+func TestDynamoNumberSizeBytes_ZeroStripping(t *testing.T) {
+	// Leading/trailing zero handling must not panic and stays within the 1..21 range.
+	for _, in := range []string{"0.00012", "1200", "0.5", "100.00", "-0.0007"} {
+		got := dynamoNumberSizeBytes(in)
+		if got < 1 || got > 21 {
+			t.Errorf("dynamoNumberSizeBytes(%q) = %d, want within [1,21]", in, got)
+		}
+	}
+}

--- a/calculate-size/doc.go
+++ b/calculate-size/doc.go
@@ -1,0 +1,11 @@
+// Package docsize estimates DynamoDB item size in bytes for low-level DynamoDB JSON items
+// (each attribute maps to a single-key AttributeValue: S, N, M, L, ...).
+//
+// The rules follow AWS documentation as summarized in
+// https://zaccharles.medium.com/calculating-a-dynamodb-items-size-and-consumed-capacity-d1728942eb7c
+// and match the reference implementation in
+// https://github.com/zaccharles/dynamodb-calculator (index.html).
+//
+// This is not the same as treating {"S":"x"} as a DynamoDB Map (3 + key + payload + 1);
+// older dynamodb-size-js style code did that and over-counts heavily on real exports.
+package docsize

--- a/calculate-size/docsize.go
+++ b/calculate-size/docsize.go
@@ -1,0 +1,169 @@
+package docsize
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+const (
+	nestedItemOverhead    = 1
+	compositeItemOverhead = 3
+)
+
+// DocumentSet mirrors the AWS SDK for JavaScript DocumentClient "Set" wrapper
+// (wrapperName === 'Set') so set attributes can be sized when not using DynamoDB JSON.
+type DocumentSet struct {
+	// Type is one of: String, Number, NumberValue, Binary.
+	Type string
+	// Values holds set elements (strings, numbers, or binary blobs per Type).
+	Values []any
+}
+
+// CalculateDocumentSize returns the estimated byte size of a DynamoDB item: sum over
+// attributes of (UTF-8 length of attribute name + size of the AttributeValue).
+func CalculateDocumentSize(doc map[string]any) (int, error) {
+	if doc == nil {
+		return 0, fmt.Errorf("doc: expected non-nil map")
+	}
+
+	total := 0
+
+	for name, val := range doc {
+		total += calculateString(name)
+
+		switch x := val.(type) {
+		case map[string]any:
+			sz, err := sizeAttributeValue(x)
+			if err != nil {
+				return 0, fmt.Errorf("attribute %q: %w", name, err)
+			}
+
+			total += sz
+		case DocumentSet:
+			total += calculateSet(x)
+		case *DocumentSet:
+			if x == nil {
+				return 0, fmt.Errorf("attribute %q: nil DocumentSet", name)
+			}
+
+			total += calculateSet(*x)
+		default:
+			return 0, fmt.Errorf("attribute %q: expected AttributeValue map or DocumentSet, got %T", name, val)
+		}
+	}
+
+	return total, nil
+}
+
+func calculateString(s string) int {
+	return len(s)
+}
+
+func calculateBoolean() int {
+	return 1
+}
+
+func calculateNull() int {
+	return 1
+}
+
+func calculateSet(x DocumentSet) int {
+	var calc func(any) int
+
+	switch x.Type {
+	case "String":
+		calc = func(v any) int {
+			s, _ := v.(string)
+
+			return calculateString(s)
+		}
+	case "Number", "NumberValue":
+		calc = func(v any) int {
+			if s, ok := v.(string); ok {
+				return dynamoNumberSizeBytes(s)
+			}
+
+			f, ok := toFloat64(v)
+			if !ok {
+				return 0
+			}
+
+			return dynamoNumberSizeBytes(trimFloatJSON(f))
+		}
+	case "Binary":
+		calc = calculateBinaryDecoded
+	default:
+		return 0
+	}
+
+	total := 0
+
+	for _, item := range x.Values {
+		total += calc(item)
+	}
+
+	return total
+}
+
+func trimFloatJSON(f float64) string {
+	// Best-effort decimal string for DocumentSet numeric literals (non-DynamoDB-JSON).
+	return trimTrailingZerosFloat(strconv.FormatFloat(f, 'f', -1, 64))
+}
+
+func trimTrailingZerosFloat(s string) string {
+	if strings.Contains(s, ".") {
+		s = trimRightChar(s, '0')
+		s = trimRightChar(s, '.')
+	}
+
+	return s
+}
+
+func trimRightChar(s string, c byte) string {
+	for s != "" && s[len(s)-1] == c {
+		s = s[:len(s)-1]
+	}
+
+	return s
+}
+
+func toFloat64(v any) (float64, bool) {
+	switch n := v.(type) {
+	case float64:
+		return n, true
+	case float32:
+		return float64(n), true
+	case int:
+		return float64(n), true
+	case int64:
+		return float64(n), true
+	case json.Number:
+		f, err := n.Float64()
+		if err != nil {
+			return 0, false
+		}
+
+		return f, true
+	default:
+		return 0, false
+	}
+}
+
+func calculateBinaryDecoded(x any) int {
+	switch b := x.(type) {
+	case []byte:
+		return len(b)
+	case string:
+		raw, err := base64.StdEncoding.DecodeString(b)
+		if err != nil {
+			return 0
+		}
+
+		return len(raw)
+	default:
+		return 0
+	}
+}

--- a/calculate-size/docsize_test.go
+++ b/calculate-size/docsize_test.go
@@ -1,0 +1,130 @@
+package docsize
+
+import "testing"
+
+func TestCalculateDocumentSize_Scalars(t *testing.T) {
+	// attribute name "S" (1) + S value "hello" (5) = 6
+	got, err := CalculateDocumentSize(map[string]any{"S": map[string]any{"S": "hello"}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got != 6 {
+		t.Fatalf("got=%d want 6", got)
+	}
+}
+
+func TestCalculateDocumentSize_NumberAndBinary(t *testing.T) {
+	// "n" (1) + N "123" (3 digits -> ceil(3/2)=2 blocks +1 = 3) = 4
+	got, err := CalculateDocumentSize(map[string]any{"n": map[string]any{"N": "123"}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got != 4 {
+		t.Fatalf("number: got=%d want 4", got)
+	}
+
+	// "b" (1) + B base64 "AAEC" -> 3 decoded bytes = 4
+	got, err = CalculateDocumentSize(map[string]any{"b": map[string]any{"B": "AAEC"}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got != 4 {
+		t.Fatalf("binary: got=%d want 4", got)
+	}
+}
+
+func TestCalculateDocumentSize_BoolNull(t *testing.T) {
+	// "b" (1) + BOOL (1) + "n" (1) + NULL (1) = 4
+	doc := map[string]any{
+		"b": map[string]any{"BOOL": true},
+		"n": map[string]any{"NULL": true},
+	}
+
+	got, err := CalculateDocumentSize(doc)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got != 4 {
+		t.Fatalf("got=%d want 4", got)
+	}
+}
+
+func TestCalculateDocumentSize_NestedMapList(t *testing.T) {
+	// "m"(1) + M{compositeOverhead 3 + key "a"(1) + S "x"(1) + nestedOverhead 1} = 1 + 6 = 7
+	// "l"(1) + L{compositeOverhead 3 + N "5"(2) + nestedOverhead 1}              = 1 + 6 = 7
+	doc := map[string]any{
+		"m": map[string]any{"M": map[string]any{"a": map[string]any{"S": "x"}}},
+		"l": map[string]any{"L": []any{map[string]any{"N": "5"}}},
+	}
+
+	got, err := CalculateDocumentSize(doc)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got != 14 {
+		t.Fatalf("got=%d want 14", got)
+	}
+}
+
+func TestCalculateDocumentSize_Sets(t *testing.T) {
+	// "ss"(2) + SS{"a"(1)+"bb"(2)=3}            = 5
+	// "ns"(2) + NS{"1"(2)+"10"(2)=4}            = 6
+	// "bs"(2) + BS{base64 "AAEC" -> 3 bytes}    = 5
+	doc := map[string]any{
+		"ss": map[string]any{"SS": []any{"a", "bb"}},
+		"ns": map[string]any{"NS": []any{"1", "10"}},
+		"bs": map[string]any{"BS": []any{"AAEC"}},
+	}
+
+	got, err := CalculateDocumentSize(doc)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got != 16 {
+		t.Fatalf("got=%d want 16", got)
+	}
+}
+
+func TestCalculateDocumentSize_DocumentSet(t *testing.T) {
+	// "s"(1) + String set {"a"(1)+"bb"(2)=3}        = 4
+	// "n"(1) + Number set {1 -> "1"(2), 22 -> "22"(2)} = 5
+	doc := map[string]any{
+		"s": DocumentSet{Type: "String", Values: []any{"a", "bb"}},
+		"n": &DocumentSet{Type: "Number", Values: []any{1, 22}},
+	}
+
+	got, err := CalculateDocumentSize(doc)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got != 9 {
+		t.Fatalf("got=%d want 9", got)
+	}
+}
+
+func TestCalculateDocumentSize_Errors(t *testing.T) {
+	cases := []struct {
+		name string
+		doc  map[string]any
+	}{
+		{"nil doc", nil},
+		{"non-attribute value", map[string]any{"x": 123}},
+		{"two type keys", map[string]any{"x": map[string]any{"S": "a", "N": "1"}}},
+		{"unknown type key", map[string]any{"x": map[string]any{"WUT": "a"}}},
+		{"bad nested map value", map[string]any{"x": map[string]any{"M": map[string]any{"k": 5}}}},
+		{"nil DocumentSet pointer", map[string]any{"x": (*DocumentSet)(nil)}},
+	}
+
+	for _, c := range cases {
+		if _, err := CalculateDocumentSize(c.doc); err == nil {
+			t.Errorf("%s: expected error, got nil", c.name)
+		}
+	}
+}

--- a/calculate-size/number_dynamo.go
+++ b/calculate-size/number_dynamo.go
@@ -1,0 +1,126 @@
+package docsize
+
+import (
+	"math"
+	"math/big"
+	"strings"
+)
+
+// dynamoNumberSizeBytes matches Zac Charles' dynamodb-calculator (Medium / GitHub)
+// calculateNumberSizeInBytes: Decimal normalization + measure() + 21-byte cap.
+func dynamoNumberSizeBytes(s string) int {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 21
+	}
+
+	r, ok := new(big.Rat).SetString(s)
+	if !ok {
+		return 21
+	}
+
+	if r.Sign() == 0 {
+		return 1
+	}
+
+	neg := r.Sign() < 0
+	if neg {
+		r = new(big.Rat).Abs(r)
+	}
+
+	fixed := strings.TrimRight(strings.TrimRight(r.FloatString(380), "0"), ".")
+	if fixed == "" {
+		fixed = "0"
+	}
+
+	m := measureNumberString(fixed)
+
+	size := m + 1
+	if neg {
+		size++
+	}
+
+	if size > 21 {
+		size = 21
+	}
+
+	return size
+}
+
+func measureNumberString(n string) int {
+	if i := strings.IndexByte(n, '.'); i >= 0 {
+		p0 := n[:i]
+		p1 := n[i+1:]
+
+		if p0 == "0" {
+			p0 = ""
+			p1 = zerosStripLeadingZeroPairs(p1)
+		}
+
+		if len(p0)%2 != 0 {
+			p0 = "Z" + p0
+		}
+
+		if len(p1)%2 != 0 {
+			p1 += "Z"
+		}
+
+		return measureNumberString(p0 + p1)
+	}
+
+	n = zerosStripBothEndsPairs(n)
+	if n == "" {
+		return 0
+	}
+
+	return int(math.Ceil(float64(len(n)) / 2))
+}
+
+func zerosStripLeadingZeroPairs(n string) string {
+	for {
+		t := stripLeadingPairOfZeros(n)
+		if t == n {
+			return n
+		}
+
+		n = t
+	}
+}
+
+func stripLeadingPairOfZeros(n string) string {
+	if strings.HasPrefix(n, "00") {
+		return n[2:]
+	}
+
+	return n
+}
+
+func zerosStripBothEndsPairs(n string) string {
+	for {
+		t := stripLeadingPairOfZeros(n)
+		if t == n {
+			break
+		}
+
+		n = t
+	}
+
+	for {
+		t := stripTrailingPairOfZeros(n)
+		if t == n {
+			break
+		}
+
+		n = t
+	}
+
+	return n
+}
+
+func stripTrailingPairOfZeros(n string) string {
+	if len(n) >= 2 && n[len(n)-2:] == "00" {
+		return n[:len(n)-2]
+	}
+
+	return n
+}

--- a/calculate-size/number_dynamo_test.go
+++ b/calculate-size/number_dynamo_test.go
@@ -1,0 +1,27 @@
+package docsize
+
+import "testing"
+
+func TestDynamoNumberSizeBytes(t *testing.T) {
+	cases := []struct {
+		in   string
+		want int
+	}{
+		{"0", 1},
+		{"", 21},
+		{"not-a-number", 21},
+		{"5", 2},
+		{"-5", 3},
+		{"10", 2},
+		{"123", 3},
+		{"3.14159", 5},
+		{"  42  ", 2}, // trimmed before parsing
+		{"1234567890123456789012345678901234567890", 21}, // 21-byte cap
+	}
+
+	for _, c := range cases {
+		if got := dynamoNumberSizeBytes(c.in); got != c.want {
+			t.Errorf("dynamoNumberSizeBytes(%q) = %d, want %d", c.in, got, c.want)
+		}
+	}
+}

--- a/capacity/capacity.go
+++ b/capacity/capacity.go
@@ -1,0 +1,129 @@
+package capacity
+
+import "math"
+
+const (
+	readBlockBytes  = 4096
+	writeBlockBytes = 1024
+)
+
+// Mode is the resolved ReturnConsumedCapacity level.
+type Mode string
+
+const (
+	// ModeNone means no ConsumedCapacity should be reported.
+	ModeNone Mode = "NONE"
+	// ModeTotal reports table-level totals only.
+	ModeTotal Mode = "TOTAL"
+	// ModeIndexes reports totals plus a per-table/index breakdown.
+	ModeIndexes Mode = "INDEXES"
+)
+
+// ParseMode maps a ReturnConsumedCapacity string ("", "NONE", "TOTAL", "INDEXES") to a Mode.
+// Unset and any unknown value map to ModeNone.
+func ParseMode(s string) Mode {
+	switch s {
+	case string(ModeTotal):
+		return ModeTotal
+	case string(ModeIndexes):
+		return ModeIndexes
+	default:
+		return ModeNone
+	}
+}
+
+// ReadUnits returns the read capacity units for an item/result of the given byte size.
+// One unit covers a 4KB strongly consistent read; eventually consistent reads cost half.
+func ReadUnits(size int, consistent bool) float64 {
+	blocks := math.Ceil(float64(size) / readBlockBytes)
+	if blocks < 1 {
+		blocks = 1
+	}
+
+	if consistent {
+		return blocks
+	}
+
+	return blocks / 2
+}
+
+// WriteUnits returns the write capacity units for an item of the given byte size.
+// One unit covers a 1KB write.
+func WriteUnits(size int) float64 {
+	blocks := math.Ceil(float64(size) / writeBlockBytes)
+	if blocks < 1 {
+		blocks = 1
+	}
+
+	return blocks
+}
+
+// Consumed is a client-agnostic consumed-capacity result. Each client maps it to its own
+// output shape. Breakdown is set for ModeIndexes; IndexName/IndexKind identify the index
+// charged for an index read (otherwise capacity is attributed to the base table).
+type Consumed struct {
+	TableName          string
+	CapacityUnits      float64
+	ReadCapacityUnits  float64
+	WriteCapacityUnits float64
+	Breakdown          bool
+	IndexName          string
+	IndexKind          string // "GSI" | "LSI" | ""
+}
+
+func build(mode Mode, table, index, indexKind string, units float64, isRead bool) *Consumed {
+	if mode == ModeNone {
+		return nil
+	}
+
+	c := &Consumed{
+		TableName:     table,
+		CapacityUnits: units,
+		Breakdown:     mode == ModeIndexes,
+	}
+
+	if isRead {
+		c.ReadCapacityUnits = units
+	} else {
+		c.WriteCapacityUnits = units
+	}
+
+	if mode == ModeIndexes && index != "" {
+		c.IndexName = index
+		c.IndexKind = indexKind
+	}
+
+	return c
+}
+
+// ForRead builds the consumed capacity for a read of total byte size from a table or index.
+func ForRead(mode Mode, table, index, indexKind string, size int, consistent bool) *Consumed {
+	return build(mode, table, index, indexKind, ReadUnits(size, consistent), true)
+}
+
+// ForWrite builds the consumed capacity for a single write of the given byte size.
+func ForWrite(mode Mode, table string, size int) *Consumed {
+	return build(mode, table, "", "", WriteUnits(size), false)
+}
+
+// ForReadUnits builds read consumed capacity from already-aggregated units. Used by batch
+// reads, which sum per-item rounded units across a table.
+func ForReadUnits(mode Mode, table string, units float64) *Consumed {
+	return build(mode, table, "", "", units, true)
+}
+
+// ForWriteUnits builds write consumed capacity from already-aggregated units. Used by batch
+// and transactional writes, which sum per-item rounded units across a table.
+func ForWriteUnits(mode Mode, table string, units float64) *Consumed {
+	return build(mode, table, "", "", units, false)
+}
+
+// ForTransactRead builds the consumed capacity for a transactional read (2x, strongly consistent).
+func ForTransactRead(mode Mode, table string, size int) *Consumed {
+	return build(mode, table, "", "", 2*ReadUnits(size, true), true)
+}
+
+// ForTransactWrite builds the consumed capacity for a transactional write (2x).
+func ForTransactWrite(mode Mode, table string, size int) *Consumed {
+	return build(mode, table, "", "", 2*WriteUnits(size), false)
+}

--- a/capacity/capacity_test.go
+++ b/capacity/capacity_test.go
@@ -1,0 +1,136 @@
+package capacity
+
+import "testing"
+
+func TestParseMode(t *testing.T) {
+	cases := map[string]Mode{
+		"":         ModeNone,
+		"NONE":     ModeNone,
+		"TOTAL":    ModeTotal,
+		"INDEXES":  ModeIndexes,
+		"whatever": ModeNone,
+	}
+
+	for in, want := range cases {
+		if got := ParseMode(in); got != want {
+			t.Errorf("ParseMode(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestReadUnits(t *testing.T) {
+	cases := []struct {
+		size       int
+		consistent bool
+		want       float64
+	}{
+		{0, true, 1},      // min 1
+		{100, true, 1},    // < 4KB strong
+		{100, false, 0.5}, // < 4KB eventual
+		{5000, true, 2},   // ceil(5000/4096) = 2 blocks
+		{5000, false, 1},  // 2 blocks halved
+	}
+
+	for _, c := range cases {
+		if got := ReadUnits(c.size, c.consistent); got != c.want {
+			t.Errorf("ReadUnits(%d, %v) = %v, want %v", c.size, c.consistent, got, c.want)
+		}
+	}
+}
+
+func TestWriteUnits(t *testing.T) {
+	cases := []struct {
+		size int
+		want float64
+	}{
+		{0, 1},    // min 1
+		{100, 1},  // < 1KB
+		{1024, 1}, // exactly 1KB
+		{1500, 2}, // ceil(1500/1024) = 2
+	}
+
+	for _, c := range cases {
+		if got := WriteUnits(c.size); got != c.want {
+			t.Errorf("WriteUnits(%d) = %v, want %v", c.size, got, c.want)
+		}
+	}
+}
+
+func TestForRead_None(t *testing.T) {
+	if c := ForRead(ModeNone, "t", "", "", 100, true); c != nil {
+		t.Fatalf("ModeNone must return nil, got %#v", c)
+	}
+}
+
+func TestForRead_Total(t *testing.T) {
+	c := ForRead(ModeTotal, "tbl", "", "", 100, true)
+	if c == nil {
+		t.Fatal("expected non-nil Consumed")
+	}
+
+	if c.TableName != "tbl" || c.CapacityUnits != 1 || c.ReadCapacityUnits != 1 {
+		t.Fatalf("bad TOTAL read: %#v", c)
+	}
+
+	if c.WriteCapacityUnits != 0 || c.Breakdown || c.IndexName != "" {
+		t.Fatalf("TOTAL must not set write/breakdown/index: %#v", c)
+	}
+}
+
+func TestForRead_IndexesGSI(t *testing.T) {
+	c := ForRead(ModeIndexes, "tbl", "by-type", "GSI", 100, true)
+	if c == nil || !c.Breakdown {
+		t.Fatalf("INDEXES must set Breakdown: %#v", c)
+	}
+
+	if c.IndexName != "by-type" || c.IndexKind != "GSI" {
+		t.Fatalf("INDEXES must carry index info: %#v", c)
+	}
+}
+
+func TestForWrite(t *testing.T) {
+	c := ForWrite(ModeTotal, "tbl", 100)
+	if c == nil || c.CapacityUnits != 1 || c.WriteCapacityUnits != 1 || c.ReadCapacityUnits != 0 {
+		t.Fatalf("bad write: %#v", c)
+	}
+}
+
+func TestForWrite_None(t *testing.T) {
+	if c := ForWrite(ModeNone, "t", 100); c != nil {
+		t.Fatalf("ModeNone write must return nil, got %#v", c)
+	}
+}
+
+func TestForUnits(t *testing.T) {
+	r := ForReadUnits(ModeTotal, "tbl", 3.5)
+	if r == nil || r.CapacityUnits != 3.5 || r.ReadCapacityUnits != 3.5 || r.WriteCapacityUnits != 0 {
+		t.Fatalf("bad ForReadUnits: %#v", r)
+	}
+
+	w := ForWriteUnits(ModeTotal, "tbl", 4)
+	if w == nil || w.CapacityUnits != 4 || w.WriteCapacityUnits != 4 || w.ReadCapacityUnits != 0 {
+		t.Fatalf("bad ForWriteUnits: %#v", w)
+	}
+
+	if ForReadUnits(ModeNone, "tbl", 3) != nil || ForWriteUnits(ModeNone, "tbl", 3) != nil {
+		t.Fatalf("ModeNone unit constructors must return nil")
+	}
+}
+
+func TestForTransactWrite_DoublesWCU(t *testing.T) {
+	single := ForWrite(ModeTotal, "t", 1000)
+	txn := ForTransactWrite(ModeTotal, "t", 1000)
+
+	if txn.CapacityUnits != 2*single.CapacityUnits {
+		t.Fatalf("transact write should double: single=%v txn=%v", single.CapacityUnits, txn.CapacityUnits)
+	}
+}
+
+func TestForTransactRead_DoublesRCU(t *testing.T) {
+	single := ForRead(ModeTotal, "t", "", "", 100, true)
+	txn := ForTransactRead(ModeTotal, "t", 100)
+
+	if txn.CapacityUnits != 2*single.CapacityUnits {
+		t.Fatalf("transact read should double: single=%v txn=%v", single.CapacityUnits, txn.CapacityUnits)
+	}
+}

--- a/capacity/convert.go
+++ b/capacity/convert.go
@@ -1,0 +1,101 @@
+package capacity
+
+import (
+	"encoding/base64"
+
+	docsize "github.com/truora/minidyn/calculate-size"
+	"github.com/truora/minidyn/types"
+)
+
+// Size returns the estimated DynamoDB byte size of an item. A nil/empty item is 0.
+// docsize returns 0 on any conversion error, so capacity accounting never breaks an operation.
+func Size(item map[string]*types.Item) int {
+	n, _ := docsize.CalculateDocumentSize(itemToDoc(item))
+
+	return n
+}
+
+// SumSize returns the combined Size of every item (used by Query/Scan/batch accounting).
+func SumSize(items []map[string]*types.Item) int {
+	total := 0
+	for _, item := range items {
+		total += Size(item)
+	}
+
+	return total
+}
+
+// itemToDoc converts minidyn's internal item form into the low-level DynamoDB-JSON
+// map[string]any that docsize.CalculateDocumentSize expects.
+func itemToDoc(item map[string]*types.Item) map[string]any {
+	doc := make(map[string]any, len(item))
+	for name, value := range item {
+		doc[name] = attrToAny(value)
+	}
+
+	return doc
+}
+
+// attrToAny renders a single types.Item as a one-key AttributeValue map. It branches on
+// the first populated field using the same precedence as the SDK/wire mappers.
+func attrToAny(it *types.Item) map[string]any {
+	if it == nil {
+		return map[string]any{"NULL": true}
+	}
+
+	switch {
+	case len(it.B) != 0:
+		return map[string]any{"B": base64.StdEncoding.EncodeToString(it.B)}
+	case it.BOOL != nil:
+		return map[string]any{"BOOL": *it.BOOL}
+	case len(it.BS) != 0:
+		return map[string]any{"BS": encodeBinarySet(it.BS)}
+	case it.N != nil:
+		return map[string]any{"N": *it.N}
+	case len(it.NS) != 0:
+		return map[string]any{"NS": derefStrings(it.NS)}
+	case it.S != nil:
+		return map[string]any{"S": *it.S}
+	case len(it.SS) != 0:
+		return map[string]any{"SS": derefStrings(it.SS)}
+	case len(it.L) != 0:
+		return map[string]any{"L": listToAny(it.L)}
+	case len(it.M) != 0:
+		return map[string]any{"M": itemToDoc(it.M)}
+	case it.NULL != nil:
+		return map[string]any{"NULL": *it.NULL}
+	default:
+		return map[string]any{"NULL": true}
+	}
+}
+
+func listToAny(items []*types.Item) []any {
+	out := make([]any, len(items))
+	for i, el := range items {
+		out[i] = attrToAny(el)
+	}
+
+	return out
+}
+
+func encodeBinarySet(bs [][]byte) []any {
+	out := make([]any, len(bs))
+	for i, b := range bs {
+		out[i] = base64.StdEncoding.EncodeToString(b)
+	}
+
+	return out
+}
+
+func derefStrings(ptrs []*string) []any {
+	out := make([]any, len(ptrs))
+	for i, p := range ptrs {
+		if p != nil {
+			out[i] = *p
+		} else {
+			out[i] = ""
+		}
+	}
+
+	return out
+}

--- a/capacity/convert_test.go
+++ b/capacity/convert_test.go
@@ -1,0 +1,80 @@
+package capacity
+
+import (
+	"testing"
+
+	"github.com/truora/minidyn/types"
+)
+
+func TestSize_Scalar(t *testing.T) {
+	// "id" (2) + S "hello" (5) = 7
+	item := map[string]*types.Item{"id": {S: new("hello")}}
+
+	if got := Size(item); got != 7 {
+		t.Fatalf("Size = %d, want 7", got)
+	}
+}
+
+func TestSize_NilAndEmpty(t *testing.T) {
+	if got := Size(nil); got != 0 {
+		t.Fatalf("Size(nil) = %d, want 0", got)
+	}
+
+	if got := Size(map[string]*types.Item{}); got != 0 {
+		t.Fatalf("Size(empty) = %d, want 0", got)
+	}
+}
+
+func TestSize_AllShapes(t *testing.T) {
+	b := true
+	n := "5"
+
+	item := map[string]*types.Item{
+		"s":    {S: new("x")},
+		"n":    {N: &n},
+		"b":    {B: []byte{1, 2, 3}},
+		"bool": {BOOL: &b},
+		"null": {NULL: &b},
+		"ss":   {SS: []*string{new("a"), new("bb")}},
+		"ns":   {NS: []*string{new("1"), new("10")}},
+		"l":    {L: []*types.Item{{N: &n}}},
+		"m":    {M: map[string]*types.Item{"a": {S: new("x")}}},
+	}
+
+	if got := Size(item); got <= 0 {
+		t.Fatalf("Size = %d, want > 0", got)
+	}
+}
+
+func TestSize_BinarySet(t *testing.T) {
+	// "bs" (2) + BS{[]byte(3 bytes), base64 "AAEC" -> 3 bytes} = 2 + 6 = 8
+	item := map[string]*types.Item{"bs": {BS: [][]byte{{1, 2, 3}, {0, 1, 2}}}}
+
+	if got := Size(item); got != 8 {
+		t.Fatalf("Size = %d, want 8", got)
+	}
+}
+
+func TestSumSize(t *testing.T) {
+	items := []map[string]*types.Item{
+		{"id": {S: new("hello")}}, // 7
+		{"id": {S: new("hi")}},    // 2 + 2 = 4
+	}
+
+	if got := SumSize(items); got != 11 {
+		t.Fatalf("SumSize = %d, want 11", got)
+	}
+
+	if got := SumSize(nil); got != 0 {
+		t.Fatalf("SumSize(nil) = %d, want 0", got)
+	}
+}
+
+func TestSize_NilAttributeAndEmptyItem(t *testing.T) {
+	// A nil attribute value and an all-zero item must not panic; they size as NULL (1 byte).
+	item := map[string]*types.Item{"a": nil, "b": {}}
+
+	if got := Size(item); got <= 0 {
+		t.Fatalf("Size = %d, want > 0", got)
+	}
+}

--- a/capacity/doc.go
+++ b/capacity/doc.go
@@ -1,0 +1,8 @@
+// Package capacity computes DynamoDB consumed-capacity values for minidyn operations.
+//
+// It is SDK-free and operates on minidyn's internal item form (map[string]*types.Item),
+// so both the in-memory aws-v2 client and the HTTP server can share it. Item byte sizes
+// come from the docsize package (calculate-size); this package turns those bytes into
+// read/write capacity units following the documented DynamoDB rules (4KB per read unit,
+// 1KB per write unit, eventual reads halved, transactional operations doubled).
+package capacity

--- a/core/table.go
+++ b/core/table.go
@@ -63,6 +63,22 @@ func (t *Table) ValidatePrimaryKeyMap(key map[string]*types.Item) error {
 	return t.KeySchema.validatePrimaryKeyMap(key)
 }
 
+// IndexKind classifies a secondary index by name: "GSI" for a global secondary index,
+// "LSI" for a local one. It returns "" for the primary index or an unknown name. Used to
+// place per-index entries when reporting ConsumedCapacity at the INDEXES level.
+func (t *Table) IndexKind(name string) string {
+	idx, ok := t.Indexes[name]
+	if !ok {
+		return ""
+	}
+
+	if idx.typ == indexTypeLocal {
+		return "LSI"
+	}
+
+	return "GSI"
+}
+
 // SetAttributeDefinition sets the attribute definition of a table
 func (t *Table) SetAttributeDefinition(attrs []*types.AttributeDefinition) {
 	for _, attr := range attrs {

--- a/core/table_test.go
+++ b/core/table_test.go
@@ -127,6 +127,24 @@ func TestAddLocalIndexes(t *testing.T) {
 	c.Contains(err.Error(), "ValidationException: LSI list is empty/invalid")
 }
 
+func TestIndexKind(t *testing.T) {
+	c := require.New(t)
+
+	newTable, err := createPokemonTable()
+	c.NoError(err)
+
+	localIndexes := createLocalSecondaryIndex()
+	localIndexes[0].KeySchema = []*types.KeySchemaElement{
+		{AttributeName: "id", KeyType: "HASH"},
+	}
+	c.NoError(newTable.AddLocalIndexes(localIndexes))
+
+	c.Equal("GSI", newTable.IndexKind("invert"))
+	c.Equal("LSI", newTable.IndexKind("indexname"))
+	c.Equal("", newTable.IndexKind(PrimaryIndexName))
+	c.Equal("", newTable.IndexKind("does-not-exist"))
+}
+
 func TestTableIndexesDescription(t *testing.T) {
 	c := require.New(t)
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -25,7 +25,7 @@ Minidyn aims to accurately mock DynamoDB behavior for local testing. However, it
   - **Eventual Consistency**: Global Secondary Indexes are updated synchronously and are always strongly consistent in minidyn. Real DynamoDB updates GSIs asynchronously (eventually consistent).
   - **Throughput/Limits**: Minidyn does not enforce index-specific read/write capacity limits.
 - **Limits and Restrictions**: Real DynamoDB limits (such as 400KB item sizes, 1MB limits per Query/Scan, or max limits for pagination) are not enforced in minidyn. Queries and Scans will return all matching items unless explicitly limited.
-- **ReturnConsumedCapacity**: Operations in minidyn do not accurately calculate or return the consumed capacity units. The `ReturnConsumedCapacity` parameter is largely ignored, and mock/empty capacity reports are returned or omitted entirely.
+- **ReturnConsumedCapacity**: Supported for all operations that report it (`GetItem`, `PutItem`, `UpdateItem`, `DeleteItem`, `Query`, `Scan`, `BatchGetItem`, `BatchWriteItem`, `TransactGetItems`, `TransactWriteItems`). `NONE` (or unset) omits `ConsumedCapacity`; `TOTAL` returns table-level totals; `INDEXES` additionally returns a per-table/index breakdown. Capacity units are derived from the documented DynamoDB item-size algorithm (4&nbsp;KB per read unit, 1&nbsp;KB per write unit, eventually consistent reads halved, transactional operations doubled). Because that algorithm is the contract, the exact unit values may differ slightly from a given DynamoDB Local build's rounding; per-index **write** capacity under `INDEXES` is attributed to the table rather than split across each GSI.
 
 ---
 

--- a/e2e/parity_capacity_test.go
+++ b/e2e/parity_capacity_test.go
@@ -1,0 +1,331 @@
+package e2e
+
+import (
+	"context"
+	"sort"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	dynamodbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/stretchr/testify/require"
+)
+
+// capacitySnapshot is a stable, comparable projection of *types.ConsumedCapacity.
+//
+// minidyn computes consumed capacity from the documented docsize/AWS item-size algorithm
+// (the contract). DynamoDB Local's exact byte-to-unit rounding can legitimately differ, so
+// parity here is structural — presence, table name, and whether any capacity was charged —
+// rather than exact unit equality. Exact values are pinned by the unit tests in the
+// capacity and aws-v2/client packages. The spike test below logs the raw numbers for anyone
+// reconciling minidyn against a specific DynamoDB Local build.
+type capacitySnapshot struct {
+	Present   bool
+	TableName string
+	Positive  bool // CapacityUnits > 0
+}
+
+func snapshotCapacity(cc *dynamodbtypes.ConsumedCapacity) capacitySnapshot {
+	if cc == nil {
+		return capacitySnapshot{}
+	}
+
+	return capacitySnapshot{
+		Present:   true,
+		TableName: aws.ToString(cc.TableName),
+		Positive:  aws.ToFloat64(cc.CapacityUnits) > 0,
+	}
+}
+
+func sortedCapacitySnapshots(ccs []dynamodbtypes.ConsumedCapacity) []capacitySnapshot {
+	out := make([]capacitySnapshot, 0, len(ccs))
+	for i := range ccs {
+		out = append(out, snapshotCapacity(&ccs[i]))
+	}
+
+	sort.Slice(out, func(i, j int) bool { return out[i].TableName < out[j].TableName })
+
+	return out
+}
+
+// TestE2E_CapacitySpike runs against both engines and logs DynamoDB Local's actual
+// ConsumedCapacity numbers (run with -v) so the implementer can reconcile minidyn's
+// docsize-derived values against a specific DynamoDB Local build. It also asserts the
+// structural parity invariant, so it doubles as a regression test.
+func TestE2E_CapacitySpike(t *testing.T) {
+	RunE2E(t, func(t *testing.T, client *dynamodb.Client) capacitySnapshot {
+		t.Helper()
+		ctx := context.Background()
+
+		parityCreatePokemonTable(ctx, t, client)
+
+		putOut, err := client.PutItem(ctx, &dynamodb.PutItemInput{
+			TableName:              aws.String(parityPokemonTable),
+			Item:                   parityMarshalPokemon(t, parityPokemon{ID: "spike-1", Type: "fire", Name: "charmander", Level: 7}),
+			ReturnConsumedCapacity: dynamodbtypes.ReturnConsumedCapacityTotal,
+		})
+		require.NoError(t, err)
+		t.Logf("PUT ConsumedCapacity = %#v", putOut.ConsumedCapacity)
+
+		getOut, err := client.GetItem(ctx, &dynamodb.GetItemInput{
+			TableName:              aws.String(parityPokemonTable),
+			Key:                    map[string]dynamodbtypes.AttributeValue{"id": &dynamodbtypes.AttributeValueMemberS{Value: "spike-1"}},
+			ConsistentRead:         aws.Bool(true),
+			ReturnConsumedCapacity: dynamodbtypes.ReturnConsumedCapacityTotal,
+		})
+		require.NoError(t, err)
+		t.Logf("GET(consistent) ConsumedCapacity = %#v", getOut.ConsumedCapacity)
+
+		return snapshotCapacity(getOut.ConsumedCapacity)
+	})
+}
+
+func TestE2E_ConsumedCapacity(t *testing.T) {
+	tests := []struct {
+		name string
+		fn   func(t *testing.T, client *dynamodb.Client) any
+	}{
+		{
+			name: "GetItemConsistentTotal",
+			fn: func(t *testing.T, client *dynamodb.Client) any {
+				t.Helper()
+				ctx := context.Background()
+				parityCreatePokemonTable(ctx, t, client)
+				parityCreatePokemon(ctx, t, client, parityPokemon{ID: "001", Type: "water", Name: "squirtle"})
+
+				out, err := client.GetItem(ctx, &dynamodb.GetItemInput{
+					TableName:              aws.String(parityPokemonTable),
+					Key:                    map[string]dynamodbtypes.AttributeValue{"id": &dynamodbtypes.AttributeValueMemberS{Value: "001"}},
+					ConsistentRead:         aws.Bool(true),
+					ReturnConsumedCapacity: dynamodbtypes.ReturnConsumedCapacityTotal,
+				})
+				require.NoError(t, err)
+
+				return snapshotCapacity(out.ConsumedCapacity)
+			},
+		},
+		{
+			name: "GetItemEventualTotal",
+			fn: func(t *testing.T, client *dynamodb.Client) any {
+				t.Helper()
+				ctx := context.Background()
+				parityCreatePokemonTable(ctx, t, client)
+				parityCreatePokemon(ctx, t, client, parityPokemon{ID: "001", Type: "water", Name: "squirtle"})
+
+				out, err := client.GetItem(ctx, &dynamodb.GetItemInput{
+					TableName:              aws.String(parityPokemonTable),
+					Key:                    map[string]dynamodbtypes.AttributeValue{"id": &dynamodbtypes.AttributeValueMemberS{Value: "001"}},
+					ReturnConsumedCapacity: dynamodbtypes.ReturnConsumedCapacityTotal,
+				})
+				require.NoError(t, err)
+
+				return snapshotCapacity(out.ConsumedCapacity)
+			},
+		},
+		{
+			name: "GetItemNoneOmitsCapacity",
+			fn: func(t *testing.T, client *dynamodb.Client) any {
+				t.Helper()
+				ctx := context.Background()
+				parityCreatePokemonTable(ctx, t, client)
+				parityCreatePokemon(ctx, t, client, parityPokemon{ID: "001", Type: "water", Name: "squirtle"})
+
+				out, err := client.GetItem(ctx, &dynamodb.GetItemInput{
+					TableName: aws.String(parityPokemonTable),
+					Key:       map[string]dynamodbtypes.AttributeValue{"id": &dynamodbtypes.AttributeValueMemberS{Value: "001"}},
+				})
+				require.NoError(t, err)
+
+				return snapshotCapacity(out.ConsumedCapacity)
+			},
+		},
+		{
+			name: "PutItemTotal",
+			fn: func(t *testing.T, client *dynamodb.Client) any {
+				t.Helper()
+				ctx := context.Background()
+				parityCreatePokemonTable(ctx, t, client)
+
+				out, err := client.PutItem(ctx, &dynamodb.PutItemInput{
+					TableName:              aws.String(parityPokemonTable),
+					Item:                   parityMarshalPokemon(t, parityPokemon{ID: "cc-put", Type: "fire", Name: "ponyta", Level: 40}),
+					ReturnConsumedCapacity: dynamodbtypes.ReturnConsumedCapacityTotal,
+				})
+				require.NoError(t, err)
+
+				return snapshotCapacity(out.ConsumedCapacity)
+			},
+		},
+		{
+			name: "UpdateItemTotal",
+			fn: func(t *testing.T, client *dynamodb.Client) any {
+				t.Helper()
+				ctx := context.Background()
+				parityCreatePokemonTable(ctx, t, client)
+				parityCreatePokemon(ctx, t, client, parityPokemon{ID: "001", Type: "grass", Name: "bulbasaur"})
+
+				out, err := client.UpdateItem(ctx, &dynamodb.UpdateItemInput{
+					TableName:                aws.String(parityPokemonTable),
+					Key:                      map[string]dynamodbtypes.AttributeValue{"id": &dynamodbtypes.AttributeValueMemberS{Value: "001"}},
+					UpdateExpression:         aws.String("SET #t = :t"),
+					ExpressionAttributeNames: map[string]string{"#t": "type"},
+					ExpressionAttributeValues: map[string]dynamodbtypes.AttributeValue{
+						":t": &dynamodbtypes.AttributeValueMemberS{Value: "poison"},
+					},
+					ReturnConsumedCapacity: dynamodbtypes.ReturnConsumedCapacityTotal,
+				})
+				require.NoError(t, err)
+
+				return snapshotCapacity(out.ConsumedCapacity)
+			},
+		},
+		{
+			name: "DeleteItemTotal",
+			fn: func(t *testing.T, client *dynamodb.Client) any {
+				t.Helper()
+				ctx := context.Background()
+				parityCreatePokemonTable(ctx, t, client)
+				parityCreatePokemon(ctx, t, client, parityPokemon{ID: "001", Type: "grass", Name: "bulbasaur"})
+
+				out, err := client.DeleteItem(ctx, &dynamodb.DeleteItemInput{
+					TableName:              aws.String(parityPokemonTable),
+					Key:                    map[string]dynamodbtypes.AttributeValue{"id": &dynamodbtypes.AttributeValueMemberS{Value: "001"}},
+					ReturnConsumedCapacity: dynamodbtypes.ReturnConsumedCapacityTotal,
+				})
+				require.NoError(t, err)
+
+				return snapshotCapacity(out.ConsumedCapacity)
+			},
+		},
+		{
+			name: "QueryTotal",
+			fn: func(t *testing.T, client *dynamodb.Client) any {
+				t.Helper()
+				ctx := context.Background()
+				parityCreatePokemonTable(ctx, t, client)
+				parityCreatePokemon(ctx, t, client, parityPokemon{ID: "001", Type: "grass", Name: "bulbasaur"})
+
+				out, err := client.Query(ctx, &dynamodb.QueryInput{
+					TableName:                aws.String(parityPokemonTable),
+					KeyConditionExpression:   aws.String("#id = :id"),
+					ExpressionAttributeNames: map[string]string{"#id": "id"},
+					ExpressionAttributeValues: map[string]dynamodbtypes.AttributeValue{
+						":id": &dynamodbtypes.AttributeValueMemberS{Value: "001"},
+					},
+					ReturnConsumedCapacity: dynamodbtypes.ReturnConsumedCapacityTotal,
+				})
+				require.NoError(t, err)
+
+				return snapshotCapacity(out.ConsumedCapacity)
+			},
+		},
+		{
+			name: "ScanTotal",
+			fn: func(t *testing.T, client *dynamodb.Client) any {
+				t.Helper()
+				ctx := context.Background()
+				parityCreatePokemonTable(ctx, t, client)
+				parityCreatePokemon(ctx, t, client, parityPokemon{ID: "001", Type: "grass", Name: "bulbasaur"})
+
+				out, err := client.Scan(ctx, &dynamodb.ScanInput{
+					TableName:              aws.String(parityPokemonTable),
+					ReturnConsumedCapacity: dynamodbtypes.ReturnConsumedCapacityTotal,
+				})
+				require.NoError(t, err)
+
+				return snapshotCapacity(out.ConsumedCapacity)
+			},
+		},
+		{
+			name: "BatchGetItemTotal",
+			fn: func(t *testing.T, client *dynamodb.Client) any {
+				t.Helper()
+				ctx := context.Background()
+				parityCreatePokemonTable(ctx, t, client)
+				parityCreatePokemon(ctx, t, client, parityPokemon{ID: "001", Type: "grass", Name: "bulbasaur"})
+
+				out, err := client.BatchGetItem(ctx, &dynamodb.BatchGetItemInput{
+					ReturnConsumedCapacity: dynamodbtypes.ReturnConsumedCapacityTotal,
+					RequestItems: map[string]dynamodbtypes.KeysAndAttributes{
+						parityPokemonTable: {Keys: []map[string]dynamodbtypes.AttributeValue{
+							{"id": &dynamodbtypes.AttributeValueMemberS{Value: "001"}},
+						}},
+					},
+				})
+				require.NoError(t, err)
+
+				return sortedCapacitySnapshots(out.ConsumedCapacity)
+			},
+		},
+		{
+			name: "BatchWriteItemTotal",
+			fn: func(t *testing.T, client *dynamodb.Client) any {
+				t.Helper()
+				ctx := context.Background()
+				parityCreatePokemonTable(ctx, t, client)
+
+				out, err := client.BatchWriteItem(ctx, &dynamodb.BatchWriteItemInput{
+					ReturnConsumedCapacity: dynamodbtypes.ReturnConsumedCapacityTotal,
+					RequestItems: map[string][]dynamodbtypes.WriteRequest{
+						parityPokemonTable: {
+							{PutRequest: &dynamodbtypes.PutRequest{Item: parityMarshalPokemon(t, parityPokemon{ID: "bw1", Type: "fire", Name: "a"})}},
+							{PutRequest: &dynamodbtypes.PutRequest{Item: parityMarshalPokemon(t, parityPokemon{ID: "bw2", Type: "fire", Name: "b"})}},
+						},
+					},
+				})
+				require.NoError(t, err)
+
+				return sortedCapacitySnapshots(out.ConsumedCapacity)
+			},
+		},
+		{
+			name: "TransactGetItemsTotal",
+			fn: func(t *testing.T, client *dynamodb.Client) any {
+				t.Helper()
+				ctx := context.Background()
+				parityCreatePokemonTable(ctx, t, client)
+				parityCreatePokemon(ctx, t, client, parityPokemon{ID: "001", Type: "grass", Name: "bulbasaur"})
+
+				out, err := client.TransactGetItems(ctx, &dynamodb.TransactGetItemsInput{
+					ReturnConsumedCapacity: dynamodbtypes.ReturnConsumedCapacityTotal,
+					TransactItems: []dynamodbtypes.TransactGetItem{
+						{Get: &dynamodbtypes.Get{
+							TableName: aws.String(parityPokemonTable),
+							Key:       map[string]dynamodbtypes.AttributeValue{"id": &dynamodbtypes.AttributeValueMemberS{Value: "001"}},
+						}},
+					},
+				})
+				require.NoError(t, err)
+
+				return sortedCapacitySnapshots(out.ConsumedCapacity)
+			},
+		},
+		{
+			name: "TransactWriteItemsTotal",
+			fn: func(t *testing.T, client *dynamodb.Client) any {
+				t.Helper()
+				ctx := context.Background()
+				parityCreatePokemonTable(ctx, t, client)
+
+				out, err := client.TransactWriteItems(ctx, &dynamodb.TransactWriteItemsInput{
+					ReturnConsumedCapacity: dynamodbtypes.ReturnConsumedCapacityTotal,
+					TransactItems: []dynamodbtypes.TransactWriteItem{
+						{Put: &dynamodbtypes.Put{
+							TableName: aws.String(parityPokemonTable),
+							Item:      parityMarshalPokemon(t, parityPokemon{ID: "tw1", Type: "fire", Name: "x"}),
+						}},
+					},
+				})
+				require.NoError(t, err)
+
+				return sortedCapacitySnapshots(out.ConsumedCapacity)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			RunE2E(t, tt.fn)
+		})
+	}
+}

--- a/server/capacity.go
+++ b/server/capacity.go
@@ -1,0 +1,92 @@
+package server
+
+import (
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/truora/minidyn/capacity"
+)
+
+// consumedMode resolves the request's ReturnConsumedCapacity enum into a capacity.Mode.
+func consumedMode(s string) capacity.Mode {
+	return capacity.ParseMode(s)
+}
+
+// toWireConsumed maps a capacity.Consumed into the server's JSON ConsumedCapacity shape.
+// It returns nil for a nil input so callers can assign it directly and omit the field.
+func toWireConsumed(c *capacity.Consumed) *ConsumedCapacity {
+	if c == nil {
+		return nil
+	}
+
+	cc := &ConsumedCapacity{
+		TableName:     c.TableName,
+		CapacityUnits: aws.Float64(c.CapacityUnits),
+	}
+
+	if c.ReadCapacityUnits != 0 {
+		cc.ReadCapacityUnits = aws.Float64(c.ReadCapacityUnits)
+	}
+
+	if c.WriteCapacityUnits != 0 {
+		cc.WriteCapacityUnits = aws.Float64(c.WriteCapacityUnits)
+	}
+
+	if c.Breakdown {
+		applyWireBreakdown(cc, c)
+	}
+
+	return cc
+}
+
+func applyWireBreakdown(cc *ConsumedCapacity, c *capacity.Consumed) {
+	entry := Capacity{CapacityUnits: aws.Float64(c.CapacityUnits)}
+
+	if c.ReadCapacityUnits != 0 {
+		entry.ReadCapacityUnits = aws.Float64(c.ReadCapacityUnits)
+	}
+
+	if c.WriteCapacityUnits != 0 {
+		entry.WriteCapacityUnits = aws.Float64(c.WriteCapacityUnits)
+	}
+
+	switch {
+	case c.IndexName != "" && c.IndexKind == "GSI":
+		cc.GlobalSecondaryIndexes = map[string]Capacity{c.IndexName: entry}
+	case c.IndexName != "" && c.IndexKind == "LSI":
+		cc.LocalSecondaryIndexes = map[string]Capacity{c.IndexName: entry}
+	default:
+		cc.Table = &entry
+	}
+}
+
+// wireConsumedSlice assembles the per-table ConsumedCapacity slice for batch and
+// transactional operations from already-aggregated units. Zero-unit tables are omitted.
+func wireConsumedSlice(mode capacity.Mode, unitsByTable map[string]float64, isRead bool) []ConsumedCapacity {
+	if mode == capacity.ModeNone || len(unitsByTable) == 0 {
+		return nil
+	}
+
+	out := make([]ConsumedCapacity, 0, len(unitsByTable))
+
+	for table, units := range unitsByTable {
+		if units == 0 {
+			continue
+		}
+
+		var c *capacity.Consumed
+		if isRead {
+			c = capacity.ForReadUnits(mode, table, units)
+		} else {
+			c = capacity.ForWriteUnits(mode, table, units)
+		}
+
+		if cc := toWireConsumed(c); cc != nil {
+			out = append(out, *cc)
+		}
+	}
+
+	if len(out) == 0 {
+		return nil
+	}
+
+	return out
+}

--- a/server/capacity_test.go
+++ b/server/capacity_test.go
@@ -1,0 +1,149 @@
+package server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	ddbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/stretchr/testify/require"
+	"github.com/truora/minidyn/capacity"
+)
+
+func TestToWireConsumedBreakdowns(t *testing.T) {
+	c := require.New(t)
+
+	c.Nil(toWireConsumed(nil))
+
+	gsi := toWireConsumed(&capacity.Consumed{TableName: "t", CapacityUnits: 1, ReadCapacityUnits: 1, Breakdown: true, IndexName: "i", IndexKind: "GSI"})
+	c.Contains(gsi.GlobalSecondaryIndexes, "i")
+	c.Nil(gsi.Table)
+
+	lsi := toWireConsumed(&capacity.Consumed{TableName: "t", CapacityUnits: 1, WriteCapacityUnits: 1, Breakdown: true, IndexName: "i", IndexKind: "LSI"})
+	c.Contains(lsi.LocalSecondaryIndexes, "i")
+
+	tbl := toWireConsumed(&capacity.Consumed{TableName: "t", CapacityUnits: 1, WriteCapacityUnits: 1, Breakdown: true})
+	c.NotNil(tbl.Table)
+}
+
+func TestWireConsumedSlice(t *testing.T) {
+	c := require.New(t)
+
+	c.Nil(wireConsumedSlice(capacity.ModeNone, map[string]float64{"t": 1}, true))
+	c.Nil(wireConsumedSlice(capacity.ModeTotal, map[string]float64{}, true))
+	c.Nil(wireConsumedSlice(capacity.ModeTotal, map[string]float64{"t": 0}, true))
+
+	out := wireConsumedSlice(capacity.ModeTotal, map[string]float64{"t": 3}, true)
+	c.Len(out, 1)
+	c.Equal(3.0, aws.ToFloat64(out[0].ReadCapacityUnits))
+}
+
+func newServerWithPokemonTable(t *testing.T) *Client {
+	t.Helper()
+
+	c := NewClient()
+
+	_, err := c.CreateTable(context.Background(), &CreateTableInput{
+		TableName: aws.String("pokemons"),
+		KeySchema: []ddbtypes.KeySchemaElement{
+			{AttributeName: aws.String("id"), KeyType: ddbtypes.KeyTypeHash},
+		},
+		AttributeDefinitions: []ddbtypes.AttributeDefinition{
+			{AttributeName: aws.String("id"), AttributeType: ddbtypes.ScalarAttributeTypeS},
+		},
+		BillingMode: ddbtypes.BillingModePayPerRequest,
+	})
+	require.NoError(t, err)
+
+	return c
+}
+
+func TestServerItemSizeByKey(t *testing.T) {
+	c := require.New(t)
+	client := newServerWithPokemonTable(t)
+
+	_, err := client.PutItem(context.Background(), &PutItemInput{
+		TableName: aws.String("pokemons"),
+		Item: map[string]*AttributeValue{
+			"id": {S: aws.String("001")},
+			"n":  {S: aws.String("bulbasaur")},
+		},
+	})
+	c.NoError(err)
+
+	key := map[string]*AttributeValue{"id": {S: aws.String("001")}}
+
+	c.Greater(client.itemSizeByKey("pokemons", key), 0)                                                         // stored item
+	c.Greater(client.itemSizeByKey("pokemons", map[string]*AttributeValue{"id": {S: aws.String("absent")}}), 0) // missing item
+	c.Greater(client.itemSizeByKey("no-such-table", key), 0)                                                    // missing table
+	c.GreaterOrEqual(client.itemSizeByKey("pokemons", map[string]*AttributeValue{}), 0)                         // bad key
+}
+
+func TestServerTransactWriteUpdateConsumedCapacity(t *testing.T) {
+	c := require.New(t)
+	client := newServerWithPokemonTable(t)
+	ctx := context.Background()
+
+	_, err := client.PutItem(ctx, &PutItemInput{
+		TableName: aws.String("pokemons"),
+		Item:      map[string]*AttributeValue{"id": {S: aws.String("001")}, "n": {S: aws.String("bulbasaur")}},
+	})
+	c.NoError(err)
+
+	out, err := client.TransactWriteItems(ctx, &TransactWriteItemsInput{
+		ReturnConsumedCapacity: ddbtypes.ReturnConsumedCapacityTotal,
+		TransactItems: []TransactWriteItem{
+			{Update: &Update{
+				TableName:                aws.String("pokemons"),
+				Key:                      map[string]*AttributeValue{"id": {S: aws.String("001")}},
+				UpdateExpression:         aws.String("SET #n = :n"),
+				ExpressionAttributeNames: map[string]string{"#n": "n"},
+				ExpressionAttributeValues: map[string]*AttributeValue{
+					":n": {S: aws.String("ivysaur")},
+				},
+			}},
+		},
+	})
+	c.NoError(err)
+	c.Len(out.ConsumedCapacity, 1)
+	c.Greater(aws.ToFloat64(out.ConsumedCapacity[0].WriteCapacityUnits), 0.0)
+}
+
+func TestServerBatchAndTransactGetConsumedCapacity(t *testing.T) {
+	c := require.New(t)
+	client := newServerWithPokemonTable(t)
+	ctx := context.Background()
+
+	_, err := client.PutItem(ctx, &PutItemInput{
+		TableName: aws.String("pokemons"),
+		Item:      map[string]*AttributeValue{"id": {S: aws.String("001")}, "n": {S: aws.String("bulbasaur")}},
+	})
+	c.NoError(err)
+
+	bw, err := client.BatchWriteItem(ctx, &BatchWriteItemInput{
+		ReturnConsumedCapacity: ddbtypes.ReturnConsumedCapacityTotal,
+		RequestItems: map[string][]WriteRequest{
+			"pokemons": {{PutRequest: &PutRequest{Item: map[string]*AttributeValue{"id": {S: aws.String("002")}}}}},
+		},
+	})
+	c.NoError(err)
+	c.Len(bw.ConsumedCapacity, 1)
+
+	bg, err := client.BatchGetItem(ctx, &BatchGetItemInput{
+		ReturnConsumedCapacity: ddbtypes.ReturnConsumedCapacityTotal,
+		RequestItems: map[string]KeysAndAttributes{
+			"pokemons": {Keys: []map[string]*AttributeValue{{"id": {S: aws.String("001")}}}},
+		},
+	})
+	c.NoError(err)
+	c.Len(bg.ConsumedCapacity, 1)
+
+	tg, err := client.TransactGetItems(ctx, &TransactGetItemsInput{
+		ReturnConsumedCapacity: ddbtypes.ReturnConsumedCapacityTotal,
+		TransactItems: []TransactGetItem{
+			{Get: &Get{TableName: aws.String("pokemons"), Key: map[string]*AttributeValue{"id": {S: aws.String("001")}}}},
+		},
+	})
+	c.NoError(err)
+	c.Len(tg.ConsumedCapacity, 1)
+}

--- a/server/client.go
+++ b/server/client.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	ddbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 	"github.com/aws/smithy-go"
+	"github.com/truora/minidyn/capacity"
 	"github.com/truora/minidyn/core"
 	"github.com/truora/minidyn/interpreter"
 	"github.com/truora/minidyn/types"
@@ -330,13 +331,22 @@ func (c *Client) PutItem(ctx context.Context, input *PutItemInput) (*PutItemOutp
 		return nil, err
 	}
 
+	putItem := mapAttributeValueMapToTypes(input.Item)
+
+	newSize := capacity.Size(putItem)
+
+	oldSize := 0
+	if key, kerr := table.KeySchema.GetKey(table.AttributesDef, putItem); kerr == nil {
+		oldSize = capacity.Size(table.Data[key])
+	}
+
 	item, err := table.Put(&types.PutItemInput{
 		TableName:                   input.TableName,
 		ConditionExpression:         input.ConditionExpression,
 		ConditionalOperator:         toStringPtr(string(input.ConditionalOperator)),
 		ExpressionAttributeNames:    input.ExpressionAttributeNames,
 		ExpressionAttributeValues:   mapAttributeValueMapToTypes(input.ExpressionAttributeValues),
-		Item:                        mapAttributeValueMapToTypes(input.Item),
+		Item:                        putItem,
 		ReturnConsumedCapacity:      toStringPtr(string(input.ReturnConsumedCapacity)),
 		ReturnItemCollectionMetrics: toStringPtr(string(input.ReturnItemCollectionMetrics)),
 		ReturnValues:                toStringPtr(string(input.ReturnValues)),
@@ -345,7 +355,13 @@ func (c *Client) PutItem(ctx context.Context, input *PutItemInput) (*PutItemOutp
 		return nil, mapKnownError(err)
 	}
 
-	return &PutItemOutput{Attributes: mapTypesMapToAttributeValue(item)}, nil
+	return &PutItemOutput{
+		Attributes: mapTypesMapToAttributeValue(item),
+		ConsumedCapacity: toWireConsumed(capacity.ForWrite(
+			consumedMode(string(input.ReturnConsumedCapacity)),
+			aws.ToString(input.TableName), max(oldSize, newSize),
+		)),
+	}, nil
 }
 
 // DeleteItem removes an item and optionally returns old values.
@@ -370,23 +386,35 @@ func (c *Client) DeleteItem(ctx context.Context, input *DeleteItemInput) (*Delet
 		return nil, err
 	}
 
+	deleteKey := mapAttributeValueMapToTypes(input.Key)
+
 	item, err := table.Delete(&types.DeleteItemInput{
 		TableName:                 input.TableName,
 		ConditionExpression:       input.ConditionExpression,
 		ConditionalOperator:       toStringPtr(string(input.ConditionalOperator)),
 		ExpressionAttributeNames:  toStringPtrMap(input.ExpressionAttributeNames),
 		ExpressionAttributeValues: mapAttributeValueMapToTypes(input.ExpressionAttributeValues),
-		Key:                       mapAttributeValueMapToTypes(input.Key),
+		Key:                       deleteKey,
 	})
 	if err != nil {
 		return nil, mapKnownError(err)
 	}
 
-	if input.ReturnValues == ddbtypes.ReturnValueAllOld {
-		return &DeleteItemOutput{Attributes: mapTypesMapToAttributeValue(item)}, nil
+	sizeSource := item
+	if len(sizeSource) == 0 {
+		sizeSource = deleteKey
 	}
 
-	return &DeleteItemOutput{}, nil
+	consumed := toWireConsumed(capacity.ForWrite(
+		consumedMode(string(input.ReturnConsumedCapacity)),
+		aws.ToString(input.TableName), capacity.Size(sizeSource),
+	))
+
+	if input.ReturnValues == ddbtypes.ReturnValueAllOld {
+		return &DeleteItemOutput{Attributes: mapTypesMapToAttributeValue(item), ConsumedCapacity: consumed}, nil
+	}
+
+	return &DeleteItemOutput{ConsumedCapacity: consumed}, nil
 }
 
 // UpdateItem modifies attributes of an item using an update expression.
@@ -412,13 +440,22 @@ func (c *Client) UpdateItem(ctx context.Context, input *UpdateItemInput) (*Updat
 		return nil, err
 	}
 
+	updateKeyMap := mapAttributeValueMapToTypes(input.Key)
+
+	updateKey, keyErr := table.KeySchema.GetKey(table.AttributesDef, updateKeyMap)
+
+	beforeSize := 0
+	if keyErr == nil {
+		beforeSize = capacity.Size(table.Data[updateKey])
+	}
+
 	item, err := table.Update(&types.UpdateItemInput{
 		TableName:                           input.TableName,
 		ConditionExpression:                 input.ConditionExpression,
 		ConditionalOperator:                 toStringPtr(string(input.ConditionalOperator)),
 		ExpressionAttributeNames:            input.ExpressionAttributeNames,
 		ExpressionAttributeValues:           mapAttributeValueMapToTypes(input.ExpressionAttributeValues),
-		Key:                                 mapAttributeValueMapToTypes(input.Key),
+		Key:                                 updateKeyMap,
 		UpdateExpression:                    aws.ToString(input.UpdateExpression),
 		ReturnValues:                        toStringPtr(string(input.ReturnValues)),
 		ReturnValuesOnConditionCheckFailure: toStringPtr(string(input.ReturnValuesOnConditionCheckFailure)),
@@ -427,7 +464,18 @@ func (c *Client) UpdateItem(ctx context.Context, input *UpdateItemInput) (*Updat
 		return nil, mapKnownError(err)
 	}
 
-	return &UpdateItemOutput{Attributes: mapTypesMapToAttributeValue(item)}, nil
+	afterSize := beforeSize
+	if keyErr == nil {
+		afterSize = capacity.Size(table.Data[updateKey])
+	}
+
+	return &UpdateItemOutput{
+		Attributes: mapTypesMapToAttributeValue(item),
+		ConsumedCapacity: toWireConsumed(capacity.ForWrite(
+			consumedMode(string(input.ReturnConsumedCapacity)),
+			aws.ToString(input.TableName), max(beforeSize, afterSize),
+		)),
+	}, nil
 }
 
 // GetItem returns a single item by key.
@@ -469,7 +517,19 @@ func (c *Client) GetItem(ctx context.Context, input *GetItemInput) (*GetItemOutp
 		return nil, &smithy.GenericAPIError{Code: "ValidationException", Message: err.Error()}
 	}
 
-	return &GetItemOutput{Item: item}, nil
+	sizeSource := stored
+	if len(sizeSource) == 0 {
+		sizeSource = keyMap
+	}
+
+	return &GetItemOutput{
+		Item: item,
+		ConsumedCapacity: toWireConsumed(capacity.ForRead(
+			consumedMode(string(input.ReturnConsumedCapacity)),
+			aws.ToString(input.TableName), "", "",
+			capacity.Size(sizeSource), aws.ToBool(input.ConsistentRead),
+		)),
+	}, nil
 }
 
 // Query searches items by key condition and optional filter.
@@ -516,11 +576,17 @@ func (c *Client) Query(ctx context.Context, input *QueryInput) (*QueryOutput, er
 	}
 
 	count := int32(len(items))
+	indexName := aws.ToString(input.IndexName)
 
 	return &QueryOutput{
 		Items:            mapTypesSliceToAttributeValue(items),
 		Count:            count,
 		LastEvaluatedKey: mapTypesMapToAttributeValue(last),
+		ConsumedCapacity: toWireConsumed(capacity.ForRead(
+			consumedMode(string(input.ReturnConsumedCapacity)),
+			aws.ToString(input.TableName), indexName, table.IndexKind(indexName),
+			capacity.SumSize(items), aws.ToBool(input.ConsistentRead),
+		)),
 	}, nil
 }
 
@@ -563,11 +629,17 @@ func (c *Client) Scan(ctx context.Context, input *ScanInput) (*ScanOutput, error
 	}
 
 	count := int32(len(items))
+	indexName := aws.ToString(input.IndexName)
 
 	return &ScanOutput{
 		Items:            mapTypesSliceToAttributeValue(items),
 		Count:            count,
 		LastEvaluatedKey: mapTypesMapToAttributeValue(last),
+		ConsumedCapacity: toWireConsumed(capacity.ForRead(
+			consumedMode(string(input.ReturnConsumedCapacity)),
+			aws.ToString(input.TableName), indexName, table.IndexKind(indexName),
+			capacity.SumSize(items), aws.ToBool(input.ConsistentRead),
+		)),
 	}, nil
 }
 
@@ -649,6 +721,7 @@ func (c *Client) BatchWriteItem(ctx context.Context, input *BatchWriteItemInput)
 	}
 
 	unprocessed := map[string][]WriteRequest{}
+	unitsByTable := map[string]float64{}
 
 	for tableName, reqs := range input.RequestItems {
 		for i, req := range reqs {
@@ -676,10 +749,29 @@ func (c *Client) BatchWriteItem(ctx context.Context, input *BatchWriteItemInput)
 			if err != nil {
 				return nil, err
 			}
+
+			unitsByTable[tableName] += capacity.WriteUnits(capacity.Size(batchWriteRequestItem(req)))
 		}
 	}
 
-	return &BatchWriteItemOutput{UnprocessedItems: unprocessed}, nil
+	return &BatchWriteItemOutput{
+		UnprocessedItems: unprocessed,
+		ConsumedCapacity: wireConsumedSlice(consumedMode(string(input.ReturnConsumedCapacity)), unitsByTable, false),
+	}, nil
+}
+
+// batchWriteRequestItem returns the internal item used to size a write request: the put
+// item, or the delete key when sizing a delete.
+func batchWriteRequestItem(req WriteRequest) map[string]*types.Item {
+	if req.PutRequest != nil {
+		return mapAttributeValueMapToTypes(req.PutRequest.Item)
+	}
+
+	if req.DeleteRequest != nil {
+		return mapAttributeValueMapToTypes(req.DeleteRequest.Key)
+	}
+
+	return nil
 }
 
 func tableNames[V any](requestItems map[string]V) []string {
@@ -737,14 +829,16 @@ func (c *Client) BatchGetItem(ctx context.Context, input *BatchGetItemInput) (*B
 
 	responses := map[string][]map[string]*AttributeValue{}
 	unprocessed := map[string]KeysAndAttributes{}
+	unitsByTable := map[string]float64{}
 
 	for tableName, reqs := range input.RequestItems {
-		tableResponses, unprocessedKeys, err := c.batchGetItemForTable(ctx, tableName, reqs, emulation)
+		tableResponses, unprocessedKeys, units, err := c.batchGetItemForTable(ctx, tableName, reqs, emulation)
 		if err != nil {
 			return nil, err
 		}
 
 		responses[tableName] = tableResponses
+		unitsByTable[tableName] += units
 
 		if len(unprocessedKeys) > 0 {
 			tableUnprocessed := reqs
@@ -753,16 +847,23 @@ func (c *Client) BatchGetItem(ctx context.Context, input *BatchGetItemInput) (*B
 		}
 	}
 
-	return &BatchGetItemOutput{Responses: responses, UnprocessedKeys: unprocessed}, nil
+	return &BatchGetItemOutput{
+		Responses:        responses,
+		UnprocessedKeys:  unprocessed,
+		ConsumedCapacity: wireConsumedSlice(consumedMode(string(input.ReturnConsumedCapacity)), unitsByTable, true),
+	}, nil
 }
 
-func (c *Client) batchGetItemForTable(ctx context.Context, tableName string, reqs KeysAndAttributes, emulation batchEmulation) ([]map[string]*AttributeValue, []map[string]*AttributeValue, error) {
+func (c *Client) batchGetItemForTable(ctx context.Context, tableName string, reqs KeysAndAttributes, emulation batchEmulation) ([]map[string]*AttributeValue, []map[string]*AttributeValue, float64, error) {
 	if err := validateExpressionAttributes(reqs.ExpressionAttributeNames, nil, aws.ToString(reqs.ProjectionExpression)); err != nil {
-		return nil, nil, err
+		return nil, nil, 0, err
 	}
 
 	responses := make([]map[string]*AttributeValue, 0, len(reqs.Keys))
 	unprocessedKeys := make([]map[string]*AttributeValue, 0, len(reqs.Keys))
+
+	consistent := aws.ToBool(reqs.ConsistentRead)
+	units := 0.0
 
 	for i, key := range reqs.Keys {
 		if emulation.unprocessed(tableName, i, key) {
@@ -779,15 +880,17 @@ func (c *Client) batchGetItemForTable(ctx context.Context, tableName string, req
 			ProjectionExpression:     reqs.ProjectionExpression,
 		})
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, 0, err
 		}
+
+		units += capacity.ReadUnits(capacity.Size(mapAttributeValueMapToTypes(item.Item)), consistent)
 
 		if len(item.Item) > 0 {
 			responses = append(responses, item.Item)
 		}
 	}
 
-	return responses, unprocessedKeys, nil
+	return responses, unprocessedKeys, units, nil
 }
 
 func (c *Client) prepareTransact(items []TransactWriteItem) (map[string]core.TableSnapshot, error) {
@@ -880,7 +983,59 @@ func (c *Client) TransactWriteItems(ctx context.Context, input *TransactWriteIte
 		}
 	}
 
-	return &TransactWriteItemsOutput{}, nil
+	unitsByTable := map[string]float64{}
+
+	for _, item := range input.TransactItems {
+		tableName, size := c.transactWriteSize(item)
+		if tableName == "" {
+			continue
+		}
+
+		unitsByTable[tableName] += 2 * capacity.WriteUnits(size)
+	}
+
+	return &TransactWriteItemsOutput{
+		ConsumedCapacity: wireConsumedSlice(consumedMode(string(input.ReturnConsumedCapacity)), unitsByTable, false),
+	}, nil
+}
+
+// transactWriteSize returns the table name and byte size used to bill a transact write item.
+// Update sizes the stored item after the update; Delete/ConditionCheck size the key.
+func (c *Client) transactWriteSize(item TransactWriteItem) (string, int) {
+	switch {
+	case item.Put != nil:
+		return aws.ToString(item.Put.TableName), capacity.Size(mapAttributeValueMapToTypes(item.Put.Item))
+	case item.Update != nil:
+		return aws.ToString(item.Update.TableName), c.itemSizeByKey(aws.ToString(item.Update.TableName), item.Update.Key)
+	case item.Delete != nil:
+		return aws.ToString(item.Delete.TableName), capacity.Size(mapAttributeValueMapToTypes(item.Delete.Key))
+	case item.ConditionCheck != nil:
+		return aws.ToString(item.ConditionCheck.TableName), capacity.Size(mapAttributeValueMapToTypes(item.ConditionCheck.Key))
+	default:
+		return "", 0
+	}
+}
+
+// itemSizeByKey returns the byte size of the stored item for a key, falling back to the
+// key's own size when the table or item is not found.
+func (c *Client) itemSizeByKey(tableName string, key map[string]*AttributeValue) int {
+	keyMap := mapAttributeValueMapToTypes(key)
+
+	table, err := c.getTable(tableName)
+	if err != nil {
+		return capacity.Size(keyMap)
+	}
+
+	k, err := table.KeySchema.GetKey(table.AttributesDef, keyMap)
+	if err != nil {
+		return capacity.Size(keyMap)
+	}
+
+	if stored := table.Data[k]; len(stored) > 0 {
+		return capacity.Size(stored)
+	}
+
+	return capacity.Size(keyMap)
 }
 
 func validateTransactGetItemsInput(c *Client, input *TransactGetItemsInput) error {
@@ -964,6 +1119,7 @@ func (c *Client) TransactGetItems(ctx context.Context, input *TransactGetItemsIn
 	}
 
 	responses := make([]ItemResponse, 0, len(input.TransactItems))
+	unitsByTable := map[string]float64{}
 
 	for _, item := range input.TransactItems {
 		get := item.Get
@@ -979,9 +1135,14 @@ func (c *Client) TransactGetItems(ctx context.Context, input *TransactGetItemsIn
 		}
 
 		responses = append(responses, ItemResponse{Item: out.Item})
+
+		unitsByTable[aws.ToString(get.TableName)] += 2 * capacity.ReadUnits(capacity.Size(mapAttributeValueMapToTypes(out.Item)), true)
 	}
 
-	return &TransactGetItemsOutput{Responses: responses}, nil
+	return &TransactGetItemsOutput{
+		Responses:        responses,
+		ConsumedCapacity: wireConsumedSlice(consumedMode(string(input.ReturnConsumedCapacity)), unitsByTable, true),
+	}, nil
 }
 
 func (c *Client) runTransactItem(i, n int, item TransactWriteItem) error {

--- a/server/responses.go
+++ b/server/responses.go
@@ -23,24 +23,46 @@ type DescribeTableOutput struct {
 	Table any `json:"Table,omitempty"`
 }
 
+// Capacity mirrors DynamoDB Capacity (throughput consumed on a table or index).
+type Capacity struct {
+	CapacityUnits      *float64 `json:"CapacityUnits,omitempty"`
+	ReadCapacityUnits  *float64 `json:"ReadCapacityUnits,omitempty"`
+	WriteCapacityUnits *float64 `json:"WriteCapacityUnits,omitempty"`
+}
+
+// ConsumedCapacity mirrors DynamoDB ConsumedCapacity.
+type ConsumedCapacity struct {
+	TableName              string              `json:"TableName,omitempty"`
+	CapacityUnits          *float64            `json:"CapacityUnits,omitempty"`
+	ReadCapacityUnits      *float64            `json:"ReadCapacityUnits,omitempty"`
+	WriteCapacityUnits     *float64            `json:"WriteCapacityUnits,omitempty"`
+	Table                  *Capacity           `json:"Table,omitempty"`
+	GlobalSecondaryIndexes map[string]Capacity `json:"GlobalSecondaryIndexes,omitempty"`
+	LocalSecondaryIndexes  map[string]Capacity `json:"LocalSecondaryIndexes,omitempty"`
+}
+
 // PutItemOutput mirrors DynamoDB PutItemOutput.
 type PutItemOutput struct {
-	Attributes map[string]*AttributeValue `json:"Attributes,omitempty"`
+	Attributes       map[string]*AttributeValue `json:"Attributes,omitempty"`
+	ConsumedCapacity *ConsumedCapacity          `json:"ConsumedCapacity,omitempty"`
 }
 
 // DeleteItemOutput mirrors DynamoDB DeleteItemOutput.
 type DeleteItemOutput struct {
-	Attributes map[string]*AttributeValue `json:"Attributes,omitempty"`
+	Attributes       map[string]*AttributeValue `json:"Attributes,omitempty"`
+	ConsumedCapacity *ConsumedCapacity          `json:"ConsumedCapacity,omitempty"`
 }
 
 // UpdateItemOutput mirrors DynamoDB UpdateItemOutput.
 type UpdateItemOutput struct {
-	Attributes map[string]*AttributeValue `json:"Attributes,omitempty"`
+	Attributes       map[string]*AttributeValue `json:"Attributes,omitempty"`
+	ConsumedCapacity *ConsumedCapacity          `json:"ConsumedCapacity,omitempty"`
 }
 
 // GetItemOutput mirrors DynamoDB GetItemOutput.
 type GetItemOutput struct {
-	Item map[string]*AttributeValue `json:"Item,omitempty"`
+	Item             map[string]*AttributeValue `json:"Item,omitempty"`
+	ConsumedCapacity *ConsumedCapacity          `json:"ConsumedCapacity,omitempty"`
 }
 
 // QueryOutput mirrors DynamoDB QueryOutput.
@@ -49,6 +71,7 @@ type QueryOutput struct {
 	Count            int32                        `json:"Count,omitempty"`
 	ScannedCount     int32                        `json:"ScannedCount,omitempty"`
 	LastEvaluatedKey map[string]*AttributeValue   `json:"LastEvaluatedKey,omitempty"`
+	ConsumedCapacity *ConsumedCapacity            `json:"ConsumedCapacity,omitempty"`
 }
 
 // ScanOutput mirrors DynamoDB ScanOutput.
@@ -57,21 +80,26 @@ type ScanOutput struct {
 	Count            int32                        `json:"Count,omitempty"`
 	ScannedCount     int32                        `json:"ScannedCount,omitempty"`
 	LastEvaluatedKey map[string]*AttributeValue   `json:"LastEvaluatedKey,omitempty"`
+	ConsumedCapacity *ConsumedCapacity            `json:"ConsumedCapacity,omitempty"`
 }
 
 // BatchWriteItemOutput mirrors DynamoDB BatchWriteItemOutput.
 type BatchWriteItemOutput struct {
 	UnprocessedItems map[string][]WriteRequest `json:"UnprocessedItems,omitempty"`
+	ConsumedCapacity []ConsumedCapacity        `json:"ConsumedCapacity,omitempty"`
 }
 
 // BatchGetItemOutput mirrors DynamoDB BatchGetItemOutput.
 type BatchGetItemOutput struct {
-	Responses       map[string][]map[string]*AttributeValue `json:"Responses,omitempty"`
-	UnprocessedKeys map[string]KeysAndAttributes            `json:"UnprocessedKeys,omitempty"`
+	Responses        map[string][]map[string]*AttributeValue `json:"Responses,omitempty"`
+	UnprocessedKeys  map[string]KeysAndAttributes            `json:"UnprocessedKeys,omitempty"`
+	ConsumedCapacity []ConsumedCapacity                      `json:"ConsumedCapacity,omitempty"`
 }
 
 // TransactWriteItemsOutput mirrors DynamoDB TransactWriteItemsOutput.
-type TransactWriteItemsOutput struct{}
+type TransactWriteItemsOutput struct {
+	ConsumedCapacity []ConsumedCapacity `json:"ConsumedCapacity,omitempty"`
+}
 
 // ItemResponse mirrors DynamoDB ItemResponse.
 type ItemResponse struct {
@@ -80,5 +108,6 @@ type ItemResponse struct {
 
 // TransactGetItemsOutput mirrors DynamoDB TransactGetItemsOutput.
 type TransactGetItemsOutput struct {
-	Responses []ItemResponse `json:"Responses,omitempty"`
+	Responses        []ItemResponse     `json:"Responses,omitempty"`
+	ConsumedCapacity []ConsumedCapacity `json:"ConsumedCapacity,omitempty"`
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -100,6 +100,48 @@ func TestServerCRUDWithSDKv2(t *testing.T) {
 	require.Equal(t, "pikachu", out.Item["n"].(*ddbtypes.AttributeValueMemberS).Value)
 }
 
+func TestServerConsumedCapacityWithSDKv2(t *testing.T) {
+	srv := NewServer()
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	cli := newTestDynamoClient(t, ts.URL)
+	ctx := context.Background()
+
+	makeBasicTable(t, cli, "pokemons", "id")
+
+	putOut, err := cli.PutItem(ctx, &dynamodb.PutItemInput{
+		TableName: aws.String("pokemons"),
+		Item: map[string]ddbtypes.AttributeValue{
+			"id": &ddbtypes.AttributeValueMemberS{Value: "25"},
+			"n":  &ddbtypes.AttributeValueMemberS{Value: "pikachu"},
+		},
+		ReturnConsumedCapacity: ddbtypes.ReturnConsumedCapacityTotal,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, putOut.ConsumedCapacity, "ConsumedCapacity must survive the HTTP round-trip")
+	require.Equal(t, "pokemons", aws.ToString(putOut.ConsumedCapacity.TableName))
+	require.Greater(t, aws.ToFloat64(putOut.ConsumedCapacity.WriteCapacityUnits), 0.0)
+
+	getOut, err := cli.GetItem(ctx, &dynamodb.GetItemInput{
+		TableName:              aws.String("pokemons"),
+		Key:                    map[string]ddbtypes.AttributeValue{"id": &ddbtypes.AttributeValueMemberS{Value: "25"}},
+		ConsistentRead:         aws.Bool(true),
+		ReturnConsumedCapacity: ddbtypes.ReturnConsumedCapacityTotal,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, getOut.ConsumedCapacity)
+	require.Greater(t, aws.ToFloat64(getOut.ConsumedCapacity.ReadCapacityUnits), 0.0)
+
+	// Omitted when ReturnConsumedCapacity is not requested.
+	noCC, err := cli.GetItem(ctx, &dynamodb.GetItemInput{
+		TableName: aws.String("pokemons"),
+		Key:       map[string]ddbtypes.AttributeValue{"id": &ddbtypes.AttributeValueMemberS{Value: "25"}},
+	})
+	require.NoError(t, err)
+	require.Nil(t, noCC.ConsumedCapacity)
+}
+
 func TestServerQueryGSIWithSDKv2(t *testing.T) {
 	ts := httptest.NewServer(NewServer())
 	defer ts.Close()


### PR DESCRIPTION
Why:
Minidyn decoded ReturnConsumedCapacity on every request but never populated ConsumedCapacity on any response, so tests that assert on consumed capacity could not run against the fake. This adds accurate, documented item-size based capacity accounting so the fake mirrors DynamoDB for those tests.

What:
- Add a shared capacity package that sizes items via the docsize algorithm and derives read/write units (4KB read, 1KB write, eventual halved, transact 2x)
- Add docsize package doc.go and tests; it provides the item-size contract
- Add core.Table.IndexKind to classify GSI vs LSI for the INDEXES breakdown
- Populate ConsumedCapacity on all reporting ops in aws-v2/client and server (Get, Put, Update, Delete, Query, Scan, BatchGet, BatchWrite, TransactGet, TransactWrite), honoring NONE/TOTAL/INDEXES
- Add ConsumedCapacity fields to the server JSON response structs
- Add unit, server round-trip, and e2e parity/spike coverage
- Document the supported behavior in docs/operations.md

Issue: #49