### PR TITLE
Fix stale GSI projection on PutItem overwrite

### DIFF
--- a/aws-v2/client/client_test.go
+++ b/aws-v2/client/client_test.go
@@ -3633,6 +3633,38 @@ func TestUpdateItemAndQueryAfterUpsert(t *testing.T) {
 	c.Len(items, 1)
 }
 
+func TestPutItemOverwriteAndQueryByGSI(t *testing.T) {
+	c := require.New(t)
+	client := setupClient(tableName)
+
+	err := ensurePokemonTable(client)
+	c.NoError(err)
+
+	err = ensurePokemonTypeIndex(client)
+	c.NoError(err)
+
+	err = createPokemon(client, pokemon{ID: "001", Type: "grass", Name: "Bulbasaur"})
+	c.NoError(err)
+
+	items, err := getPokemonsByType(client, "grass")
+	c.NoError(err)
+	c.Len(items, 1)
+
+	// Overwrite the item via PutItem, changing the GSI partition key (type).
+	err = createPokemon(client, pokemon{ID: "001", Type: "fire", Name: "Charmander"})
+	c.NoError(err)
+
+	// The projection under the new key must be queryable.
+	items, err = getPokemonsByType(client, "fire")
+	c.NoError(err)
+	c.Len(items, 1)
+
+	// The stale projection under the old key must be gone.
+	items, err = getPokemonsByType(client, "grass")
+	c.NoError(err)
+	c.Len(items, 0)
+}
+
 func BenchmarkQuery(b *testing.B) {
 	c := require.New(b)
 	client := setupClient(tableName)

--- a/core/index.go
+++ b/core/index.go
@@ -118,12 +118,27 @@ func (i *index) putData(key string, item map[string]*types.Item) error {
 		return err
 	}
 
-	_, exists := i.refs[key]
+	old, exists := i.refs[key]
 
 	i.refs[key] = indexKey
 
 	if !exists {
 		i.sortedKeys = append(i.sortedKeys, indexKey)
+		sort.Strings(i.sortedKeys)
+
+		return nil
+	}
+
+	// On overwrite, reconcile sortedKeys so a changed index key does not leave
+	// a stale projection behind (and the new projection becomes searchable).
+	if old != indexKey {
+		pos := sort.SearchStrings(i.sortedKeys, old)
+		if pos >= len(i.sortedKeys) {
+			i.sortedKeys = append(i.sortedKeys, indexKey)
+		} else {
+			i.sortedKeys[pos] = indexKey
+		}
+
 		sort.Strings(i.sortedKeys)
 	}
 

--- a/core/table_test.go
+++ b/core/table_test.go
@@ -1074,6 +1074,57 @@ func TestPutItem(t *testing.T) {
 	c.NoError(err)
 }
 
+func TestPutItemOverwriteReconcilesGSIKey(t *testing.T) {
+	c := require.New(t)
+
+	newTable := NewTable(tableName)
+	newTable.AttributesDef = map[string]string{"id": "S", "type": "S"}
+	newTable.KeySchema = keySchema{"id", "", false}
+
+	indexName, allStr := "by-type", "ALL"
+	err := newTable.AddGlobalIndexes([]*types.GlobalSecondaryIndex{
+		{
+			ProvisionedThroughput: &types.ProvisionedThroughput{ReadCapacityUnits: 1, WriteCapacityUnits: 1},
+			IndexName:             &indexName,
+			KeySchema: []*types.KeySchemaElement{
+				{AttributeName: "type", KeyType: "HASH"},
+			},
+			Projection: &types.Projection{ProjectionType: &allStr},
+		},
+	})
+	c.NoError(err)
+
+	put := func(id, typ string) {
+		_, perr := newTable.Put(&types.PutItemInput{
+			Item:      map[string]*types.Item{"id": {S: new(id)}, "type": {S: new(typ)}},
+			TableName: &newTable.Name,
+		})
+		c.NoError(perr)
+	}
+
+	queryByType := func(typ string) []map[string]*types.Item {
+		items, _, qerr := newTable.SearchData(QueryInput{
+			Index:                     "by-type",
+			KeyConditionExpression:    "#type = :type",
+			Aliases:                   map[string]string{"#type": "type"},
+			ExpressionAttributeValues: map[string]*types.Item{":type": {S: new(typ)}},
+			ScanIndexForward:          true,
+		})
+		c.NoError(qerr)
+
+		return items
+	}
+
+	put("001", "grass")
+	c.Len(queryByType("grass"), 1)
+
+	// Overwriting the same primary key with a changed GSI key must move the
+	// projection: the new key becomes searchable and the old one is dropped.
+	put("001", "fire")
+	c.Len(queryByType("fire"), 1)
+	c.Len(queryByType("grass"), 0)
+}
+
 func TestGetItem(t *testing.T) {
 	c := require.New(t)
 


### PR DESCRIPTION
## Summary

`PutItem` that overwrites an existing item and changes a GSI key attribute left a **stale projection** in the index: the item disappeared from a query on its *new* key value and still matched its *old* key value. Real DynamoDB updates the GSI on every overwrite, so minidyn diverged.

Root cause: `core.Table.Put` → `index.putData` updated the `refs` map on overwrite but never reconciled `sortedKeys` when the index key changed. `Table.Update` was already correct via `index.updateData`; only the `Put` path had the gap.

Fixes #137.

## Changes

- **`core/index.go`** — `putData` now reconciles `sortedKeys` on overwrite: when the index key changed, it drops the stale key and inserts the new one (mirrors `updateData`). The insert (non-overwrite) path is unchanged.
- **`core/table_test.go`** — `TestPutItemOverwriteReconcilesGSIKey`: two `Put`s on the same primary key with a changed GSI key, then `SearchData` on the GSI — new key returns 1, old key returns 0.
- **`aws-v2/client/client_test.go`** — `TestPutItemOverwriteAndQueryByGSI`: client-level parity equivalent via `PutItem` + `Query`.

## Verification (qa-engineer)

- `go fix`: no changes
- unit tests (non-e2e): pass
- `golangci-lint`: 0 issues
- `scripts/check_coverage.sh`: pass — `putData` 87.5% (above the 80% threshold)